### PR TITLE
Read errors from the service pipe and handle fatal ones

### DIFF
--- a/manage.h
+++ b/manage.h
@@ -68,5 +68,6 @@ BOOL OpenManagement(connection_t *);
 BOOL ManagementCommand(connection_t *, char *, mgmt_msg_func, mgmt_cmd_type);
 
 void OnManagement(SOCKET, LPARAM);
+void CloseManagement(connection_t *);
 
 #endif

--- a/openvpn.h
+++ b/openvpn.h
@@ -38,4 +38,10 @@ void OnStop(connection_t *, char *);
 
 extern const TCHAR *cfgProp;
 
+/* These error codes are from openvpn service sources */
+#define ERROR_OPENVPN_STARTUP 0x20000000
+#define ERROR_STARTUP_DATA 0x20000001
+#define ERROR_MESSAGE_DATA 0x20000002
+#define ERROR_MESSAGE_TYPE 0x20000003
+
 #endif

--- a/options.h
+++ b/options.h
@@ -74,6 +74,14 @@ typedef enum {
     timedout
 } conn_state_t;
 
+/* Interactive Service IO parameters */
+typedef struct {
+    OVERLAPPED o; /* This has to be the first element */
+    HANDLE pipe;
+    HANDLE hEvent;
+    WCHAR readbuf[512];
+} service_io_t;
+
 /* Connections parameters */
 struct connection {
     TCHAR config_file[MAX_PATH];    /* Name of the config file */
@@ -95,7 +103,11 @@ struct connection {
         char *saved_data;
         size_t saved_size;
         mgmt_cmd_t *cmd_queue;
+        BOOL connected;             /* True, if management interface has connected */
     } manage;
+
+    HANDLE hProcess;                /* Handle of openvpn process if directly started */
+    service_io_t iserv;
 
     HANDLE exit_event;
     DWORD threadId;


### PR DESCRIPTION
To test, try to trigger an option error or an auth error using, say, config in user profile 
as a limited user, not member of ovpn_admin_group. Interactive service must be running.
This is against the current master, may not cleanly apply on top of PR#26