### PR TITLE
harden build script

### DIFF
--- a/.travis-build-openssl.sh
+++ b/.travis-build-openssl.sh
@@ -1,5 +1,6 @@
 #!/bin/bash 
 
+set -e
 
 if [ ! -f download-cache/openssl-${OPENSSL_VERSION}.tar.gz ]; then wget -P download-cache/ https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz; fi
 


### PR DESCRIPTION
when playing with openssl-1.1.0 build, I noticed that build fails on very late stage

https://travis-ci.org/chipitsine/openvpn-gui/builds/246756272

so, adding "set -e" should make it really better