### PR TITLE
Fix builds from release tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ AM_CFLAGS = -municode
 
 openvpn_gui_RESOURCES = \
 	res/openvpn-gui-res.rc \
+	res/openvpn-gui-res-cs.rc \
 	res/openvpn-gui-res-de.rc \
 	res/openvpn-gui-res-dk.rc \
 	res/openvpn-gui-res-en.rc \


### PR DESCRIPTION
The openvpn-gui-res-cs.rc file was not included in release tarballs, which made
tarball-based builds fail.

URL: https://github.com/OpenVPN/openvpn-gui/issues/131
Signed-off-by: Samuli Seppänen <samuli@openvpn.net>