### PR TITLE
Support user and global config directories

### DIFF
--- a/main.c
+++ b/main.c
@@ -170,6 +170,8 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
   if (!GetRegistryKeys()) {
     exit(1);
   }
+  EnsureDirExists(o.config_dir);
+
   if (!CheckVersion()) {
     exit(1);
   }

--- a/options.h
+++ b/options.h
@@ -125,6 +125,7 @@ typedef struct {
     /* Registry values */
     TCHAR exe_path[MAX_PATH];
     TCHAR config_dir[MAX_PATH];
+    TCHAR global_config_dir[MAX_PATH];
     TCHAR ext_string[16];
     TCHAR log_dir[MAX_PATH];
     TCHAR priority_string[64];

--- a/registry.c
+++ b/registry.c
@@ -73,8 +73,15 @@ GetRegistryKeys()
   if (openvpn_path[_tcslen(openvpn_path) - 1] != _T('\\'))
     _tcscat(openvpn_path, _T("\\"));
 
+  /* an admin-defined global config dir defined in HKLM\OpenVPN\config_dir */
+  if (!GetRegistryValue(regkey, _T("config_dir"), o.global_config_dir, _countof(o.global_config_dir)))
+    {
+      /* use default = openvpnpath\config */
+      _sntprintf_0(o.global_config_dir, _T("%sconfig"), openvpn_path);
+    }
 
-  _sntprintf_0(temp_path, _T("%sconfig"), openvpn_path);
+  /* config_dir in user's profile by default */
+  _sntprintf_0(temp_path, _T("%s\\OpenVPN\\config"), profile_dir);
   if (!GetRegKey(_T("config_dir"), o.config_dir, 
       temp_path, _countof(o.config_dir))) return(false);
 

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -201,7 +201,7 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI does not support more than %d configs. Please contact the author if you have the need for more."
-    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found at %s"
+    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found"
     IDS_ERR_ONE_CONN_OLD_VER "You can only have one connection running at the same time when using an older version on OpenVPN than 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "You cannot use OpenVPN GUI to start a connection while the OpenVPN Service is running (with OpenVPN 1.5/1.6). Stop OpenVPN Service first if you want to use OpenVPN GUI."
     IDS_ERR_CREATE_EVENT "CreateEvent failed on exit event: %s"

--- a/service.h
+++ b/service.h
@@ -23,3 +23,4 @@ int MyStartService();
 int MyStopService();
 int MyReStartService();
 int CheckServiceStatus();
+BOOL CheckIServiceStatus();


### PR DESCRIPTION
Collect configs from both locations so that existing installations may not be adversely affected while new users can install configs in their user profile. As a side effect, makes PR#17 work for non-admin users.

- Set default config directory (config_dir) to %UserProfile%\OpenVPN\config
  (saved and read back from HKCU\Software\OpenVPN-GUI\config_dir)

- Add a global_config_dir variable read from HKLM\Software\OpenVPN\config_dir
  or set to OpenVPN-install-path\config

- Scan both directories and their sub directories for connection profiles.
  In case of name conflicts config_dir gets priority over global_config_dir

- Eliminate multiple warnings of duplicate configs
 
Signed-off-by: Selva Nair <selva.nair@gmail.com>