### PR TITLE
Add a default for openvpnpath

### DIFF
--- a/registry.c
+++ b/registry.c
@@ -93,45 +93,47 @@ GetGlobalRegistryKeys()
       != ERROR_SUCCESS)
     {
       /* registry key not found */
+      regkey = NULL;
       ShowLocalizedMsg(IDS_ERR_OPEN_REGISTRY);
-      return(false);
     }
-  if (!GetRegistryValue(regkey, _T(""), openvpn_path, _countof(openvpn_path)))
+  if (!regkey || !GetRegistryValue(regkey, _T(""), openvpn_path, _countof(openvpn_path)))
     {
       /* error reading registry value */
-      ShowLocalizedMsg(IDS_ERR_READING_REGISTRY);
-      RegCloseKey(regkey);
-      return(false);
+      if (regkey)
+          ShowLocalizedMsg(IDS_ERR_READING_REGISTRY);
+      /* Use a sane default value */
+      _sntprintf_0(openvpn_path, _T("%s"), _T("C:\\Program Files\\OpenVPN\\"));
     }
   if (openvpn_path[_tcslen(openvpn_path) - 1] != _T('\\'))
     _tcscat(openvpn_path, _T("\\"));
 
   /* an admin-defined global config dir defined in HKLM\OpenVPN\config_dir */
-  if (!GetRegistryValue(regkey, _T("config_dir"), o.global_config_dir, _countof(o.global_config_dir)))
+  if (!regkey || !GetRegistryValue(regkey, _T("config_dir"), o.global_config_dir, _countof(o.global_config_dir)))
     {
       /* use default = openvpnpath\config */
       _sntprintf_0(o.global_config_dir, _T("%sconfig"), openvpn_path);
     }
 
-  if (!GetRegistryValue(regkey, _T("ovpn_admin_group"), o.ovpn_admin_group, _countof(o.ovpn_admin_group)))
+  if (!regkey || !GetRegistryValue(regkey, _T("ovpn_admin_group"), o.ovpn_admin_group, _countof(o.ovpn_admin_group)))
     {
       _tcsncpy(o.ovpn_admin_group, OVPN_ADMIN_GROUP, _countof(o.ovpn_admin_group)-1);
     }
 
-  if (!GetRegistryValue(regkey, _T("exe_path"), o.exe_path, _countof(o.exe_path)))
+  if (!regkey || !GetRegistryValue(regkey, _T("exe_path"), o.exe_path, _countof(o.exe_path)))
     {
       _sntprintf_0(o.exe_path, _T("%sbin\\openvpn.exe"), openvpn_path);
     }
 
-  if (!GetRegistryValue(regkey, _T("priority"), o.priority_string, _countof(o.priority_string)))
+  if (!regkey || !GetRegistryValue(regkey, _T("priority"), o.priority_string, _countof(o.priority_string)))
     {
       _tcsncpy(o.priority_string, _T("NORMAL_PRIORITY_CLASS"), _countof(o.priority_string)-1);
     }
-  if (!GetRegistryValueNumeric(regkey, _T("disable_save_passwords"), &o.disable_save_passwords))
+  if (!regkey || !GetRegistryValueNumeric(regkey, _T("disable_save_passwords"), &o.disable_save_passwords))
   {
       o.disable_save_passwords = 0;
   }
-  RegCloseKey(regkey);
+  if (regkey)
+      RegCloseKey(regkey);
   return true;
 }
 


### PR DESCRIPTION
Allow the GUI to run without any registry keys present:
the location of openvpn installation defaults to
C:\Program Files\OpenVPN if not found in registry.

Useful for testing builds or to display --help etc.

See also: PR #147

Signed-off-by: Selva Nair <selva.nair@gmail.com>