### PR TITLE
Optionally allow overwrite when importing a config

### DIFF
--- a/main.c
+++ b/main.c
@@ -761,6 +761,14 @@ ImportConfigFile()
         TCHAR destination[MAX_PATH];
         PTCHAR fileName = source + fn.nFileOffset;
 
+        /* check if the source points to the config_dir */
+        if (wcsncmp(source, o.global_config_dir, wcslen(o.global_config_dir)) == 0
+            || wcsncmp(source, o.config_dir, wcslen(o.config_dir)) == 0)
+        {
+            ShowLocalizedMsg(IDS_ERR_IMPORT_SOURCE, source);
+            return;
+        }
+
         _sntprintf_0(destination, _T("%s\\%s"), o.config_dir, fileName);
 
         destination[_tcslen(destination) - _tcslen(o.ext_string) - 1] = _T('\0');
@@ -769,28 +777,30 @@ ImportConfigFile()
         {
 
             _sntprintf_0(destination, _T("%s\\%s"), destination, fileName);
-            
-            if (!CopyFile(source, destination, TRUE))
+
+            bool  no_overwrite = TRUE;
+            while(!CopyFile(source, destination, no_overwrite))
             {
-                if (GetLastError() == ERROR_FILE_EXISTS)
+                if (GetLastError() != ERROR_FILE_EXISTS || !no_overwrite)
                 {
-                    fileName[_tcslen(fileName) - _tcslen(o.ext_string) - 1] = _T('\0');
-                    ShowLocalizedMsg(IDS_ERR_IMPORT_EXISTS, fileName);
+                    MsgToEventLog(EVENTLOG_ERROR_TYPE, L"Copy file <%s> to <%s> failed (error = %lu)",
+                                  source, destination, GetLastError());
+                    ShowLocalizedMsg(IDS_ERR_IMPORT_FAILED, destination);
                     return;
                 }
-            }
-            else
-            {
-                ShowLocalizedMsg(IDS_NFO_IMPORT_SUCCESS);
-                return;
-            }
 
+                /* A file with same name exists. Ask the user whether to replace or not. */
+                if (ShowLocalizedMsgEx(MB_YESNO, _T(PACKAGE_NAME), IDS_NFO_IMPORT_OVERWRITE, fileName) == IDNO)
+                    return;
+
+                /* try again with overwrite allowed */
+                no_overwrite = FALSE;
+            }
+            ShowLocalizedMsg(IDS_NFO_IMPORT_SUCCESS);
+            return;
         }
-
         ShowLocalizedMsg(IDS_ERR_IMPORT_FAILED, destination);
-
     }
-    
 }
 
 #ifdef DEBUG

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -304,6 +304,8 @@
 #define IDS_ERR_IMPORT_EXISTS           1901
 #define IDS_ERR_IMPORT_FAILED           1902
 #define IDS_NFO_IMPORT_SUCCESS          1903
+#define IDS_NFO_IMPORT_OVERWRITE        1904
+#define IDS_ERR_IMPORT_SOURCE           1905
 
 /* Save password related messages */
 #define IDS_NFO_DELETE_PASS             2001

--- a/res/openvpn-gui-res-en-msvc.rc
+++ b/res/openvpn-gui-res-en-msvc.rc
@@ -392,6 +392,8 @@ BEGIN
     IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n%s\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -459,6 +459,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n" \
                           "%s\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""


### PR DESCRIPTION
- Prompt the user for permission if import may overwrite
  an existing config.

- Also raise an error if the import file source matches the
  global or local config directory. Reimporting a config on to
  itself is not supported. This also  avoids ERROR_SHARING_VIOLATION
  in CopyFile() when source and destination are the same.

Signed-off-by: Selva Nair <selva.nair@gmail.com>