### PR TITLE
Improve the message shown when no config files are found

### DIFF
--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -235,7 +235,7 @@ BuildFileList()
         BuildFileList0 (o.global_config_dir, issue_warnings);
 
     if (o.num_configs == 0 && issue_warnings)
-        ShowLocalizedMsg(IDS_NFO_NO_CONFIGS);
+        ShowLocalizedMsg(IDS_NFO_NO_CONFIGS, o.config_dir, o.global_config_dir);
 
     issue_warnings = false;
 }

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -247,7 +247,8 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI does not support more than %d configs. Please contact the author if you have the need for more."
-    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found"
+    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
     IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in "\
                                   """%s"" group. Contact your system administrator.\n"
     IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -244,7 +244,8 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI ondersteunt niet meer dan %d configuraties. Neem contact op met de auteur indien u er meer wenst."
-    IDS_NFO_NO_CONFIGS "Geen leesbare verbindingsprofielen (config files) gevonden."
+    IDS_NFO_NO_CONFIGS "Geen leesbare verbindingsprofielen (config files) gevonden.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
     IDS_ERR_CONFIG_NOT_AUTHORIZED "Het maken van deze verbinding (%s) vereist lidmaatschap van\n"\
                                   "de groep ""%s"". Neem contact op met de systeembeheerder.\n"
     IDS_ERR_CONFIG_TRY_AUTHORIZE  "Het maken van deze verbinding (%s) vereist lidmaatschap van\n"\

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -244,7 +244,8 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI não suporta mais do que %d configurações. Contate o autor se você necessita de mais."
-    IDS_NFO_NO_CONFIGS "Nenhum perfil de conexão (arquivo de configuração) foi localizado."
+    IDS_NFO_NO_CONFIGS "Nenhum perfil de conexão (arquivo de configuração) foi localizado.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
     IDS_ERR_ONE_CONN_OLD_VER "Você pode ter apenas uma conexão ativa enquanto estiver usando uma versão anterior a OpenVPN 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Você não pode usar o OpenVPN GUI para iniciar uma conexão enquanto o serviço OpenVPN estiver em execução (com OpenVPN 1.5/1.6). Pare o serviço OpenVPN primero se você quiser utilizar o OpenVPN GUI."
     IDS_ERR_CREATE_EVENT "CreateEvent falhou no evento de saída: %s"

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -248,7 +248,8 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI не поддерживает более %d конфигураций. Пожалуйста, свяжитесь с автором, если вам нужно больше."
-    IDS_NFO_NO_CONFIGS "Файлы конфигурации не найдены."
+    IDS_NFO_NO_CONFIGS "Файлы конфигурации не найдены.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
     IDS_ERR_CONFIG_NOT_AUTHORIZED "Для запуска данного подключения (%s) требуется членство в группе\n"\
                                   """%s"". Свяжитесь с вашим системным администратором.\n"
     IDS_ERR_CONFIG_TRY_AUTHORIZE  "Для запуска данного подключения (%s) требуется членство в группе\n"\


### PR DESCRIPTION
The popup message shown when no config files are present now includes a pointer to the "Import File.." menu and the location of the user and global config directories.

Note: Translations of the added text is missing.