### PR TITLE
Add '--command rescan' to rescan config folders

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,9 @@ silent\_connection 0 \| 1
 exit
      Disconnect all active connections and terminate the GUI process
 
+rescan
+     Rescan the config folders for changes
+
 If no running instance of the GUI is found, these commands do nothing
 except for *--command connect config-name* which gets interpreted
 as *--connect config-name*

--- a/main.c
+++ b/main.c
@@ -481,6 +481,10 @@ HandleCopyDataMessage(const COPYDATASTRUCT *copy_data)
     {
         ShowTrayBalloon(L"", copy_data->lpData);
     }
+    else if (copy_data->dwData == WM_OVPN_RESCAN)
+    {
+        OnNotifyTray(WM_OVPN_RESCAN);
+    }
     else
     {
         MsgToEventLog(EVENTLOG_ERROR_TYPE,

--- a/main.h
+++ b/main.h
@@ -59,6 +59,7 @@
 #define WM_OVPN_EXIT           (WM_APP + 17)
 #define WM_OVPN_SILENT         (WM_APP + 18)
 #define WM_OVPN_IMPORT         (WM_APP + 20)
+#define WM_OVPN_RESCAN         (WM_APP + 21)
 
 /* bool definitions */
 #define bool int

--- a/options.c
+++ b/options.c
@@ -268,6 +268,10 @@ add_option(options_t *options, int i, TCHAR **p)
         {
             options->action = WM_OVPN_EXIT;
         }
+        else if (streq(p[1], _T("rescan")))
+        {
+            options->action = WM_OVPN_RESCAN;
+        }
         else
         {
             ShowLocalizedMsg(IDS_ERR_BAD_OPTION, p[0]);

--- a/tray.c
+++ b/tray.c
@@ -208,6 +208,14 @@ DestroyPopupMenus()
     hMenu = NULL;
 }
 
+/* Rescan config folders and recreate popup menus */
+static void
+RecreatePopupMenus(void)
+{
+    DestroyPopupMenus();
+    BuildFileList();
+    CreatePopupMenus();
+}
 
 /*
  * Handle mouse clicks on tray icon
@@ -219,10 +227,7 @@ OnNotifyTray(LPARAM lParam)
 
     switch (lParam) {
     case WM_RBUTTONUP:
-        /* Recreate popup menus */
-        DestroyPopupMenus();
-        BuildFileList();
-        CreatePopupMenus();
+        RecreatePopupMenus();
 
         GetCursorPos(&pt);
         SetForegroundWindow(o.hWnd);
@@ -244,9 +249,7 @@ OnNotifyTray(LPARAM lParam)
         else {
             int disconnected_conns = CountConnState(disconnected);
 
-            DestroyPopupMenus();
-            BuildFileList();
-            CreatePopupMenus();
+            RecreatePopupMenus();
 
             /* Start connection if only one config exist */
             if (o.num_configs == 1 && o.conn[0].state == disconnected)
@@ -263,6 +266,11 @@ OnNotifyTray(LPARAM lParam)
                 }
             }
         }
+        break;
+
+    case WM_OVPN_RESCAN:
+        /* Rescan config folders and recreate popup menus */
+        RecreatePopupMenus();
         break;
     }
 }


### PR DESCRIPTION
Add an new command 'rescan' that may be sent to a running
instance of the GUI to force it rescan the config folders.

Use case: with an instance of the is GUI running, one can
manually copy a config file to the config folder and start
it using "openvpn-gui --command rescan" followed by
"openvpn-gui --command connect foo"

v2: The calls to rebuild config file list and recreate
menus is refactored into a function.

Signed-off-by: Selva Nair <selva.nair@gmail.com>

See also: #319 