### PR TITLE
Rescan configs

### DIFF
--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -217,7 +217,13 @@ BuildFileList()
 {
     static bool issue_warnings = true;
 
-    o.num_configs = 0;
+    /*
+     * If no connections are active reset num_configs and rescan
+     * to make a new list. Else we keep all current configs and
+     * rescan to add any new one's found
+     */
+    if (CountConnState(disconnected) == o.num_configs)
+        o.num_configs = 0;
 
     BuildFileList0 (o.config_dir, issue_warnings);
 

--- a/tray.c
+++ b/tray.c
@@ -182,8 +182,7 @@ OnNotifyTray(LPARAM lParam)
     case WM_RBUTTONUP:
         /* Recreate popup menus */
         DestroyPopupMenus();
-        if (CountConnState(disconnected) == o.num_configs)
-            BuildFileList();
+        BuildFileList();
         CreatePopupMenus();
 
         GetCursorPos(&pt);
@@ -206,16 +205,13 @@ OnNotifyTray(LPARAM lParam)
         else {
             int disconnected_conns = CountConnState(disconnected);
 
-            if (disconnected_conns == o.num_configs) {
-                /* Reread configs and recreate menus if no connection is running */
-                DestroyPopupMenus();
-                BuildFileList();
-                CreatePopupMenus();
+            DestroyPopupMenus();
+            BuildFileList();
+            CreatePopupMenus();
 
-                /* Start connection if only one config exist */
-                if (o.num_configs == 1 && o.conn[0].state == disconnected)
+            /* Start connection if only one config exist */
+            if (o.num_configs == 1 && o.conn[0].state == disconnected)
                     StartOpenVPN(&o.conn[0]);
-            }
             else if (disconnected_conns == o.num_configs - 1) {
                 /* Show status window if only one connection is running */
                 int i;


### PR DESCRIPTION
The first patch is a minor bug fix -- add a missing call to CheckReadAccess() and also simplify its usage.

The second patch adds a feature that helps the "import file" option:
Currently if a config is imported when connections are active it does not appear in the config list until all connections terminate or GUI restarts. The patch makes it possible to rescan for configs even if connections are active.