### PR TITLE
better alignment of warning message

### DIFF
--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -50,7 +50,7 @@ BEGIN
     CHECKBOX "Uložit heslo", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Zrušit", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -50,7 +50,7 @@ BEGIN
     CHECKBOX "Passwort speichern", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "Ok", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Abbrechen", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -51,7 +51,7 @@ BEGIN
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Annuller", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -50,7 +50,7 @@ BEGIN
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Cancel", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -49,7 +49,7 @@ BEGIN
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Cancelar", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -50,7 +50,7 @@ BEGIN
     CHECKBOX "Tallenna salasana", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Peruuta", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -49,7 +49,7 @@ BEGIN
     CHECKBOX "Se souvenir du mot de passe", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Annuler", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -49,7 +49,7 @@ BEGIN
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Annulla", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -52,7 +52,7 @@ BEGIN
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "キャンセル", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -51,7 +51,7 @@ BEGIN
     CHECKBOX "암호 저장", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "확인", IDOK, 25, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "취소", IDCANCEL, 85, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -49,7 +49,7 @@ BEGIN
     CHECKBOX "Wachtwoord opslaan", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Annuleren", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -50,7 +50,7 @@ BEGIN
     CHECKBOX "Husk passord", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Avbryt", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -51,7 +51,7 @@ BEGIN
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Anuluj", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -49,7 +49,7 @@ BEGIN
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Cancelar", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -51,7 +51,7 @@ BEGIN
     CHECKBOX "Запомнить", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 30, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Отмена", IDCANCEL, 100, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 180, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 180, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -49,7 +49,7 @@ BEGIN
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Avbryt", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -51,7 +51,7 @@ BEGIN
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "Tamam", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Çıkış", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -49,7 +49,7 @@ BEGIN
     CHECKBOX "Запам'ятати", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 30, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Скасувати", IDCANCEL, 100, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 180, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 180, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -52,7 +52,7 @@ BEGIN
     CHECKBOX "儲存密碼", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "確認", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "取消", IDCANCEL, 90, 58, 52, 14
-    LTEXT "", ID_TXT_WARNING, 6, 74, 150, 10
+    LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
 END
 
 /* Auth Username/Password/Challenge Dialog */


### PR DESCRIPTION
@selvanair , was "74" specified in purpose ?

if not, "80" seem to be better

74:

![screenshot from 2018-01-06 23-14-40](https://user-images.githubusercontent.com/2217296/34642925-2d8cb22e-f33d-11e7-9de9-e0b903139a8c.png)

80:

![screenshot from 2018-01-06 23-18-07](https://user-images.githubusercontent.com/2217296/34642928-34be629a-f33d-11e7-89a6-cfe6f949f847.png)
