### PR TITLE
Run with highest privilege available

### DIFF
--- a/res/openvpn-gui.manifest
+++ b/res/openvpn-gui.manifest
@@ -21,7 +21,7 @@
     <security>
         <requestedPrivileges>
             <requestedExecutionLevel
-                level="asInvoker"
+                level="highestAvailable"
                 uiAccess="false"/>
         </requestedPrivileges>
     </security>


### PR DESCRIPTION
Request the highest privilege of the invoking user. When started by a
user with admin rights, a UAC prompt may pop up requesting consent.
The current behaviour is preserved for users with limited privileges.

Signed-off-by: Selva Nair <selva.nair@gmail.com>