### PR TITLE
Revert "Run with highest privilege available"

### DIFF
--- a/res/openvpn-gui.manifest
+++ b/res/openvpn-gui.manifest
@@ -21,7 +21,7 @@
     <security>
         <requestedPrivileges>
             <requestedExecutionLevel
-                level="highestAvailable"
+                level="asInvoker"
                 uiAccess="false"/>
         </requestedPrivileges>
     </security>


### PR DESCRIPTION
This reverts commit 2af86368964a55c662a2f8548f363e2d65fcbb94.

Requiring "highestAvalable" privilege is no longer required,
nor advisable, as the same functionality is provided using
the interactive service with the GUI running with limited rights.

Signed-off-by: Selva Nair <selva.nair@gmail.com>