### PR TITLE
Fallback to default sublanguage when loading resources

### DIFF
--- a/localization.c
+++ b/localization.c
@@ -53,6 +53,12 @@ FindResourceLang(PTSTR resType, PTSTR resId, LANGID langId)
     if (res)
         return res;
 
+    /* try to find the resource in the default sublanguage */
+    LANGID defLangId = MAKELANGID(PRIMARYLANGID(langId), SUBLANG_DEFAULT);
+    res = FindResourceEx(o.hInstance, resType, resId, defLangId);
+    if (res)
+        return res;
+
     /* try to find the resource in the default language */
     res = FindResourceEx(o.hInstance, resType, resId, fallbackLangId);
     if (res)


### PR DESCRIPTION
When a resource is not found in user's preferred language, first
try the primary language with SUBLANG set to default before
falling back to English.

See issue #216

Signed-off-by: Selva Nair <selva.nair@gmail.com>