### PR TITLE
res/openvpn-gui-res-fi.rc: add missing IDS_MENU_RECONNECT translation

### DIFF
--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -247,6 +247,7 @@ BEGIN
     IDS_MENU_CLOSE "Poistu"
     IDS_MENU_CONNECT "Yhdistä"
     IDS_MENU_DISCONNECT "Katkaise yhteys"
+    IDS_MENU_RECONNECT "Yhdistä uudelleen"
     IDS_MENU_STATUS "Näytä tila"
     IDS_MENU_VIEWLOG "Näytä loki"
     IDS_MENU_EDITCONFIG "Muokkaa asetuksia"


### PR DESCRIPTION
Signed-off-by: Lev Stipakov <lev@openvpn.net>