### PR TITLE
Parse ECHO directives from openvpn

### DIFF
--- a/main.c
+++ b/main.c
@@ -121,6 +121,7 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
       { stop,     OnStop },
       { needok,   OnNeedOk },
       { needstr,  OnNeedStr },
+      { echo,     OnEcho },
       { 0,        NULL }
   };
   InitManagement(handler);

--- a/manage.c
+++ b/manage.c
@@ -322,6 +322,11 @@ OnManagement(SOCKET sk, LPARAM lParam)
                     if (rtmsg_handler[needstr])
                         rtmsg_handler[needstr](c, pos + 9);
                 }
+                else if (strncmp(pos, "ECHO:", 5) == 0)
+                {
+                    if (rtmsg_handler[echo])
+                        rtmsg_handler[echo](c, pos + 5);
+                }
             }
             else if (c->manage.cmd_queue)
             {

--- a/openvpn.c
+++ b/openvpn.c
@@ -108,6 +108,7 @@ OnReady(connection_t *c, UNUSED char *msg)
 {
     ManagementCommand(c, "state on", NULL, regular);
     ManagementCommand(c, "log all on", OnLogLine, combined);
+    ManagementCommand(c, "echo all on", OnEcho, combined);
 }
 
 
@@ -687,6 +688,38 @@ out:
     if (!ret)
         PrintDebug (L"Error parsing password/string request msg: <%S>", msg);
     return ret;
+}
+
+/*
+ * Handle >ECHO: request from OpenVPN management interface
+ * Expect msg = timestamp,message
+ */
+void
+OnEcho(connection_t *c, char *msg)
+{
+    WCHAR errmsg[256];
+
+    PrintDebug(L"OnEcho with msg = %S", msg);
+    if (!(msg = strchr(msg, ',')))
+    {
+        PrintDebug(L"OnEcho: msg format not recognized");
+        return;
+    }
+    msg++;
+
+    if (strcmp(msg, "forget-passwords") == 0)
+    {
+        DeleteSavedPasswords(c->config_name);
+    }
+    else if (strcmp(msg, "save-passwords") == 0)
+    {
+        c->flags |= (FLAG_SAVE_KEY_PASS | FLAG_SAVE_AUTH_PASS);
+    }
+    else
+    {
+        _sntprintf_0(errmsg, L"WARNING: Unknown ECHO directive '%S' ignored.", msg);
+        WriteStatusLog(c, L"GUI> ", errmsg, false);
+    }
 }
 
 /*

--- a/openvpn.h
+++ b/openvpn.h
@@ -37,6 +37,7 @@ void OnPassword(connection_t *, char *);
 void OnStop(connection_t *, char *);
 void OnNeedOk(connection_t *, char *);
 void OnNeedStr(connection_t *, char *);
+void OnEcho(connection_t *, char *);
 
 void DisablePasswordSave(connection_t *);
 


### PR DESCRIPTION
Support the following echo commands

- "echo forget-passwords": delete passwords internally saved by the GUI
  but do not disable the password save feature. Useful when pushed
  from the server so that it gets processed after authentication. Also see
  management-notes.txt in openvpn docs.

- "echo save-passwords": enables private-key and auth-user-pass passwords
  to be saved. Will be effective at startup only if present in the config
  file. If pushed from the server, will get used for subsequent
  password prompts. Essentially this has the effect of presenting the password
  dialogs to the user with save-password checkbox selected. The user may still
  uncheck it during the dialog.

Note: echo commands are processed as and when they are received and in the order
received.

TODO: support "echo setenv", "echo disable-save-passwords"

Signed-off-by: Selva Nair <selva.nair@gmail.com>