### PR TITLE
Functionality to import configuration file from the command line

### DIFF
--- a/main.h
+++ b/main.h
@@ -115,5 +115,6 @@ void PrintDebugMsg(TCHAR *msg);
 DWORD GetDllVersion(LPCTSTR lpszDllName);
 
 void ImportConfigFile(PTCHAR);
+void ShowConfigFileDialog(PTCHAR config_file);
 
 #endif

--- a/main.h
+++ b/main.h
@@ -114,4 +114,6 @@ void PrintDebugMsg(TCHAR *msg);
 
 DWORD GetDllVersion(LPCTSTR lpszDllName);
 
+void ImportConfigFile(PTCHAR);
+
 #endif

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -292,7 +292,7 @@
 #define IDS_ERR_IMPORT_EXISTS           1901
 #define IDS_ERR_IMPORT_FAILED           1902
 #define IDS_NFO_IMPORT_SUCCESS          1903
-#define IDS_ASK_IMPORT_CONFIRM          1904
+#define IDS_ASK_IMPORT_OR_EDIT          1904
 
 /* Save password related messages */
 #define IDS_NFO_DELETE_PASS             2001

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -293,6 +293,7 @@
 #define IDS_ERR_IMPORT_FAILED           1902
 #define IDS_NFO_IMPORT_SUCCESS          1903
 #define IDS_ASK_IMPORT_OR_EDIT          1904
+#define IDS_ERR_PATH_NOT_FOUND          1905
 
 /* Save password related messages */
 #define IDS_NFO_DELETE_PASS             2001

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -292,6 +292,7 @@
 #define IDS_ERR_IMPORT_EXISTS           1901
 #define IDS_ERR_IMPORT_FAILED           1902
 #define IDS_NFO_IMPORT_SUCCESS          1903
+#define IDS_ASK_IMPORT_CONFIRM          1904
 
 /* Save password related messages */
 #define IDS_NFO_DELETE_PASS             2001

--- a/options.c
+++ b/options.c
@@ -41,6 +41,7 @@
 #include "localization.h"
 #include "misc.h"
 #include "registry.h"
+#include "viewlog.h"
 
 #define streq(x, y) (_tcscmp((x), (y)) == 0)
 
@@ -85,11 +86,6 @@ add_option(options_t *options, int i, TCHAR **p)
         TCHAR caption[200];
         LoadLocalizedStringBuf(caption, _countof(caption), IDS_NFO_USAGECAPTION);
         ShowLocalizedMsgEx(MB_OK, caption, IDS_NFO_USAGE);
-        exit(0);
-    }
-    else if (streq(p[0], _T("import")) && p[1])
-    {
-        ImportConfigFile(p[1]);
         exit(0);
     }
     else if (streq(p[0], _T("connect")) && p[1])
@@ -149,6 +145,16 @@ add_option(options_t *options, int i, TCHAR **p)
     {
         ++i;
         PrintDebug (L"Deprecated option: '%s' ignored.", p[0]);
+    }
+        else if (streq(p[0], _T("edit")) && p[1])
+    {
+        EditConfig(0, p[1]);
+        exit(0);
+    }
+        else if (streq(p[0], _T("configfile_dialog")) && p[1])
+    {
+        ShowConfigFileDialog(p[1]);
+        exit(0);
     }
     else if (streq(p[0], _T("allow_service")) && p[1])
     {

--- a/options.c
+++ b/options.c
@@ -262,6 +262,8 @@ InitOptions(options_t *opt)
     CLEAR(*opt);
     opt->netcmd_semaphore = InitSemaphore ();
     opt->version = MakeVersion (PACKAGE_VERSION_RESOURCE);
+    /* An editor to fall back to if associated exec not found*/
+    _sntprintf_0(opt->editor, L"%s", L"C:\\Windows\\system32\\notepad.exe");
 }
 
 

--- a/options.c
+++ b/options.c
@@ -87,6 +87,11 @@ add_option(options_t *options, int i, TCHAR **p)
         ShowLocalizedMsgEx(MB_OK, caption, IDS_NFO_USAGE);
         exit(0);
     }
+    else if (streq(p[0], _T("import")) && p[1])
+    {
+        ImportConfigFile(p[1]);
+        exit(0);
+    }
     else if (streq(p[0], _T("connect")) && p[1])
     {
         ++i;

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -429,6 +429,7 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n" \
                           "%s\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
+    IDS_ASK_IMPORT_CONFIRM "Do you want to import file ""%s""?"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -431,6 +431,7 @@ BEGIN
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_ASK_IMPORT_OR_EDIT "Do you want to import ""%s""?\n" \
                        "Choose ""yes"" to import or ""no"" to edit config file."
+    IDS_ERR_PATH_NOT_FOUND "Specified path '%s' not found"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -429,7 +429,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n" \
                           "%s\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
-    IDS_ASK_IMPORT_CONFIRM "Do you want to import file ""%s""?"
+    IDS_ASK_IMPORT_OR_EDIT "Do you want to import ""%s""?\n" \
+                       "Choose ""yes"" to import or ""no"" to edit config file."
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""

--- a/viewlog.c
+++ b/viewlog.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <shellapi.h>
 #include <objbase.h>
+#include <shlwapi.h>
 
 #include "tray.h"
 #include "openvpn.h"
@@ -40,12 +41,14 @@ extern options_t o;
 void ViewLog(int config)
 {
   TCHAR filename[2*MAX_PATH];
+  TCHAR assocexe[2*MAX_PATH];
+  DWORD assocexe_num;
 
   STARTUPINFO start_info;
   PROCESS_INFORMATION proc_info;
   SECURITY_ATTRIBUTES sa;
   SECURITY_DESCRIPTOR sd;
-  HINSTANCE status;
+  HINSTANCE status = 0;
 
   CLEAR (start_info);
   CLEAR (proc_info);
@@ -54,8 +57,8 @@ void ViewLog(int config)
 
   /* Try first using file association */
   CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE); /* Safe to init COM multiple times */
-  status = ShellExecuteW (o.hWnd, L"open", o.conn[config].log_path, NULL, o.log_dir, SW_SHOWNORMAL);
-
+  if (AssocQueryString(0, ASSOCSTR_EXECUTABLE, L".txt", NULL, assocexe, &assocexe_num) == S_OK)
+    status = ShellExecuteW (o.hWnd, L"open", assocexe, o.conn[config].log_path, o.log_dir, SW_SHOWNORMAL);
   if (status > (HINSTANCE) 32) /* Success */
     return;
   else
@@ -95,12 +98,14 @@ void ViewLog(int config)
 void EditConfig(int config)
 {
   TCHAR filename[2*MAX_PATH];
+  TCHAR assocexe[2*MAX_PATH];
+  DWORD assocexe_num;
 
   STARTUPINFO start_info;
   PROCESS_INFORMATION proc_info;
   SECURITY_ATTRIBUTES sa;
   SECURITY_DESCRIPTOR sd;
-  HINSTANCE status;
+  HINSTANCE status = 0;
 
   CLEAR (start_info);
   CLEAR (proc_info);
@@ -111,7 +116,8 @@ void EditConfig(int config)
   _sntprintf_0(filename, L"%s\\%s", o.conn[config].config_dir, o.conn[config].config_file);
 
   CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE); /* Safe to init COM multiple times */
-  status = ShellExecuteW (o.hWnd, L"open", filename, NULL, o.conn[config].config_dir, SW_SHOWNORMAL);
+  if (AssocQueryString(0, ASSOCSTR_EXECUTABLE, L".txt", NULL, assocexe, &assocexe_num) == S_OK)
+    status = ShellExecuteW (o.hWnd, L"open", assocexe, filename, o.conn[config].config_dir, SW_SHOWNORMAL);
   if (status > (HINSTANCE) 32)
     return;
   else

--- a/viewlog.h
+++ b/viewlog.h
@@ -20,4 +20,4 @@
  */
 
 void ViewLog(int config);
-void EditConfig(int config);
+void EditConfig(int config, PTCHAR config_path);


### PR DESCRIPTION
This functionality allows to import configuration file using `--import` command line option. It is intended to be used as a handler when *.ovpn files are double-clicked. NSIS installer script should be modified to achieve this (https://github.com/OpenVPN/openvpn-build/pull/26).
