### PR TITLE
Save username only if/when saving auth password

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -511,6 +511,7 @@ UserAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             else
             {
                 DeleteSavedAuthPass(param->c->config_name);
+                DeleteSavedUsername(param->c->config_name);
                 Button_SetCheck(GetDlgItem (hwndDlg, ID_CHK_SAVE_PASS), BST_UNCHECKED);
             }
             AutoCloseCancel(hwndDlg); /* user interrupt */
@@ -524,7 +525,6 @@ UserAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
                     show_error_tip(GetDlgItem(hwndDlg, ID_EDT_AUTH_USER), LoadLocalizedString(IDS_ERR_INVALID_USERNAME_INPUT));
                     return 0;
                 }
-                SaveUsername(param->c->config_name, username);
             }
             if (GetDlgItemTextW(hwndDlg, ID_EDT_AUTH_PASS, password, _countof(password)))
             {
@@ -536,6 +536,7 @@ UserAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
                 }
                 if ( param->c->flags & FLAG_SAVE_AUTH_PASS && wcslen(password) )
                 {
+                    SaveUsername(param->c->config_name, username);
                     SaveAuthPass(param->c->config_name, password);
                 }
                 SecureZeroMemory(password, sizeof(password));

--- a/save_pass.h
+++ b/save_pass.h
@@ -14,6 +14,7 @@ int RecallKeyPass(const WCHAR *config_name, WCHAR *password);
 int RecallAuthPass(const WCHAR *config_name, WCHAR *password);
 int RecallUsername(const WCHAR *config_name, WCHAR *username);
 
+void DeleteSavedUsername(const WCHAR *config_name);
 void DeleteSavedAuthPass(const WCHAR *config_name);
 void DeleteSavedKeyPass(const WCHAR *config_name);
 void DeleteSavedPasswords(const WCHAR *config_name);


### PR DESCRIPTION
There has been a few requests to do this:
Eg., Trac #866 https://community.openvpn.net/openvpn/ticket/866
Note that this ties saving username to saving password -- there is no option to save one and not the other. Also if disable_save_passwords is active, the username is also not saved.

Commit message:

- Currently username is always saved. This changes that to save
  username only when auth password is saved.
- Usernames saved by previous versions are automatically migrated
  if password is also saved, else cleared, to enforce the new behaviour.
- Username and password are saved as encrypted by DPAPI.

Note: Setups in which saving of password is not enabled, any previously
saved username will be forgotten. However, the migration or clearing of
username is attempted only when a connection is started. So previously
saved usernames may stay in the store if a config is unused.

Signed-off-by: Selva Nair <selva.nair@gmail.com>