### PR TITLE
Check group membership without needing connection to DC

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -1551,6 +1551,7 @@ StartOpenVPN(connection_t *c)
         if ( !AuthorizeConfig(c))
         {
             CloseHandle(c->exit_event);
+            CloseServiceIO(&c->iserv);
             goto out;
         }
 

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -270,7 +270,7 @@ BEGIN
     IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\
                                   """%s"" group.\n\n"\
                                   "Do you want to add yourself to this group?\n"\
-                                  "This action may prompt for administrtaive password or consent."
+                                  "This action may prompt for administrative password or consent."
     IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
                                   """%s"" group.\n\n"\
                                   "Please complete the previous authorization dialog."


### PR DESCRIPTION
(updated)
See also [Trac #810](https://community.openvpn.net/openvpn/ticket/810)

~Compare the SID of the user with member SIDs in the Administrators
group and ovpn_admin_group. This avoid issues on setups where the
DC may not be reachable and allows validating users logged in with
cached credentials.~
Authorize the user if

(i) admin groups are found in the process token
(ii) or the SID of the user is a member of the admin groups

The second check is needed to support adding the user to the
ovpn_admin_group when GUI is running, as such changes in group
membership will not be reflected in the token.

Same approach is used in the proposed patch (v2) for interactive service
http://www.mail-archive.com/openvpn-devel@lists.sourceforge.net/msg13834.html