### PR TITLE
Fix truncation of usage message shown when --help is used

### DIFF
--- a/localization.c
+++ b/localization.c
@@ -63,7 +63,7 @@ FindResourceLang(PTSTR resType, PTSTR resId, LANGID langId)
 }
 
 
-static LANGID
+LANGID
 GetGUILanguage(void)
 {
     if (gui_language != 0)

--- a/localization.h
+++ b/localization.h
@@ -34,5 +34,6 @@ INT_PTR LocalizedDialogBoxParam(const UINT, DLGPROC, const LPARAM);
 HWND CreateLocalizedDialogParam(const UINT, DLGPROC, const LPARAM);
 HWND CreateLocalizedDialog(const UINT, DLGPROC);
 INT_PTR CALLBACK GeneralSettingsDlgProc(HWND, UINT, WPARAM, LPARAM);
+LANGID GetGUILanguage(void);
 
 #endif

--- a/main.h
+++ b/main.h
@@ -40,6 +40,7 @@
 #define MAX_LOG_LENGTH      1024/* Max number of characters per log line */
 #define MAX_LOG_LINES		500	/* Max number of lines in LogWindow */
 #define DEL_LOG_LINES		10	/* Number of lines to delete from LogWindow */
+#define USAGE_BUF_SIZE		2048	/* Size of buffer used to display usage message */
 
 /* Authorized group who can use any options and config locations */
 #define OVPN_ADMIN_GROUP TEXT("OpenVPN Administrators") /* May be reset in registry */

--- a/options.c
+++ b/options.c
@@ -83,8 +83,10 @@ add_option(options_t *options, int i, TCHAR **p)
     if (streq(p[0], _T("help")))
     {
         TCHAR caption[200];
+        TCHAR msg[USAGE_BUF_SIZE];
         LoadLocalizedStringBuf(caption, _countof(caption), IDS_NFO_USAGECAPTION);
-        ShowLocalizedMsgEx(MB_OK, caption, IDS_NFO_USAGE);
+        LoadLocalizedStringBuf(msg, _countof(msg), IDS_NFO_USAGE);
+        MessageBoxEx(NULL, msg, caption, MB_OK | MB_SETFOREGROUND, GetGUILanguage());
         exit(0);
     }
     else if (streq(p[0], _T("connect")) && p[1])


### PR DESCRIPTION
- Increase the buffer size used to load the usage string to 2048
  chars (defined by USAGE_BUF_SIZE in main.h)
- Make GetGUILanguage() visible outside localization.c

Trac: #833

Signed-off-by: Selva Nair <selva.nair@gmail.com>