### PR TITLE
Ignore pushed --route-method when interactive service is in use

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -1931,8 +1931,13 @@ StartOpenVPN(connection_t *c)
 
         c->hProcess = NULL;
         c->manage.password[sizeof(c->manage.password) - 1] = '\n';
-        _sntprintf_0(startup_info, _T("%s%c%s%c%.*S"), c->config_dir, _T('\0'),
-            options, _T('\0'), sizeof(c->manage.password), c->manage.password);
+
+        /* Ignore pushed route-method when service is in use */
+        const wchar_t *extra_options = L" --pull-filter ignore route-method";
+        size += wcslen(extra_options);
+
+        _sntprintf_0(startup_info, L"%s%c%s%s%c%.*S", c->config_dir, L'\0',
+            options, extra_options, L'\0', sizeof(c->manage.password), c->manage.password);
         c->manage.password[sizeof(c->manage.password) - 1] = '\0';
 
         if (!WritePipe(c->iserv.pipe, startup_info, size * sizeof (TCHAR)))


### PR DESCRIPTION
When using interactive service, route addition should use the
service. The user may not have privileges to set routes
otherwise.  We already override any --route-method set in the
config file as openvpn.exe is started with --msg-channel as the
last option which sets route-method to ROUTE_METHOD_SERVICE.

This patch extends that to pushed --route-method

Also change _T("") to L"" in the edited lines to be explicit about
wide and narrow strings. We no longer support non-unicode builds.

No change when interactive service is not used.

Ref: issue #281

Signed-off-by: Selva Nair <selva.nair@gmail.com>