### PR TITLE
AppVeyor support

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -1,0 +1,19 @@
+
+autoreconf -iv
+unset CC
+unset CXX
+
+if [ "${ARCH}" = "x86" ]; then 
+	export ABBR="i686" 
+	export CHOST="i686-w64-mingw32"
+fi
+
+if [ "${ARCH}" = "x86_64" ]; then 
+        export ABBR="x86_64"
+	export CHOST="x86_64-w64-mingw32"
+fi
+
+export CC=${ABBR}-w64-mingw32-gcc
+
+./configure --prefix=/ --libdir=/lib --host=$CHOST --build=i686-pc-cygwin --program-prefix=''
+make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: "cygwin-{build}"
+
+environment:
+  matrix:
+    - ARCH: x86
+      CYGWIN: C:\Cygwin
+    - ARCH: x86_64
+      CYGWIN: C:\Cygwin64
+
+build_script:
+  - "%CYGWIN%\\setup-%ARCH%.exe -q -P mingw64-i686-openssl,mingw64-x86_64-openssl,mingw64-i686-gcc-core,mingw64-x86_64-gcc-core,cygwin-devel"
+  - "%CYGWIN%\\bin\\bash -lc 'cd /cygdrive/c/projects/%APPVEYOR_PROJECT_NAME% ; ./appveyor.sh'"
+
+artifacts:
+  - path: openvpn-gui.exe


### PR DESCRIPTION
AppVeyor stores artifacts, it might be used for "test new feature" builds.
also, it is useful to build in cygwin regularly

@mattock , can you add openvpn-gui to ci.appveyor.com ?