### PR TITLE
Set a fall back for editor if file association fails

### DIFF
--- a/registry.c
+++ b/registry.c
@@ -74,19 +74,18 @@ GetGlobalRegistryKeys()
 {
   TCHAR windows_dir[MAX_PATH];
   TCHAR openvpn_path[MAX_PATH];
-  TCHAR profile_dir[MAX_PATH];
   HKEY regkey;
 
   if (!GetWindowsDirectory(windows_dir, _countof(windows_dir))) {
     /* can't get windows dir */
     ShowLocalizedMsg(IDS_ERR_GET_WINDOWS_DIR);
-    return(false);
+    /* Use a default value */
+    _sntprintf_0(windows_dir, L"C:\\Windows");
   }
 
-  if (SHGetFolderPath(NULL, CSIDL_PROFILE, NULL, SHGFP_TYPE_CURRENT, profile_dir) != S_OK) {
-    ShowLocalizedMsg(IDS_ERR_GET_PROFILE_DIR);
-    return(false);
-  }
+  /* set default editor and log_viewer as a fallback for opening config/log files */
+  _sntprintf_0(o.editor, L"%s\\%s", windows_dir, L"System32\\notepad.exe");
+  _sntprintf_0(o.log_viewer, L"%s", o.editor);
 
   /* Get path to OpenVPN installation. */
   if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\OpenVPN"), 0, KEY_READ, &regkey)


### PR DESCRIPTION
- When registry keys were simplified, the log viewer and editor
  entries were removed in favour of file associations that the
  user can independently control.

  Yet, there are times when an associated application fails to start
  or no associations are present etc., and its useful to have a fall
  back editor setting to open .ovpn and .log files.
  This patch sets that default as "notepad.exe"

- Also remove the unused profile_dir[] in registry.c

Signed-off-by: Selva Nair <selva.nair@gmail.com>