### PR TITLE
Fix detection of an already running instance

### DIFF
--- a/main.c
+++ b/main.c
@@ -151,7 +151,7 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
 
   /* try to lock the semaphore, else we are not the first instance */
   if (session_semaphore &&
-      WaitForSingleObject(session_semaphore, 0) != WAIT_OBJECT_0)
+      WaitForSingleObject(session_semaphore, 200) != WAIT_OBJECT_0)
   {
       first_instance = FALSE;
   }
@@ -175,6 +175,8 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
 
   /* initialize options to default state */
   InitOptions(&o);
+  if (first_instance)
+      o.session_semaphore = session_semaphore;
 
 #ifdef DEBUG
   /* Open debug file for output */
@@ -307,6 +309,9 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
     TranslateMessage(&messages);
     DispatchMessage(&messages);
   }
+
+  CloseSemaphore(o.session_semaphore);
+  o.session_semaphore = NULL;   /* though we're going to die.. */
 
   /* The program return-value is 0 - The value that PostQuitMessage() gave */
   return messages.wParam;

--- a/main.h
+++ b/main.h
@@ -131,5 +131,6 @@ void PrintDebugMsg(TCHAR *msg);
 DWORD GetDllVersion(LPCTSTR lpszDllName);
 
 #define DPI_SCALE(x) MulDiv(x, o.dpi_scale, 100)
+void MsgToEventLog(WORD type, wchar_t *format, ...);
 
 #endif

--- a/misc.c
+++ b/misc.c
@@ -410,6 +410,16 @@ InitSemaphore (WCHAR *name)
     return semaphore;
 }
 
+void
+CloseSemaphore(HANDLE sem)
+{
+    if (sem)
+    {
+        ReleaseSemaphore(sem, 1, NULL);
+    }
+    CloseHandle(sem);
+}
+
 /* Check access rights on an existing file */
 BOOL
 CheckFileAccess (const TCHAR *path, int access)

--- a/misc.h
+++ b/misc.h
@@ -42,4 +42,6 @@ WCHAR *Widen(const char *utf8);
 BOOL validate_input(const WCHAR *input, const WCHAR *exclude);
 /* Concatenate two wide strings with a separator */
 void wcs_concat2(WCHAR *dest, int len, const WCHAR *src1, const WCHAR *src2, const WCHAR *sep);
+void CloseSemaphore(HANDLE sem);
+
 #endif

--- a/options.c
+++ b/options.c
@@ -85,6 +85,10 @@ add_option(options_t *options, int i, TCHAR **p)
     {
         TCHAR caption[200];
         TCHAR msg[USAGE_BUF_SIZE];
+        /* We only print help and exit: release the semapahore to allow another instance */
+        CloseSemaphore(o.session_semaphore); /* OK to call even if semaphore is NULL */
+        o.session_semaphore = NULL;
+
         LoadLocalizedStringBuf(caption, _countof(caption), IDS_NFO_USAGECAPTION);
         LoadLocalizedStringBuf(msg, _countof(msg), IDS_NFO_USAGE);
         MessageBoxEx(NULL, msg, caption, MB_OK | MB_SETFOREGROUND, GetGUILanguage());

--- a/options.h
+++ b/options.h
@@ -186,6 +186,7 @@ typedef struct {
     int action;            /* action to send to a running instance */
     TCHAR *action_arg;
     HANDLE session_semaphore;
+    HANDLE event_log;
 } options_t;
 
 void InitOptions(options_t *);

--- a/options.h
+++ b/options.h
@@ -185,6 +185,7 @@ typedef struct {
     COLORREF clr_error;
     int action;            /* action to send to a running instance */
     TCHAR *action_arg;
+    HANDLE session_semaphore;
 } options_t;
 
 void InitOptions(options_t *);


### PR DESCRIPTION
When openvpn is run with --help option it pops up a help
message and exits when that window is closed. Such instances
cannot accept any commands and should not be treated as a
running instance.

Fixes issue: #237

Additionally log errors to the event log when sending a command to a 
running instance fails. This supplements the non-zero exit-code
set in such cases.