### PR TITLE
No new line for "Starting this connection requires membership in"

### DIFF
--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -248,13 +248,13 @@ BEGIN
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI does not support more than %d configs. Please contact the author if you have the need for more."
     IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found"
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in\n"\
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in "\
                                   """%s"" group. Contact your system administrator.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in\n"\
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\
                                   """%s"" group.\n\n"\
                                   "Do you want to add yourself to this group?\n"\
                                   "This action may prompt for administrtaive password or consent."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in\n"\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
                                   """%s"" group.\n\n"\
                                   "Please complete the previous authorization dialog."
     IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."


### PR DESCRIPTION
Because this happens:

![screenshot_20160824_194707](https://cloud.githubusercontent.com/assets/3054729/17939590/6075551e-6a3c-11e6-8763-bbadbaabc27e.png)
