### PR TITLE
Put --log first in the command line

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -682,12 +682,13 @@ StartOpenVPN(connection_t *c)
     /* Create a management interface password */
     GetRandomPassword(c->manage.password, sizeof(c->manage.password) - 1);
 
-    /* Construct command line */
-    _sntprintf_0(cmdline, _T("openvpn --config \"%s\" "
-        "--setenv IV_GUI_VER \"%S\" --service %s 0 --log%s \"%s\" --auth-retry interact "
+    /* Construct command line -- put log first */
+    _sntprintf_0(cmdline, _T("openvpn --log%s \"%s\" --config \"%s\" "
+        "--setenv IV_GUI_VER \"%S\" --service %s 0 --auth-retry interact "
         "--management %S %hd stdin --management-query-passwords %s"
-        "--management-hold"), c->config_file, PACKAGE_STRING, exit_event_name,
+        "--management-hold"),
         (o.append_string[0] == '1' ? _T("-append") : _T("")), c->log_path,
+        c->config_file, PACKAGE_STRING, exit_event_name,
         inet_ntoa(c->manage.skaddr.sin_addr), ntohs(c->manage.skaddr.sin_port),
         (o.proxy_source != config ? _T("--management-query-proxy ") : _T("")));
 


### PR DESCRIPTION
This is needed to avoid early messages going to stdout leaving no
trace of errors when openvpn exits before management interface is up.
It also ensures that any --log directives in the config do not override
the log file location.

Signed-off-by: Selva Nair <selva.nair@gmail.com>