### PR TITLE
Do not disconnect on suspend

### DIFF
--- a/nsis/openvpn-gui.nsi
+++ b/nsis/openvpn-gui.nsi
@@ -174,7 +174,7 @@ Section "-Add registry keys" SecAddRegistryKeys
             WriteRegStr ${REG_KEY} "allow_proxy" "1"
             WriteRegStr ${REG_KEY} "allow_service" "0"
             WriteRegStr ${REG_KEY} "connectscript_timeout" "15"
-            WriteRegStr ${REG_KEY} "disconnect_on_suspend" "1"
+            WriteRegStr ${REG_KEY} "disconnect_on_suspend" "0"
             WriteRegStr ${REG_KEY} "disconnectscript_timeout" "10"
             WriteRegStr ${REG_KEY} "preconnectscript_timeout" "10"
             WriteRegStr ${REG_KEY} "editor" "C:\Windows\notepad.exe"

--- a/registry.c
+++ b/registry.c
@@ -111,7 +111,7 @@ GetRegistryKeys()
 
   if (!GetRegKey(_T("show_script_window"), o.show_script_window, _T("1"), _countof(o.show_script_window))) return(false);
 
-  if (!GetRegKey(_T("disconnect_on_suspend"), o.disconnect_on_suspend, _T("1"), 
+  if (!GetRegKey(_T("disconnect_on_suspend"), o.disconnect_on_suspend, _T("0"),
       _countof(o.disconnect_on_suspend))) return(false);
 
   if (!GetRegKey(_T("passphrase_attempts"), o.psw_attempts_string, _T("3"), 


### PR DESCRIPTION
Openvpn no longer terminates but restarts on suspend. This conflicts with
the stop/restart logic in the gui during windows power state change events.
This patch changes the default behaviour so that SIGTERM is not triggered
during windows suspend.

Signed-off-by: Selva Nair <selva.nair@gmail.com>