### PR TITLE
Set focus to password field when username is filled

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -289,7 +289,10 @@ UserAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 
         }
         if (RecallUsername(param->c->config_name, username))
+        {
             SetDlgItemTextW(hwndDlg, ID_EDT_AUTH_USER, username);
+            SetFocus(GetDlgItem(hwndDlg, ID_EDT_AUTH_PASS));
+        }
         if (RecallAuthPass(param->c->config_name, password))
         {
             SetDlgItemTextW(hwndDlg, ID_EDT_AUTH_PASS, password);


### PR DESCRIPTION
When the username is filled automatically, set the focus to the password field. This way you can enter the password immediately without having the press TAB (or even worst users using the mouse to click on the password field).