### PR TITLE
Add a system-wide option to disable the password save feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,10 @@ Registry Values affecting the OpenVPN GUI operation
 Parameters taken from the global registry values in
 *HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenVPN\\* key
 
+(Default)
+    The installation directory of openvpn (e.g., *C:\\Program Files\\OpenVPN*).
+    This value must be present.
+
 config_dir
     The global configuration file directory. Defaults to
     *C:\\Program Files\\OpenVPN\\config*
@@ -149,6 +153,10 @@ ovpn_admin_group
     The windows group whose membership allows the user to start any configuration file
     in their profile (not just those installed by the administrator in the global
     config directory). Default: "OpenVPN Administrators".
+
+disable_save_passwords
+    Set to a nonzero value to disable the password save feature.
+    Default: 0
 
 All other OpenVPN GUI registry values are located below the
 *HKEY_CURRENT_USER\\SOFTWARE\\OpenVPN-GUI\\* key

--- a/main.c
+++ b/main.c
@@ -400,7 +400,7 @@ LRESULT CALLBACK WindowProcedure (HWND hwnd, UINT message, WPARAM wParam, LPARAM
         EditConfig(LOWORD(wParam) - IDM_EDITMENU);
       }
       if ( (LOWORD(wParam) >= IDM_CLEARPASSMENU) && (LOWORD(wParam) < IDM_CLEARPASSMENU + MAX_CONFIGS) ) {
-        DisablePasswordSave(&o.conn[LOWORD(wParam) - IDM_CLEARPASSMENU]);
+        ResetSavePasswords(&o.conn[LOWORD(wParam) - IDM_CLEARPASSMENU]);
       }
 #ifndef DISABLE_CHANGE_PASSWORD
       if ( (LOWORD(wParam) >= IDM_PASSPHRASEMENU) && (LOWORD(wParam) < IDM_PASSPHRASEMENU + MAX_CONFIGS) ) {

--- a/openvpn.c
+++ b/openvpn.c
@@ -294,7 +294,9 @@ UserAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             SetDlgItemTextW(hwndDlg, ID_EDT_AUTH_PASS, password);
             SecureZeroMemory(password, sizeof(password));
         }
-        if (param->c->flags & FLAG_SAVE_AUTH_PASS)
+        if (param->c->flags & FLAG_DISABLE_SAVE_PASS)
+            ShowWindow(GetDlgItem (hwndDlg, ID_CHK_SAVE_PASS), SW_HIDE);
+        else if (param->c->flags & FLAG_SAVE_AUTH_PASS)
             Button_SetCheck(GetDlgItem (hwndDlg, ID_CHK_SAVE_PASS), BST_CHECKED);
 
         AppendTextToCaption (hwndDlg, param->c->config_name);
@@ -517,7 +519,9 @@ PrivKeyPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             EndDialog(hwndDlg, IDOK);
             return TRUE;
         }
-        if (c->flags & FLAG_SAVE_KEY_PASS)
+        if (c->flags & FLAG_DISABLE_SAVE_PASS)
+            ShowWindow(GetDlgItem (hwndDlg, ID_CHK_SAVE_PASS), SW_HIDE);
+        else if (c->flags & FLAG_SAVE_KEY_PASS)
             Button_SetCheck (GetDlgItem (hwndDlg, ID_CHK_SAVE_PASS), BST_CHECKED);
         if (c->state == resuming)
             ForceForegroundWindow(hwndDlg);
@@ -1859,8 +1863,9 @@ out:
     return retval;
 }
 
+/* Delete saved passwords and reset the checkboxes to default */
 void
-DisablePasswordSave(connection_t *c)
+ResetSavePasswords(connection_t *c)
 {
     if (ShowLocalizedMsgEx(MB_OKCANCEL, TEXT(PACKAGE_NAME), IDS_NFO_DELETE_PASS, c->config_name) == IDCANCEL)
         return;

--- a/openvpn.h
+++ b/openvpn.h
@@ -38,7 +38,7 @@ void OnStop(connection_t *, char *);
 void OnNeedOk(connection_t *, char *);
 void OnNeedStr(connection_t *, char *);
 
-void DisablePasswordSave(connection_t *);
+void ResetSavePasswords(connection_t *);
 
 extern const TCHAR *cfgProp;
 

--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -87,12 +87,13 @@ ConfigAlreadyExists(TCHAR *newconfig)
     return false;
 }
 
-
 static void
 AddConfigFileToList(int config, const TCHAR *filename, const TCHAR *config_dir)
 {
     connection_t *c = &o.conn[config];
     int i;
+
+    memset(c, 0, sizeof(*c));
 
     _tcsncpy(c->config_file, filename, _countof(c->config_file) - 1);
     _tcsncpy(c->config_dir, config_dir, _countof(c->config_dir) - 1);
@@ -120,10 +121,17 @@ AddConfigFileToList(int config, const TCHAR *filename, const TCHAR *config_dir)
         }
     }
     /* check whether passwords are saved */
-    if (IsAuthPassSaved(c->config_name))
-        c->flags |= FLAG_SAVE_AUTH_PASS;
-    if (IsKeyPassSaved(c->config_name))
-        c->flags |= FLAG_SAVE_KEY_PASS;
+    if (o.disable_save_passwords)
+    {
+        DisableSavePasswords(c);
+    }
+    else
+    {
+        if (IsAuthPassSaved(c->config_name))
+            c->flags |= FLAG_SAVE_AUTH_PASS;
+        if (IsKeyPassSaved(c->config_name))
+            c->flags |= FLAG_SAVE_KEY_PASS;
+    }
 }
 
 

--- a/options.c
+++ b/options.c
@@ -41,6 +41,7 @@
 #include "localization.h"
 #include "misc.h"
 #include "registry.h"
+#include "save_pass.h"
 
 #define streq(x, y) (_tcscmp((x), (y)) == 0)
 
@@ -530,4 +531,13 @@ CompareStringExpanded (const WCHAR *str1, const WCHAR *str2)
     ExpandString (str2_cpy, _countof(str2_cpy));
 
     return wcsicmp (str1_cpy, str2_cpy);
+}
+
+/* Hide the password save options from user */
+void
+DisableSavePasswords(connection_t *c)
+{
+    DeleteSavedPasswords(c->config_name);
+    c->flags &= ~(FLAG_SAVE_AUTH_PASS | FLAG_SAVE_KEY_PASS);
+    c->flags |= FLAG_DISABLE_SAVE_PASS;
 }

--- a/options.h
+++ b/options.h
@@ -86,6 +86,7 @@ typedef struct {
 #define FLAG_ALLOW_CHANGE_PASSPHRASE (1<<1)
 #define FLAG_SAVE_KEY_PASS  (1<<4)
 #define FLAG_SAVE_AUTH_PASS (1<<5)
+#define FLAG_DISABLE_SAVE_PASS (1<<6)
 
 typedef struct {
     unsigned short major, minor, build, revision;
@@ -149,6 +150,7 @@ typedef struct {
     TCHAR global_config_dir[MAX_PATH];
     TCHAR priority_string[64];
     TCHAR ovpn_admin_group[MAX_NAME];
+    DWORD disable_save_passwords;
     /* HKCU registry values */
     TCHAR config_dir[MAX_PATH];
     TCHAR ext_string[16];
@@ -184,6 +186,7 @@ connection_t* GetConnByManagement(SOCKET);
 INT_PTR CALLBACK ScriptSettingsDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK ConnectionSettingsDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK AdvancedSettingsDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam);
+void DisableSavePasswords(connection_t *);
 
 void ExpandOptions(void);
 int CompareStringExpanded(const WCHAR *str1, const WCHAR *str2);

--- a/registry.c
+++ b/registry.c
@@ -127,6 +127,10 @@ GetGlobalRegistryKeys()
     {
       _tcsncpy(o.priority_string, _T("NORMAL_PRIORITY_CLASS"), _countof(o.priority_string)-1);
     }
+  if (!GetRegistryValueNumeric(regkey, _T("disable_save_passwords"), &o.disable_save_passwords))
+  {
+      o.disable_save_passwords = 0;
+  }
   RegCloseKey(regkey);
   return true;
 }


### PR DESCRIPTION
Issue #105

- A new registry HKLM\Software\OpenVPN\disable_save_passwords
  (32 bit DWORD value) may be set to a non-zero value to
  disable password saving by users. Applies to both auth and
  private key passwords. Usernames are always saved.

Signed-off-by: Selva Nair <selva.nair@gmail.com>