### PR TITLE
Activate urls in status log and open them on left button click

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -22,6 +22,8 @@
 #ifndef MISC_H
 #define MISC_H
 
+#include <richedit.h>
+
 BOOL ManagementCommandFromInput(connection_t *, LPCSTR, HWND, int);
 BOOL ManagementCommandFromInputBase64(connection_t *, LPCSTR, HWND, int, int);
 
@@ -40,4 +42,6 @@ BOOL Base64Encode(const char *input, int input_len, char **output);
 int Base64Decode(const char *input, char **output);
 WCHAR *Widen(const char *utf8);
 BOOL validate_input(const WCHAR *input, const WCHAR *exclude);
+WCHAR *get_link_text(HWND hwnd, CHARRANGE chrg);
+BOOL open_url(const WCHAR *url);
 #endif


### PR DESCRIPTION
To test use a client config with no server cert verification to get a log
message with an embedded URL (see screenshot below).
 
- Only http/https urls are opened and shell open method
  is used. This should launch the user's default browser.

- Single click opens the url on left mouse button up event.

Currently few log messages contain urls. Hopefully this feature
will encourage more embedded urls in logs.

Signed-off-by: Selva Nair <selva.nair@gmail.com>

![capture](https://user-images.githubusercontent.com/3981391/33808518-dd568b3c-ddb5-11e7-968f-d4a1b72b8eee.PNG)
