### PR TITLE
Do not do escape processing on static-challenge password and response

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -220,43 +220,13 @@ ManagementCommandFromInputBase64(connection_t *c, LPCSTR fmt, HWND hDlg,int id, 
 {
     BOOL retval = FALSE;
     LPSTR input, input2, input_b64, input2_b64, cmd;
-    int input_len, input2_len, cmd_len, pos;
+    int input_len, input2_len, cmd_len;
 
     input_b64 = NULL;
     input2_b64 = NULL;
 
     GetDlgItemTextUtf8(hDlg, id, &input, &input_len);
     GetDlgItemTextUtf8(hDlg, id2, &input2, &input2_len);
-
-    /* Escape input if needed */
-    for (pos = 0; pos < input_len; ++pos)
-    {
-        if (input[pos] == '\\' || input[pos] == '"')
-        {
-            LPSTR buf = realloc(input, ++input_len + 1);
-            if (buf == NULL)
-                goto out;
-
-            input = buf;
-            memmove(input + pos + 1, input + pos, input_len - pos + 1);
-            input[pos] = '\\';
-            pos += 1;
-        }
-    }
-    for (pos = 0; pos < input2_len; ++pos)
-    {
-        if (input2[pos] == '\\' || input2[pos] == '"')
-        {
-            LPSTR buf = realloc(input2, ++input2_len + 1);
-            if (buf == NULL)
-                goto out;
-
-            input2 = buf;
-            memmove(input2 + pos + 1, input2 + pos, input2_len - pos + 1);
-            input2[pos] = '\\';
-            pos += 1;
-        }
-    }
 
     if (!Base64Encode(input, input_len, &input_b64))
         goto out;


### PR DESCRIPTION
Strings passed to the management interface should escape characters
such as " and \ that have special meaning for the parser.
But, static-challenge password and response are base64 encoded
before passing to the management interface and get literally
transported to the server in that form. Escape processing of
these strings could result in altering the password and/or response.

Reported by: macskas https://github.com/OpenVPN/openvpn-gui/issues/351

Signed-off-by: Selva Nair <selva.nair@gmail.com>