### PR TITLE
AppVeyor: switch to preinstalled mingw64-%ARCH%-gcc-core

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
       CYGWIN: C:\Cygwin64
 
 build_script:
-  - "%CYGWIN%\\setup-%ARCH%.exe -q -P mingw64-i686-openssl,mingw64-x86_64-openssl,mingw64-i686-gcc-core-5.4.0-3,mingw64-x86_64-gcc-core-5.4.0-3,cygwin-devel"
+  - "%CYGWIN%\\setup-%ARCH%.exe -q -P mingw64-i686-openssl,mingw64-x86_64-openssl,cygwin-devel"
   - "%CYGWIN%\\bin\\bash -lc 'cd /cygdrive/c/projects/%APPVEYOR_PROJECT_NAME% ; ./appveyor.sh'"
 
 artifacts:


### PR DESCRIPTION
it turned out that reinstalling mingw-gcc-core lead us to strange cygwin behaviour, gcc became ununsable (even "$CC --version" failed), so .. I decided to not install those compilers