### PR TITLE
Do not allow "echo save-passwords" to override disable_save_passwords

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -956,7 +956,11 @@ OnEcho(connection_t *c, char *msg)
     }
     else if (strcmp(msg, "save-passwords") == 0)
     {
-        c->flags |= (FLAG_SAVE_KEY_PASS | FLAG_SAVE_AUTH_PASS);
+        if (c->flags & FLAG_DISABLE_SAVE_PASS)
+            WriteStatusLog(c, L"GUI> echo save-passwords: ",
+               L"Ignored as disable_save_passwords is enabled.", false);
+        else
+            c->flags |= (FLAG_SAVE_KEY_PASS | FLAG_SAVE_AUTH_PASS);
     }
     else
     {


### PR DESCRIPTION
- As disable_save_passwords may be enforced system-wide by an Administrator,
  "echo save-passwords" should not be allowed to over-ride it. This was
  overlooked in commit d4090a8842990ba992d843c49eaec1760ac03b0e.
  Fix it by ignoring this echo directive if disable_save_passwords is in
  effect. Also write a log message to the status window.

Signed-off-by: Selva Nair <selva.nair@gmail.com>