### PR TITLE
Implement a nested menu for configs in subdirectories

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,12 +49,6 @@ AC_ARG_ENABLE(
 	[enable_password_change="yes"]
 )
 
-AC_ARG_VAR([MAX_CONFIGS], [specify the maximum number of configs @<:@default=50@:>@])
-if test -z "$MAX_CONFIGS"; then
-	MAX_CONFIGS=50
-fi
-AC_DEFINE_UNQUOTED([MAX_CONFIGS], [$MAX_CONFIGS], [Maximum number of config files supported.])
-
 case "$host" in
 	*-mingw*)
 		CPPFLAGS="${CPPFLAGS} -DWIN32_LEAN_AND_MEAN"

--- a/main.c
+++ b/main.c
@@ -879,3 +879,20 @@ MsgToEventLog(WORD type, wchar_t *format, ...)
     msg[1] = buf;
     ReportEventW(o.event_log, type, 0, 0, NULL, 2, 0, msg, NULL);
 }
+
+void
+ErrorExit(int exit_code, const wchar_t *msg)
+{
+    if (msg)
+        MessageBoxExW(NULL, msg, TEXT(PACKAGE_NAME),
+                      MB_OK | MB_SETFOREGROUND|MB_ICONERROR, GetGUILanguage());
+    if (o.hWnd)
+    {
+        StopAllOpenVPN();
+        PostQuitMessage(exit_code);
+    }
+    else
+    {
+        exit(exit_code);
+    }
+}

--- a/main.c
+++ b/main.c
@@ -80,7 +80,7 @@ VerifyAutoConnections()
 {
     int i;
 
-    for (i = 0; i < MAX_CONFIGS && o.auto_connect[i] != 0; i++)
+    for (i = 0; i < o.num_auto_connect; i++)
     {
         if (GetConnByName(o.auto_connect[i]) == NULL)
         {

--- a/main.h
+++ b/main.h
@@ -133,4 +133,6 @@ DWORD GetDllVersion(LPCTSTR lpszDllName);
 #define DPI_SCALE(x) MulDiv(x, o.dpi_scale, 100)
 void MsgToEventLog(WORD type, wchar_t *format, ...);
 
+void ErrorExit(int exit_code, const wchar_t *msg);
+
 #endif

--- a/options.c
+++ b/options.c
@@ -97,18 +97,22 @@ add_option(options_t *options, int i, TCHAR **p)
     else if (streq(p[0], _T("connect")) && p[1])
     {
         ++i;
-        static int auto_connect_nr = 0;
-        if (auto_connect_nr == MAX_CONFIGS)
+        if (!options->auto_connect || options->num_auto_connect == options->max_auto_connect)
         {
-            /* Too many configs */
-            ShowLocalizedMsg(IDS_ERR_MANY_CONFIGS, MAX_CONFIGS);
-            exit(1);
+            options->max_auto_connect += 10;
+            void *tmp = realloc(options->auto_connect, sizeof(wchar_t *)*options->max_auto_connect);
+            if (!tmp)
+            {
+                options->max_auto_connect -= 10;
+                ErrorExit(1, L"Out of memory while parsing command line");
+            }
+            options->auto_connect = tmp;
         }
-        options->auto_connect[auto_connect_nr++] = p[1];
+        options->auto_connect[options->num_auto_connect++] = p[1];
         /* Treat the first connect option to also mean --command connect profile.
          * This gets used if we are not the first instance.
          */
-        if (auto_connect_nr == 1)
+        if (options->num_auto_connect == 1)
         {
             options->action = WM_OVPN_START;
             options->action_arg = p[1];

--- a/options.c
+++ b/options.c
@@ -215,6 +215,11 @@ add_option(options_t *options, int i, TCHAR **p)
         ++i;
         options->preconnectscript_timeout = _ttoi(p[1]);
     }
+    else if (streq(p[0], _T("config_menu_view")) && p[1])
+    {
+        ++i;
+        options->config_menu_view = _ttoi(p[1]);
+    }
     else if (streq(p[0], _T("command")) && p[1])
     {
         ++i;

--- a/options.h
+++ b/options.h
@@ -103,14 +103,18 @@ typedef struct {
  * which is enough for our purposes.
  */
 typedef struct config_group {
-    int id;                      /* A unique id for the group */
+    int id;                      /* A unique id for the group >= 0*/
     wchar_t name[40];            /* Name of the group -- possibly truncated */
-    struct config_group *parent; /* Pointer to parent group */
+    int parent;                  /* Id of parent group. -1 implies no parent */
     BOOL active;                 /* Displayed in the menu if true -- used to prune empty groups */
     int children;                /* Number of children groups and configs */
     int pos;                     /* Index within the parent group -- used for rendering */
     HMENU menu;                  /* Handle to menu entry for this group */
 } config_group_t;
+
+/* short hand for pointer to the group a config belongs to */
+#define CONFIG_GROUP(c) (&o.groups[(c)->group])
+#define PARENT_GROUP(cg) ((cg)->parent < 0 ? NULL : &o.groups[(cg)->parent])
 
 /* Connections parameters */
 struct connection {
@@ -126,7 +130,7 @@ struct connection {
     int failed_auth_attempts;       /* # of failed user-auth attempts */
     time_t connected_since;         /* Time when the connection was established */
     proxy_t proxy_type;             /* Set during querying proxy credentials */
-    config_group_t *group;          /* Pointer to the group this config belongs to */
+    int group;                      /* ID of the group this config belongs to */
     int pos;                        /* Index of the config within its group */
 
     struct {

--- a/options.h
+++ b/options.h
@@ -40,8 +40,7 @@ typedef struct connection connection_t;
  * Maximum number of parameters associated with an option,
  * including the option name itself.
  */
-#define MAX_PARMS           5   /* May number of parameters per option */
-#define MAX_CONFIG_SUBDIRS  50  /* Max number of subdirs to scan for configs */
+#define MAX_PARMS           5   /* Max number of parameters per option */
 
 
 typedef enum {

--- a/options.h
+++ b/options.h
@@ -41,7 +41,8 @@ typedef struct connection connection_t;
  * including the option name itself.
  */
 #define MAX_PARMS           5   /* Max number of parameters per option */
-
+/* Menu ids are constructed as 12 bits for config number, 4 bits for action */
+#define MAX_CONFIGS         (1<<12)
 
 typedef enum {
     service_noaccess     = -1,
@@ -155,13 +156,16 @@ struct connection {
 /* All options used within OpenVPN GUI */
 typedef struct {
     /* Array of configs to autostart */
-    const TCHAR *auto_connect[MAX_CONFIGS];
+    const TCHAR **auto_connect;
 
     /* Connection parameters */
-    connection_t conn[MAX_CONFIGS];   /* Connection structure */
+    connection_t *conn;               /* Array of connection structure */
     config_group_t *groups;           /* Array of nodes defining the config groups tree */
     int num_configs;                  /* Number of configs */
+    int num_auto_connect;             /* Number of auto-connect configs */
     int num_groups;                   /* Number of config groups */
+    int max_configs;                  /* Current capacity of conn array */
+    int max_auto_connect;             /* Current capacity of auto_connect array */
     int max_groups;                   /* Current capacity of groups array */
 
     service_state_t service_state;    /* State of the OpenVPN Service */

--- a/registry.c
+++ b/registry.c
@@ -60,7 +60,8 @@ struct regkey_int {
       {L"connectscript_timeout", &o.connectscript_timeout, 30},
       {L"disconnectscript_timeout", &o.disconnectscript_timeout, 10},
       {L"show_script_window", &o.show_script_window, 0},
-      {L"service_only", &o.service_only, 0}
+      {L"service_only", &o.service_only, 0},
+      {L"config_menu_view", &o.config_menu_view, CONFIG_VIEW_AUTO}
     };
 
 static int

--- a/tray.h
+++ b/tray.h
@@ -48,6 +48,7 @@ void OnDestroyTray(void);
 void ShowTrayIcon();
 void SetTrayIcon(conn_state_t);
 void SetMenuStatus(connection_t *, conn_state_t);
+void SetMenuStatusById(int, conn_state_t);
 void SetServiceMenuStatus();
 void ShowTrayBalloon(TCHAR *, TCHAR *);
 void CheckAndSetTrayIcon();


### PR DESCRIPTION
By default, enabled only when number of configs > 50 but can be forced using `--config_menu_view 2` on command line. TODO: make this configurable from the settings menu
 
As an example the following directory structure 

CUSTOMERS/agony/dreamcity/dreamcity.ovpn
CUSTOMERS/agony/boonies/boonies.ovpn
CUSTOMERS/woeful/woeful-gw/woeful-gw.ovpn
PROVIDERS/dont-trust/washington/washington.ovpn
PROVIDERS/dont-trust/london/london.ovpn
PROVIDERS/broken-cipher/bypass-netflix/bypass-netflix.ovpn
WORK/scinet/scinet.ovpn
sample.ovpn
broken/broken.ovpn

Displays as

CUSTOMERS> agony>  dreamcity> connect,disconnect
                                       boonies>   connect...
                         woeful> woeful-gw> connect...
PROVIDERS> dont-trust>    washington>     connect...
                                            london>         connect...
                       broken-cipher> bypass-netflix> connect...
WORK> scinet> connect...
sample> connect...
broken> connect...

(for so few configs, need to enable the nested view using `config_menu_view 2`

I prefer to keep each config in its own directory with the same name (the GUI's import command does the same too). To reduce nesting in such cases the display squashes single config directories one level up.
