### PR TITLE
Check for interactive service only if OpenVPN version is >= 2.4

### DIFF
--- a/main.c
+++ b/main.c
@@ -187,7 +187,7 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
     exit(1);
   }
 
-  if (!IsUserAdmin())
+  if (!IsUserAdmin() && strtod(o.ovpn_version, NULL) > 2.3)
     CheckIServiceStatus(TRUE);
 
   BuildFileList();

--- a/openvpn.c
+++ b/openvpn.c
@@ -1431,8 +1431,14 @@ CheckVersion()
         CloseHandle(pi.hProcess);
 
         /* OpenVPN version 2.x */
-        if (strstr(line, match_version))
+        char *p = strstr(line, match_version);
+        if (p)
+        {
             retval = TRUE;
+            p = strtok(p+8, " ");
+            strncpy(o.ovpn_version, p, _countof(o.ovpn_version)-1);
+            o.ovpn_version[_countof(o.ovpn_version)] = '\0';
+        }
     }
 
 out:

--- a/options.h
+++ b/options.h
@@ -172,6 +172,7 @@ typedef struct {
     BOOL session_locked;
     HANDLE netcmd_semaphore;
     version_t version;
+    char ovpn_version[16]; /* OpenVPN version string: 2.3.12, 2.4_alpha2 etc.. */
 } options_t;
 
 void InitOptions(options_t *);


### PR DESCRIPTION
This makes it less confusing to run GUI v11 with OpenVPN 2.3.x

Signed-off-by: Selva Nair <selva.nair@gmail.com>