### PR TITLE
Do not add CRLF to base64 encoded output

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -44,6 +44,7 @@ BOOL
 Base64Encode(const char *input, int input_len, char **output)
 {
     DWORD output_len;
+    DWORD flags = CRYPT_STRING_BASE64|CRYPT_STRING_NOCRLF;
 
     if (input_len == 0)
     {
@@ -52,7 +53,7 @@ Base64Encode(const char *input, int input_len, char **output)
         return TRUE;
     }
     if (!CryptBinaryToStringA((const BYTE *) input, (DWORD) input_len,
-        CRYPT_STRING_BASE64, NULL, &output_len) || output_len == 0)
+        flags, NULL, &output_len) || output_len == 0)
     {
 #ifdef DEBUG
         PrintDebug (L"Error in CryptBinaryToStringA: input = '%.*S'", input_len, input);
@@ -65,7 +66,7 @@ Base64Encode(const char *input, int input_len, char **output)
         return FALSE;
 
     if (!CryptBinaryToStringA((const BYTE *) input, (DWORD) input_len,
-        CRYPT_STRING_BASE64, *output, &output_len))
+        flags, *output, &output_len))
     {
 #ifdef DEBUG
         PrintDebug (L"Error in CryptBinaryToStringA: input = '%.*S'", input_len, input);
@@ -74,12 +75,6 @@ Base64Encode(const char *input, int input_len, char **output)
         *output = NULL;
         return FALSE;
     }
-    /* Trim trailing "\r\n" manually.
-       Actually they can be stripped by adding CRYPT_STRING_NOCRLF to dwFlags,
-       but Windows XP/2003 does not support this flag. */
-    if(output_len > 1 && (*output)[output_len - 1] == '\x0A'
-        && (*output)[output_len - 2] == '\x0D')
-        (*output)[output_len - 2] = 0;
 
     return TRUE;
 }


### PR DESCRIPTION
By default CryptBinaryToString used for base64 encoding
adds CRLF every 76 characters or so. As LF is used as
the message delimiter by the management interface, this breaks
handling of static challenge.

Fix by setting CRYPT_STRING_NOCRLF in the flags. With this
change, the trailing '\r\n' removal is no longer required.

Fixes Issue 317: https://github.com/OpenVPN/openvpn-gui/issues/317

Signed-off-by: Selva Nair <selva.nair@gmail.com>