### PR TITLE
File 'compile' now removed as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Makefile.in
 aclocal.m4
 autodefs.h
 autom4te.cache
+compile
 config.guess
 config.h
 config.h.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,8 @@ MAINTAINERCLEANFILES = \
 	$(srcdir)/config.h.in $(srcdir)/config.h.in~\
 	$(srcdir)/install-sh $(srcdir)/missing \
 	$(srcdir)/depcomp $(srcdir)/aclocal.m4 \
-	$(srcdir)/config.guess $(srcdir)/config.sub
+	$(srcdir)/config.guess $(srcdir)/config.sub \
+	$(srcdir)/compile
 
 bin_PROGRAMS = openvpn-gui
 


### PR DESCRIPTION
When using `make maintainer-clean` the file `compile` was not removed.