### PR TITLE
Update _WIN32_WINNT to _WIN32_WINNT_VISTA

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,7 @@ AC_DEFINE_UNQUOTED([MAX_CONFIGS], [$MAX_CONFIGS], [Maximum number of config file
 case "$host" in
 	*-mingw*)
 		CPPFLAGS="${CPPFLAGS} -DWIN32_LEAN_AND_MEAN"
-		CPPFLAGS="${CPPFLAGS} -D_WIN32_WINNT=NTDDI_WINXP"
+		CPPFLAGS="${CPPFLAGS} -D_WIN32_WINNT=_WIN32_WINNT_VISTA -DWINVER=_WIN32_WINNT"
 		LDFLAGS="${LDFLAGS} -Wl,--nxcompat,--dynamicbase"
 
 		dnl older mingw doesn't support `--high-entropy-va`


### PR DESCRIPTION
The change will help warn against use of API calls not in vista.
The original setting of this macro to  _NTDDI_WINXP was wrong and
permitted use of any API not just those supported by WinXP. Build
is unaffected as we currently do not have any function calls not
present in Vista.

Signed-off-by: Selva Nair <selva.nair@gmail.com>