### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig: http://EditorConfig.org
+
+root = true
+
+[*]
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.sh]
+end_of_line = lf
+
+[*.yml]
+indent_size = 2
+
+[{Makefile,Makefile.*}]
+indent_style = tab


### PR DESCRIPTION
EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. See http://editorconfig.org/ for more details. All major editor support EditorConfig, either native of through a plugin.

This content of the file is based on the current code base, the file `.kateconfig` and on general requirements (YAML needs spaces, make need tabs).