### PR TITLE
Load icons at sizes given by DPI-dependent system metric

### DIFF
--- a/localization.h
+++ b/localization.h
@@ -28,6 +28,7 @@ int LoadLocalizedStringBuf(PTSTR, const int, const UINT, ...);
 void ShowLocalizedMsg(const UINT, ...);
 int ShowLocalizedMsgEx(const UINT, LPCTSTR, const UINT, ...);
 HICON LoadLocalizedIcon(const UINT);
+HICON LoadLocalizedSmallIcon(const UINT);
 LPCDLGTEMPLATE LocalizedDialogResource(const UINT);
 INT_PTR LocalizedDialogBoxParam(const UINT, DLGPROC, const LPARAM);
 HWND CreateLocalizedDialogParam(const UINT, DLGPROC, const LPARAM);

--- a/openvpn.c
+++ b/openvpn.c
@@ -1712,12 +1712,14 @@ SuspendOpenVPN(int config)
 void
 SetStatusWinIcon(HWND hwndDlg, int iconId)
 {
-    HICON hIcon = LoadLocalizedIcon(iconId);
+    HICON hIcon = LoadLocalizedSmallIcon(iconId);
     if (!hIcon)
         return;
-
+    HICON hIconBig = LoadLocalizedIcon(ID_ICO_APP);
+    if (!hIconBig)
+        hIconBig = hIcon;
     SendMessage(hwndDlg, WM_SETICON, (WPARAM) ICON_SMALL, (LPARAM) hIcon);
-    SendMessage(hwndDlg, WM_SETICON, (WPARAM) ICON_BIG, (LPARAM) hIcon);
+    SendMessage(hwndDlg, WM_SETICON, (WPARAM) ICON_BIG, (LPARAM) hIconBig);
 }
 
 

--- a/tray.c
+++ b/tray.c
@@ -227,7 +227,7 @@ ShowTrayIcon()
   ni.hWnd = o.hWnd;
   ni.uFlags = NIF_MESSAGE | NIF_TIP | NIF_ICON;
   ni.uCallbackMessage = WM_NOTIFYICONTRAY;
-  ni.hIcon = LoadLocalizedIcon(ID_ICO_DISCONNECTED);
+  ni.hIcon = LoadLocalizedSmallIcon(ID_ICO_DISCONNECTED);
   _tcsncpy(ni.szTip, LoadLocalizedString(IDS_TIP_DEFAULT), _countof(ni.szTip));
 
   Shell_NotifyIcon(NIM_ADD, &ni);
@@ -291,7 +291,7 @@ SetTrayIcon(conn_state_t state)
     ni.cbSize = sizeof(ni);
     ni.uID = 0;
     ni.hWnd = o.hWnd;
-    ni.hIcon = LoadLocalizedIcon(icon_id);
+    ni.hIcon = LoadLocalizedSmallIcon(icon_id);
     ni.uFlags = NIF_MESSAGE | NIF_TIP | NIF_ICON;
     ni.uCallbackMessage = WM_NOTIFYICONTRAY;
     _tcsncpy(ni.szTip, msg, _countof(ni.szTip));


### PR DESCRIPTION
- Check system metric for large and small icon sizes and
  try to load the correct size instaed of scaling from one size.

Scaling will still happen if the required size is not available
in the icon resource. As we add more icon sizes they will
get automatically used as needed.

LoadImage scales up from next smallest size available. Revisit this
when LoadIconWithScaleDown (Vista+) becomes available in mingw.

Resolves Trac: #772 (icon scaling issue)

Signed-off-by: Selva Nair <selva.nair@gmail.com>