### PR TITLE
fix cppcheck warning

### DIFF
--- a/localization.c
+++ b/localization.c
@@ -221,8 +221,9 @@ ShowLocalizedMsgEx(const UINT type, LPCTSTR caption, const UINT stringId, ...)
 {
     va_list args;
     va_start(args, stringId);
-    return __ShowLocalizedMsgEx(type, caption, stringId, args);
+    int result = __ShowLocalizedMsgEx(type, caption, stringId, args);
     va_end(args);
+    return result;
 }
 
 


### PR DESCRIPTION
$ cppcheck .
Checking localization.c...
[localization.c:224]: (error) va_list 'args' was opened but not closed by va_end().