### PR TITLE
Some error reporting improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,7 +185,8 @@ log_append
   
 silent_connection
     If set to "1", the status window with the OpenVPN log output will
-    not be showed while connecting.
+    not be shown while connecting. Warnings such as interactive service
+    not started or multiple config files with same name are also suppressed.
 
 service_only
     If set to "1", OpenVPN GUI's normal "Connect" and "Disconnect"

--- a/main.c
+++ b/main.c
@@ -189,7 +189,7 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
     exit(1);
   }
 
-  if (!IsUserAdmin() && strtod(o.ovpn_version, NULL) > 2.3)
+  if (!IsUserAdmin() && strtod(o.ovpn_version, NULL) > 2.3 && !o.silent_connection)
     CheckIServiceStatus(TRUE);
 
   BuildFileList();

--- a/openvpn.c
+++ b/openvpn.c
@@ -191,7 +191,7 @@ OnStateChange(connection_t *c, char *data)
         return;
     *pos = '\0';
 
-    if (strcmp(state, "CONNECTED") == 0)
+    if (strcmp(state, "CONNECTED") == 0 && strcmp(message, "SUCCESS") == 0)
     {
         /* Run Connect Script */
         if (c->state == connecting || c->state == resuming)

--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -221,6 +221,9 @@ BuildFileList()
 {
     static bool issue_warnings = true;
 
+    if (o.silent_connection)
+        issue_warnings = false;
+
     /*
      * If no connections are active reset num_configs and rescan
      * to make a new list. Else we keep all current configs and

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -355,7 +355,7 @@ BEGIN
                   "--allow_proxy\t\t: 1=Show Proxy Settings menu.\n" \
                   "--show_balloon\t\t: 0=Never, 1=At initial connect, 2=At every re-connect.\n" \
                   "--service_only\t\t: 1=Enable Service Only mode.\n" \
-                  "--silent_connection\t\t: 1=Do not show the status dialog while connecting.\n" \
+                  "--silent_connection\t\t: 1=Do not show the status dialog while connecting or non-critical warnings at startup.\n" \
                   "--show_script_window\t: 0=Hide Script execution window, 1=Show it.\n" \
                   "--passphrase_attempts\t: Number of passphrase attempts to allow.\n" \
                   "--connectscript_timeout\t: Time to wait for connect script to finish.\n" \


### PR DESCRIPTION
Two commits:

1. Distinguish between state change messages: CONNECTED,SUCCESS and CONNECTED,ERROR -- this avoids wrongly reporting incomplete connections as successful (see e.g., https://www.mail-archive.com/openvpn-users@lists.sourceforge.net/msg03437.html where setting ip address failed but GUI reported success). 

Note: OpenVPN reports connections completed with route setting errors  as "CONNECTED,SUCCESS", so such cases will continue to be treated as success by the GUI.

2. Disable warning popups (such as interactive service not running  or duplicate configs found) when silent_connection is true. (As discussed under issue #111).