### PR TITLE
Do not clear saved passwords on verification failure

### DIFF
--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -469,7 +469,7 @@ BEGIN
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Token Password"
     IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
 
-    IDS_NFO_AUTH_PASS_RETRY "Wrong username or password. Try again..."
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again..."
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again..."
     IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"


### PR DESCRIPTION
After a failure the auth-pass dialog is shown with the password
field prefilled but highlighted. This allows the user to easily
overwrite the password or resubmit the old password if the
failure was temporary.

After a private key passphrase failure, the dialog is not
prefilled with saved password as this failure happens locally
and in such cases the password is very likely wrong.

If the user aborts the dialog by pressing cancel, the saved
password will get used during the next connection attempt.

Wrong username or password warning text is changed to: "Wrong
credentials".

Signed-off-by: Selva Nair <selva.nair@gmail.com>

See also issues: #227 #217