### PR TITLE
Promptly close pipe handles passed to child

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -499,3 +499,13 @@ wcs_concat2(WCHAR *dest, int len, const WCHAR *src1, const WCHAR *src2, const WC
         n = 0;
     dest[n] = L'\0';
 }
+
+void
+CloseHandleEx(LPHANDLE handle)
+{
+    if (handle && *handle && *handle != INVALID_HANDLE_VALUE)
+    {
+        CloseHandle(*handle);
+        *handle = INVALID_HANDLE_VALUE;
+    }
+}

--- a/misc.h
+++ b/misc.h
@@ -44,5 +44,7 @@ BOOL validate_input(const WCHAR *input, const WCHAR *exclude);
 /* Concatenate two wide strings with a separator */
 void wcs_concat2(WCHAR *dest, int len, const WCHAR *src1, const WCHAR *src2, const WCHAR *sep);
 void CloseSemaphore(HANDLE sem);
+/* Close a handle if not null or invalid */
+void CloseHandleEx(LPHANDLE h);
 
 #endif


### PR DESCRIPTION
Parent keeping the handle to write end of child's stdout will
cause ERROR_BROKEN_PIPE not signalled if/when the child exits.

Also add a wrapper for CloseHandle()

Fixes the GUI process hanging in read from child
if the latter unexpectedly dies due to some error.
Trac #1203

Signed-off-by: Selva Nair <selva.nair@gmail.com>