### PR TITLE
Copy missing resource strings to all language files

### DIFF
--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -248,6 +248,7 @@ BEGIN
     IDS_MENU_CLOSE "Ukončit"
     IDS_MENU_CONNECT "Připojit"
     IDS_MENU_DISCONNECT "Odpojit"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "Zobrazit stav"
     IDS_MENU_VIEWLOG "Otevřít log"
     IDS_MENU_EDITCONFIG "Upravit konfiguraci"
@@ -342,6 +343,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Zobrazí tuto zprávu.\n" \
                   "--connect cnn \t\t: Připojí se k ""cnn"" při spuštění. (musí být obsažena přípona souboru)\n" \
                   "\t\t\t   Příklad: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+                  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Volby k použití explicitního nastavení namísto výchozího z registru:\n" \
                   "--exe_path\t\t: Cesta k openvpn.exe.\n" \
@@ -448,6 +459,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Nepodařilo se importovat konfigurační soubor. Následující cestu se nepodařilo vytvořit.\n\n" \
                           "%s\n\nUjistěte se prosím, že máte potřebná oprávnění."
     IDS_NFO_IMPORT_SUCCESS "Konfigurace úspěšně importována."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Stiskněte OK pro odstranění uložených hesel pro konfiguraci ""%s"""
@@ -455,5 +468,13 @@ BEGIN
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Heslo tokenu"
     IDS_NFO_TOKEN_PASSWORD_REQUEST "Prosím zadejte heslo/PIN pro token '%S'"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
 
 END

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -461,6 +461,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Fehler beim Importieren der Konfigurationsdatei. Der folgende Pfad konnte nicht erstellt werden:\n\n" \
                           "%s\n\nVergewissern Sie sich, dass Sie die erforderlichen Berechtigungen besitzen."
     IDS_NFO_IMPORT_SUCCESS "Die Konfigurationsdatei wurde erfolgreich importiert."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Drücken Sie OK um die gespeicherten Passwörter für die Konfiguration ""%s"" zu löschen."

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -243,14 +243,17 @@ BEGIN
     IDS_TIP_CONNECTED_SINCE "\nForbundet siden: "
     IDS_TIP_ASSIGNED_IP "\nTildelt IP: %s"
     IDS_MENU_SERVICE "OpenVPN Service"
+    IDS_MENU_IMPORT "Import file…"
     IDS_MENU_SETTINGS "Indstillinger…"
     IDS_MENU_CLOSE "Afslut"
     IDS_MENU_CONNECT "Forbind"
     IDS_MENU_DISCONNECT "Afbryd"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "Vis status"
     IDS_MENU_VIEWLOG "Vis log"
     IDS_MENU_EDITCONFIG "Ret konfiguration"
     IDS_MENU_PASSPHRASE "Ændre kodeord"
+    IDS_MENU_CLEARPASS  "Clear Saved Passwords"
     IDS_MENU_SERVICE_START "Start"
     IDS_MENU_SERVICE_STOP "Stop"
     IDS_MENU_SERVICE_RESTART "Genstart"
@@ -265,6 +268,18 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "Du kan ikke have flere end %d konfigurations-filer. Kontakt udvikleren af OpenVPN GUI hvis du har behov for at håndtere flere."
+    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in "\
+                                  """%s"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Do you want to add yourself to this group?\n"\
+                                  "This action may prompt for administrative password or consent."
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Please complete the previous authorization dialog."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Du kan kun have en forbindelse igang samtidig med ældre versioner af OpenVPN end 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Du kan ikke tilslutte med OpenVPN GUI når OpenVPN Service kører. (kun OpenVPN 1.5/1.6). Stop tjenesten først hvis du vil bruge OpenVPN GUI."
     IDS_ERR_CREATE_EVENT "CreateEvent fejlede ved exit event: %s"
@@ -311,6 +326,7 @@ BEGIN
                          "ligger i forskellige kataloger."
     /* main - Resources */
     IDS_ERR_OPEN_DEBUG_FILE "Fejl under åbning af debug fil. (%s)"
+    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
     IDS_ERR_LOAD_RICHED20 "Kunne ikke indlæse RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Din shell32.dll version er for lav (0x%lx). Du skal have mindst version 5.0."
     IDS_NFO_SERVICE_STARTED "OpenVPN Service startet."
@@ -326,6 +342,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Vis denne meddelelse.\n" \
                   "--connect cnn \t\t: Forbinder til ""cnn"" ved start. (filtypen skal være med i filnavnet)\n" \
                   "\t\t\t   Eksempel: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+		  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Parametre som vil tilsidesætte indstillinger i registreringsdatabasen:\n" \
                   "--exe_path\t\t: Sti til openvpn.exe.\n" \
@@ -403,9 +429,16 @@ BEGIN
     IDS_ERR_OPEN_SCMGR "OpenSCManager fejlramt (%d)"
     IDS_ERR_STOP_SERVICE "En fejl opstod ved stop af OpenVPN Service"
     IDS_NFO_RESTARTED "OpenVPN Service genstartet."
+    IDS_ERR_ACCESS_SERVICE_PIPE "Access to service pipe failed."
+    IDS_ERR_WRITE_SERVICE_PIPE "Writing to service pipe failed."
+    IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is not installed.\n"
+                                 "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
+                                 "Tasks requiring administrative access may not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Kunne ikke finde mappen hvor Windows er installeret."
+    IDS_ERR_GET_PROFILE_DIR "Error getting User Profile Directory."
     IDS_ERR_GET_PROGRAM_DIR "Kunne ikke finde stien til dit ""Programmer"" mappe."
     IDS_ERR_OPEN_REGISTRY "Fejl under åbning af register til læsning (HKLM\\SOFTWARE\\OpenVPN).\n " \
                           "OpenVPN er måske ikke installeret."
@@ -419,4 +452,28 @@ BEGIN
                            "en gang som administrator for at opdatere registret."
     IDS_ERR_READ_SET_KEY "Fejl under læsning og skrivning af register-værdi ""%s""."
     IDS_ERR_WRITE_REGVALUE "Fejl under skrivning af register-værdi ""HKEY_CURRENT_USER\\%s\\%s""."
+
+    /* importation */
+    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n" \
+                          "%s\n\nMake sure you have the right permissions."
+    IDS_NFO_IMPORT_SUCCESS "File imported successfully."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+
+    /* save/delete password */
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+
+    /* Token password related */
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+
 END

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -241,14 +241,17 @@ BEGIN
     IDS_TIP_CONNECTED_SINCE "\nConectado desde: "
     IDS_TIP_ASSIGNED_IP "\nIP asignada: %s"
     IDS_MENU_SERVICE "Servicio OpenVPN"
+    IDS_MENU_IMPORT "Import file…"
     IDS_MENU_SETTINGS "Opciones…"
     IDS_MENU_CLOSE "Salir"
     IDS_MENU_CONNECT "Conectar"
     IDS_MENU_DISCONNECT "Desconectar"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "Mostrar estado"
     IDS_MENU_VIEWLOG "Ver Log"
     IDS_MENU_EDITCONFIG "Editar config"
     IDS_MENU_PASSPHRASE "Cambiar clave"
+    IDS_MENU_CLEARPASS  "Clear Saved Passwords"
     IDS_MENU_SERVICE_START "Iniciar"
     IDS_MENU_SERVICE_STOP "Parar"
     IDS_MENU_SERVICE_RESTART "Reiniciar"
@@ -263,6 +266,18 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI no soporta más de %d configuraciones. Contacte con el autor si necesita más."
+    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in "\
+                                  """%s"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Do you want to add yourself to this group?\n"\
+                                  "This action may prompt for administrative password or consent."
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Please complete the previous authorization dialog."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Sólo se puede tener una conexión activa a la vez usando una version de OpenVPN anterior a la 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "No se puede usar OpenVPN GUI para inicar una conexión mientras el servicio OpenVPN está ejecutándose (con OpenVPN 1.5/1.6). Detenga primero el servicio OpenVPN si quiere utilizar OpenVPN GUI."
     IDS_ERR_CREATE_EVENT "CreateEvent fallido con evento de salida: %s"
@@ -309,6 +324,7 @@ BEGIN
                          "están en directorios diferentes."
     /* main - Resources */
     IDS_ERR_OPEN_DEBUG_FILE "Error al abrir el fichero de debug (%s) para salida."
+    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
     IDS_ERR_LOAD_RICHED20 "No se puede cargar RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "La versión del shell32.dll es demasiado antigua (0x%lx). Se necesita al menos la versión 5.0."
     IDS_NFO_SERVICE_STARTED "Servcio OpenVPN iniciado."
@@ -323,6 +339,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Mostrar éste mensaje.\n" \
                   "--connect cnn \t\t: Conectar con ""cnn"" al arrancar. (la extensión debe incluirse)\n" \
                   "\t\t\t   Ejemplo: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+		  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Opciones para sobreescribir opciones del registro:\n" \
                   "--exe_path\t\t: Ruta a openvpn.exe.\n" \
@@ -400,9 +426,16 @@ BEGIN
     IDS_ERR_OPEN_SCMGR "OpenSCManager falló (%d)"
     IDS_ERR_STOP_SERVICE "Error al detener el servicio OpenVPN"
     IDS_NFO_RESTARTED "Servicio OpenVPN reiniciado."
+    IDS_ERR_ACCESS_SERVICE_PIPE "Access to service pipe failed."
+    IDS_ERR_WRITE_SERVICE_PIPE "Writing to service pipe failed."
+    IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is not installed.\n"
+                                 "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
+                                 "Tasks requiring administrative access may not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Error al obtener el directorio de Windows."
+    IDS_ERR_GET_PROFILE_DIR "Error getting User Profile Directory."
     IDS_ERR_GET_PROGRAM_DIR "Error al obtener el nombre del directorio ""Program""."
     IDS_ERR_OPEN_REGISTRY "Error al abrir el registro para lectura (HKLM\\SOFTWARE\\OpenVPN).\n " \
                           "OpenVPN probablemente no está instalado"
@@ -416,4 +449,28 @@ BEGIN
                            "nuevo como Administrator para actualizar el registro."
     IDS_ERR_READ_SET_KEY "Error al leer y escribir la clave de registro ""%s""."
     IDS_ERR_WRITE_REGVALUE "Error al escribir el valor del registro ""HKEY_CURRENT_USER\\%s\\%s""."
+
+    /* importation */
+    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n" \
+                          "%s\n\nMake sure you have the right permissions."
+    IDS_NFO_IMPORT_SUCCESS "File imported successfully."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+
+    /* save/delete password */
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+
+    /* Token password related */
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+
 END

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -342,6 +342,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Näytä tämä viesti.\n" \
                   "--connect cnn \t\t: Yhdistä kohteeseen ""cnn"" käynnistettäessä. Muista liittää tiedostopääte.\n" \
                   "\t\t\t   Esim.: openvpn-gui --connect toimisto.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+                  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Rekisterin asetukset kumoavat valinnat:\n" \
                   "--exe_path\t\t: Polku openvpn.exe -tiedostoon.\n" \
@@ -429,6 +439,7 @@ BEGIN
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Virhe avattaessa Windows-kansiota."
+    IDS_ERR_GET_PROFILE_DIR "Error getting User Profile Directory."
     IDS_ERR_GET_PROGRAM_DIR "Virhe etsittäessä ""Program""-kansion sijaintia."
     IDS_ERR_OPEN_REGISTRY "Virhe luettaessa rekisteriavainta (HKLM\\SOFTWARE\\OpenVPN).\n " \
                           "OpenVPN:ää ei todennäköisesti ole asennettu."
@@ -448,6 +459,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Asetustiedoston tuonti epäonnistui. Polkua ei voitu luoda:\n\n" \
                           "%s\n\nVarmista, että sinulla on tarvittavat tiedosto-oikeudet."
     IDS_NFO_IMPORT_SUCCESS "Asetustiedoston tuonti onnistui."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Napsauta OK poistaaksesi asetustiedostoon ""%s"" liitetyt salasanat."
@@ -456,15 +469,12 @@ BEGIN
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Tokenin salasana"
     IDS_NFO_TOKEN_PASSWORD_REQUEST "Anna Salasana/PIN tokenille '%S'"
 
-
-
-
-
-
-
-
-
-
-
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
 
 END

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -247,6 +247,7 @@ BEGIN
     IDS_MENU_CLOSE "Quitter"
     IDS_MENU_CONNECT "Connecter"
     IDS_MENU_DISCONNECT "Déconnecter"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "Afficher le statut"
     IDS_MENU_VIEWLOG "Voir le log"
     IDS_MENU_EDITCONFIG "Editer la configuration"
@@ -266,7 +267,7 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI ne permet pas plus de %d configurations. Contacter l'auteur si vous en avez besoin de plus."
-        IDS_NFO_NO_CONFIGS "Aucun profil de connexion lisible trouvé (fichiers de configuration).\n"\
+    IDS_NFO_NO_CONFIGS "Aucun profil de connexion lisible trouvé (fichiers de configuration).\n"\
                        "Utilisez le menu ""Importer fichier.."" ou copiez vos fichiers de configuration vers ""%s"" ou ""%s""."
     IDS_ERR_CONFIG_NOT_AUTHORIZED "À partir de cette connexion (%s) une adhésion est nécessaire au groupe "\
                                   """%s"". Contactez votre administrateur système.\n"
@@ -341,6 +342,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Afficher ce message.\n" \
                   "--connect cnn \t\t: Connecte à ""cnn"" au démarrage. (l'extension doit être incluse)\n" \
                   "\t\t\t   Exemple: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+		  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Options pour corriger la configuration de registre:\n" \
                   "--exe_path\t\t: Chemin vers openvpn.exe.\n" \
@@ -447,6 +458,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Impossible d'importer un fichier. Le chemin suivant n'a pas pu être créé.\n\n" \
                           "%s\n\nAssurez-vous d'avoir les bonnes autorisations."
     IDS_NFO_IMPORT_SUCCESS "Fichier importé avec succès."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Appuyez sur OK pour supprimer les mots de passe enregistrés pour config ""%s"""
@@ -457,5 +470,10 @@ BEGIN
 
     IDS_NFO_AUTH_PASS_RETRY "Nom d'utilisateur ou mot de passe incorrect. Réessayer..."
     IDS_NFO_KEY_PASS_RETRY  "Mauvais mot de passe. Réessayer..."
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
 
 END

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -438,6 +438,7 @@ BEGIN
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Errore nell'ottenere la cartella di Windows."
+    IDS_ERR_GET_PROFILE_DIR "Error getting User Profile Directory."
     IDS_ERR_GET_PROGRAM_DIR "Errore nell'ottenere la cartella ""Program""."
     IDS_ERR_OPEN_REGISTRY "Errore nell'apertura del registro in lettura (HKLM\\SOFTWARE\\OpenVPN).\n " \
                           "OpenVPN probabilmente non è installato"
@@ -457,6 +458,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Errore nell'importazione del file. Non ho potuto creare il percorso seguente:\n\n" \
                           "%s\n\nControlla di avere i permessi giusti."
     IDS_NFO_IMPORT_SUCCESS "File importato con successo."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Premi OK per cancellare le password salvate per la configurazione ""%s"""

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -243,14 +243,17 @@ BEGIN
     IDS_TIP_CONNECTED_SINCE "\n接続時間: "
     IDS_TIP_ASSIGNED_IP "\n割り当てられたIP: %s"
     IDS_MENU_SERVICE "OpenVPNサービス"
+    IDS_MENU_IMPORT "Import file…"
     IDS_MENU_SETTINGS "設定…"
     IDS_MENU_CLOSE "終了"
     IDS_MENU_CONNECT "接続"
     IDS_MENU_DISCONNECT "切断"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "ステータスの表示"
     IDS_MENU_VIEWLOG "ログの表示"
     IDS_MENU_EDITCONFIG "設定の編集"
     IDS_MENU_PASSPHRASE "パスワード変更"
+    IDS_MENU_CLEARPASS  "Clear Saved Passwords"
     IDS_MENU_SERVICE_START "開始"
     IDS_MENU_SERVICE_STOP "停止"
     IDS_MENU_SERVICE_RESTART "再起動"
@@ -265,6 +268,18 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUIは %d 以上の設定はサポートしていません。これ以上の設定が必要な場合は開発者に連絡してください。"
+    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in "\
+                                  """%s"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Do you want to add yourself to this group?\n"\
+                                  "This action may prompt for administrative password or consent."
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Please complete the previous authorization dialog."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "OpenVPN 2.0-beta6 より古いバージョンでは、同時に使用できる接続は1つだけです。"
     IDS_ERR_STOP_SERV_OLD_VER "OpenVPNサービスが実行されているときには、OpenVPN GUI で接続を開始できません（OpenVPN 1.5/1.6）。OpenVPN GUIを使用する場合には先にOpenVPNサービスを停止してください。"
     IDS_ERR_CREATE_EVENT "CreateEvent failed on exit event: %s"
@@ -311,6 +326,7 @@ BEGIN
         
     /* main - Resources */
     IDS_ERR_OPEN_DEBUG_FILE "デバッグファイル (%s) を出力用に開くときにエラーが発生しました。"
+    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
     IDS_ERR_LOAD_RICHED20 "RICHED20.DLL が読み込めません。"
     IDS_ERR_SHELL_DLL_VERSION "shell32.dll のバージョンが古いです (0x%lx). バージョン 5.0 以降に更新してください。"
     IDS_NFO_SERVICE_STARTED "OpenVPNサービスが開始されました。"
@@ -325,6 +341,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: このメッセージを表示する。\n" \
                   "--connect cnn \t\t: 起動時に ""cnn"" に接続する（拡張子も含める必要があります）。\n" \
                   "\t\t\t   例: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+		  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "各オプションはレジストリの設定に優先されます:\n" \
                   "--exe_path\t\t: openvpn.exeへのパス。\n" \
@@ -402,9 +428,16 @@ BEGIN
     IDS_ERR_OPEN_SCMGR "OpenSCManagerに失敗しました。 (%d)"
     IDS_ERR_STOP_SERVICE "OpenVPNサービスの停止に失敗しました。"
     IDS_NFO_RESTARTED "OpenVPNサービスを再起動しました。"
+    IDS_ERR_ACCESS_SERVICE_PIPE "Access to service pipe failed."
+    IDS_ERR_WRITE_SERVICE_PIPE "Writing to service pipe failed."
+    IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is not installed.\n"
+                                 "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
+                                 "Tasks requiring administrative access may not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Windowsディレクトリが取得できませんでした。"
+    IDS_ERR_GET_PROFILE_DIR "Error getting User Profile Directory."
     IDS_ERR_GET_PROGRAM_DIR """Program""フォルダ名を取得できませんでした。"
     IDS_ERR_OPEN_REGISTRY  "レジストリ (HKLM\\SOFTWARE\\OpenVPN) が読み取れませんでした。\n " \
 			    "OpenVPNがインストールされていない可能性があります。"
@@ -417,4 +450,28 @@ BEGIN
     IDS_ERR_OPEN_WRITE_REG "レジストリの書き込みに失敗しました。レジストリの更新時にはアプリケーションを管理者権限で実行する必要があります。"
     IDS_ERR_READ_SET_KEY "レジストリ ""%s"" の読み取り/書き込みに失敗しました。" 
     IDS_ERR_WRITE_REGVALUE "レジストリ ""HKEY_CURRENT_USER\\%s\\%s"" への書き込みに失敗しました。"
+
+    /* importation */
+    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n" \
+                          "%s\n\nMake sure you have the right permissions."
+    IDS_NFO_IMPORT_SUCCESS "File imported successfully."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+
+    /* save/delete password */
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+
+    /* Token password related */
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+
 END

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -456,6 +456,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "파일 불러오기 실패. 다음 경로를 생성할 수 없습니다.\n\n" \
                           "%s\n\n올바른 권한을 가지고 있는지 확인 해 보십시오."
     IDS_NFO_IMPORT_SUCCESS "파일 불러오기 성공."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS """%s"" 설정의 저장된 암호를 삭제 하려면 확인을 누르십시오."

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -457,6 +457,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Importeren bestand is mislukt. De onderstaande bestandsnaam kon niet gemaakt worden.\n\n" \
                           "%s\n\nControleer of de juiste rechten gebruikt worden."
     IDS_NFO_IMPORT_SUCCESS "Importeren bestand gelukt."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Klik op OK om alle opgeslagen wachtwoorden voor de configuratie ""%s"" te verwijderen"
@@ -471,5 +473,6 @@ BEGIN
     IDS_ERR_INVALID_USERNAME_INPUT "Ongeldig karakter in de gebruikersnaam"
     IDS_NFO_AUTO_CONNECT    "Automatisch verbinden over %u seconden..."
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI draait al. Klik met de rechtermuisknop op het tray icon om te starten."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
 
 END

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -247,6 +247,7 @@ BEGIN
     IDS_MENU_CLOSE "Avslutte"
     IDS_MENU_CONNECT "Koble til"
     IDS_MENU_DISCONNECT "Koble fra"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "Vis status"
     IDS_MENU_VIEWLOG "Vis logg"
     IDS_MENU_EDITCONFIG "Endre innstillinger"
@@ -272,6 +273,10 @@ BEGIN
     IDS_ERR_CONFIG_TRY_AUTHORIZE  "For å starte tilkoblingen (%s) kreves medlemskap i gruppen ""%s"".\n\n"\
                                   "Vil du gjøre din brukerkonto medlem av denne gruppen?\n"\
                                   "Du kan bli spurt om administrator-rettigheter for å utføre denne endringen."
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Please complete the previous authorization dialog."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Du kan bare bruke én enkelt tilkobling av gangen med eldre versjoner av OpenVPN enn 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Du kan ikke koble til med OpenVPN GUI når OpenVPN-tjenesten kjører. (kun OpenVPN 1.5/1.6). Stopp tjenesten først om du vil benytte OpenVPN GUI."
     IDS_ERR_CREATE_EVENT "CreateEvent feilet med å opprette hendelsen: %s"
@@ -332,6 +337,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Vis dene meldingen.\n" \
                   "--connect cnn \t\t: Koble til ""cnn"" ved oppstart. (filetternavn må være med)\n" \
                   "\t\t\t   Eksempel: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+		  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Parametere som vil overstyre innstillinger gjort i registeret:\n" \
                   "--exe_path\t\t: Sti til openvpn.exe.\n" \
@@ -434,7 +449,22 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "En feil oppsto under importeringen. Kunne ikke opprette filstien:\n\n" \
                           "%s\n\nDet kan hende du trenger administrator-rettigheter for å importere filer."
     IDS_NFO_IMPORT_SUCCESS "Importeringen var vellykket."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Klikk OK for å slette lagrede passord for konfigurasjonen ""%s""."
+
+    /* Token password related */
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+
 END

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -243,14 +243,17 @@ BEGIN
     IDS_TIP_CONNECTED_SINCE "\nPołączony od: "
     IDS_TIP_ASSIGNED_IP "\nPrzyznane IP: %s"
     IDS_MENU_SERVICE "Usługa OpenVPN"
+    IDS_MENU_IMPORT "Import file…"
     IDS_MENU_SETTINGS "Ustawienia…"
     IDS_MENU_CLOSE "Zakończ"
     IDS_MENU_CONNECT "Połącz"
     IDS_MENU_DISCONNECT "Rozłącz"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "Pokaż Status"
     IDS_MENU_VIEWLOG "Pokaż Log"
     IDS_MENU_EDITCONFIG "Edytuj Konfigurację"
     IDS_MENU_PASSPHRASE "Zmień Hasło"
+    IDS_MENU_CLEARPASS  "Clear Saved Passwords"
     IDS_MENU_SERVICE_START "Uruchom"
     IDS_MENU_SERVICE_STOP "Zatrzymaj"
     IDS_MENU_SERVICE_RESTART "Uruchom Ponownie"
@@ -265,6 +268,18 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI nie wspiera ilości konfiguracji większej niż %d. Proszę skontaktować się z autorem w przypadku takiej potrzeby."
+    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in "\
+                                  """%s"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Do you want to add yourself to this group?\n"\
+                                  "This action may prompt for administrative password or consent."
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Please complete the previous authorization dialog."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Możesz mieć jednocześnie tylko jedno aktywne połączenie kiedy używasz OpenVPN-a w wersji starszej niż 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Nie możesz nawiązać połączenia za pomocą OpenVPN GUI gdy uruchomiona jest usługa OpenVPN (dla OpenVPN-a 1.5/1.6). Zatrzymaj usługę OpenVPN jeśli chcesz użyć OpenVPN GUI."
     IDS_ERR_CREATE_EVENT "Błąd podczas tworzenia zdarzenia wyjścia: %s"
@@ -311,6 +326,7 @@ BEGIN
                          "umieszczone są w innych katalogach."
     /* main - Resources */
     IDS_ERR_OPEN_DEBUG_FILE "Błąd otwarcia pliku debagu (%s)."
+    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
     IDS_ERR_LOAD_RICHED20 "Błąd ładowania biblioteki RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Twoja wersja biblioteki shell32.dll jest za stara (0x%lx). Wymagana co najmniej wersja 5.0."
     IDS_NFO_SERVICE_STARTED "Usługa OpenVPN uruchomiona."
@@ -325,6 +341,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Pokaż tę wiadomość.\n" \
                   "--connect cnn \t\t: Połącz z ""cnn"" na starcie. (rozszerzenie musi zostać podane jawnie)\n" \
                   "\t\t\t   Przykład: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+		  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Opcje oddalające ustawienia rejestru:\n" \
                   "--exe_path\t\t: Ścieżka do openvpn.exe.\n" \
@@ -402,9 +428,16 @@ BEGIN
     IDS_ERR_OPEN_SCMGR "Błąd OpenSCManager'a(%d)"
     IDS_ERR_STOP_SERVICE "Nie udało się zatrzymać usługi OpenVPN."
     IDS_NFO_RESTARTED "Usługa OpenVPN uruchomiona ponownie."
+    IDS_ERR_ACCESS_SERVICE_PIPE "Access to service pipe failed."
+    IDS_ERR_WRITE_SERVICE_PIPE "Writing to service pipe failed."
+    IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is not installed.\n"
+                                 "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
+                                 "Tasks requiring administrative access may not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Błąd przy pobieraniu nazwy katalogu systemowego Windows."
+    IDS_ERR_GET_PROFILE_DIR "Error getting User Profile Directory."
     IDS_ERR_GET_PROGRAM_DIR "Błąd przy pobieraniu nazwy katalogu ""Program""."
     IDS_ERR_OPEN_REGISTRY "Błąd przy otwieraniu do odczytu rejestru (HKLM\\SOFTWARE\\OpenVPN).\n " \
                       "Prawdopodobnie OpenVPN nie jest zainstalowany."
@@ -418,5 +451,29 @@ BEGIN
                        "z prawami administratora aby uaktualnić rejestr."
     IDS_ERR_READ_SET_KEY "Błąd odczytu/zmiany klucza rejestru ""%s""."
     IDS_ERR_WRITE_REGVALUE "Błąd zapisu rejestru ""HKEY_CURRENT_USER\\%s\\%s""."
+
+    /* importation */
+    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n" \
+                          "%s\n\nMake sure you have the right permissions."
+    IDS_NFO_IMPORT_SUCCESS "File imported successfully."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+
+    /* save/delete password */
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+
+    /* Token password related */
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+
 END
 

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -246,10 +246,12 @@ BEGIN
     IDS_MENU_CLOSE "Sair"
     IDS_MENU_CONNECT "Conectar"
     IDS_MENU_DISCONNECT "Desconectar"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "Mostrar status"
     IDS_MENU_VIEWLOG "Visualizar log"
     IDS_MENU_EDITCONFIG "Editar configurações"
     IDS_MENU_PASSPHRASE "Alterar senha"
+    IDS_MENU_CLEARPASS  "Clear Saved Passwords"
     IDS_MENU_SERVICE_START "Iniciar"
     IDS_MENU_SERVICE_STOP "Parar"
     IDS_MENU_SERVICE_RESTART "Reiniciar"
@@ -266,6 +268,16 @@ BEGIN
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI não suporta mais do que %d configurações. Contate o autor se você necessita de mais."
     IDS_NFO_NO_CONFIGS "Nenhum perfil de conexão (arquivo de configuração) foi localizado.\n"\
                        "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in "\
+                                  """%s"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Do you want to add yourself to this group?\n"\
+                                  "This action may prompt for administrative password or consent."
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Please complete the previous authorization dialog."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Você pode ter apenas uma conexão ativa enquanto estiver usando uma versão anterior a OpenVPN 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Você não pode usar o OpenVPN GUI para iniciar uma conexão enquanto o serviço OpenVPN estiver em execução (com OpenVPN 1.5/1.6). Pare o serviço OpenVPN primero se você quiser utilizar o OpenVPN GUI."
     IDS_ERR_CREATE_EVENT "CreateEvent falhou no evento de saída: %s"
@@ -329,6 +341,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Mostra esta mensagem.\n" \
                   "--connect cnn \t\t: Conecta a ""cnn"" no início. (extensão deve ser incluída)\n" \
                   "\t\t\t   Exemplo: openvpn-gui --connect escritorio.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+                  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Opções para sobrescrever opções do registro:\n" \
                   "--exe_path\t\t: Caminho para openvpn.exe.\n" \
@@ -435,4 +457,22 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Falha ao importar o arquivo. O seguinte caminho não pôde ser criado.\n\n" \
                           "%s\n\nCertifique-se de que você possui as permissões necessárias."
     IDS_NFO_IMPORT_SUCCESS "Arquivo importado com sucesso."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+
+    /* save/delete password */
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+
+    /* Token password related */
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+
 END

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -342,6 +342,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Отобразить это сообщение.\n" \
                   "--connect cnn \t\t: Подключиться к ""cnn"" при запуске. (включая расширение файла)\n" \
                   "\t\t\t   Пример: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+		  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Опции для переназначения настроек реестра:\n" \
                   "--exe_path\t\t: Путь к openvpn.exe.\n" \
@@ -448,13 +458,22 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "Ошибка импорта файла. Путь %s не может быть создан.\n\n" \
                           "Убедитесь, что у вас есть необходимые привилегии для данного действия."
     IDS_NFO_IMPORT_SUCCESS "Импорт файла успешно завершен."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Подтвердите удаление сохраненных паролей для ""%s"""
 
+    /* Token password related */
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+
     IDS_NFO_AUTH_PASS_RETRY "Неправильное имя пользователя или пароль"
     IDS_NFO_KEY_PASS_RETRY  "Неправильный пароль"
-
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Автоматическое подключение через %u сек..."
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
 
 END

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -241,14 +241,17 @@ BEGIN
     IDS_TIP_CONNECTED_SINCE "\nAnsluten sedan: "
     IDS_TIP_ASSIGNED_IP "\nTilldelad IP: %s"
     IDS_MENU_SERVICE "OpenVPN Service"
+    IDS_MENU_IMPORT "Import file…"
     IDS_MENU_SETTINGS "Inställningar…"
     IDS_MENU_CLOSE "Avsluta"
     IDS_MENU_CONNECT "Anslut"
     IDS_MENU_DISCONNECT "Koppla ner"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "Visa Status"
     IDS_MENU_VIEWLOG "Visa Logg"
     IDS_MENU_EDITCONFIG "Editera konfig"
     IDS_MENU_PASSPHRASE "Ändra Lösenord"
+    IDS_MENU_CLEARPASS  "Clear Saved Passwords"
     IDS_MENU_SERVICE_START "Starta"
     IDS_MENU_SERVICE_STOP "Stoppa"
     IDS_MENU_SERVICE_RESTART "Starta om"
@@ -263,6 +266,18 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "Du kan inte ha fler än %d konfig-filer. Kontakta utvecklaren av OpenVPN GUI om du har behov av att hantera fler."
+    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in "\
+                                  """%s"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Do you want to add yourself to this group?\n"\
+                                  "This action may prompt for administrative password or consent."
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Please complete the previous authorization dialog."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Du kan bara ha en uppkoppling igång samtidigt med äldre versioner av OpenVPN än 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Du kan inte ansluta med OpenVPN GUI medan OpenVPN Service är igång. (med OpenVPN 1.5/1.6). Stoppa tjänsten först om du vill använda OpenVPN GUI."
     IDS_ERR_CREATE_EVENT "CreateEvent misslyckades med att skapa event: %s"
@@ -309,6 +324,7 @@ BEGIN
 
     /* main - Resources */
     IDS_ERR_OPEN_DEBUG_FILE "Fel vid öppnande av debug fil. (%s)"
+    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
     IDS_ERR_LOAD_RICHED20 "Kunde inte ladda RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Din shell32.dll version är för låg (0x%lx). Du böhöver minst version 5.0."
     IDS_NFO_SERVICE_STARTED "OpenVPN Service startad."
@@ -322,6 +338,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Visa detta meddelande.\n" \
                   "--connect cnn \t\t: Anslut till ""cnn"" vid uppstart. (filändelsen måste vara med)\n" \
                   "\t\t\t   Exempel: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+                  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Parametrar som ersätter inställningar gjorda i registret:\n" \
                   "--exe_path\t\t: Path till openvpn.exe.\n" \
@@ -399,9 +425,16 @@ BEGIN
     IDS_ERR_OPEN_SCMGR "OpenSCManager misslyckades (%d)"
     IDS_ERR_STOP_SERVICE "Ett fel uppstod vid stoppande av OpenVPN Service"
     IDS_NFO_RESTARTED "OpenVPN Service har startats om."
+    IDS_ERR_ACCESS_SERVICE_PIPE "Access to service pipe failed."
+    IDS_ERR_WRITE_SERVICE_PIPE "Writing to service pipe failed."
+    IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is not installed.\n"
+                                 "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
+                                 "Tasks requiring administrative access may not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Kunde inte hitta i vilken katalog Windows är installerat."
+    IDS_ERR_GET_PROFILE_DIR "Error getting User Profile Directory."
     IDS_ERR_GET_PROGRAM_DIR "Kunde inte hitta pathen till din ""Program"" katalog."
     IDS_ERR_OPEN_REGISTRY "Fel vid öppnande av registret för läsning (HKLM\\SOFTWARE\\OpenVPN).\n OpenVPN är förmodligen inte installerat."
     IDS_ERR_READING_REGISTRY "Fel vid läsning av register nyckel (HKLM\\SOFTWARE\\OpenVPN)."
@@ -413,4 +446,28 @@ BEGIN
     IDS_ERR_OPEN_WRITE_REG "Fel vid öppnande av registret för skrivning. Du måste starta programmet en gång som administratör för att uppdatera registret."
     IDS_ERR_READ_SET_KEY "Fel vid läsning och skrivning av register värde ""%s""."
     IDS_ERR_WRITE_REGVALUE "Fel vid skrivning av register värdet ""HKEY_CURRENT_USER\\%s\\%s""."
+
+    /* importation */
+    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n" \
+                          "%s\n\nMake sure you have the right permissions."
+    IDS_NFO_IMPORT_SUCCESS "File imported successfully."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+
+    /* save/delete password */
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+
+    /* Token password related */
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+
 END

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -243,14 +243,17 @@ BEGIN
     IDS_TIP_CONNECTED_SINCE "\nBağlanıldı: "
     IDS_TIP_ASSIGNED_IP "\nBağlanılan IP: %s"
     IDS_MENU_SERVICE "OpenVPN Servisi"
+    IDS_MENU_IMPORT "Import file…"
     IDS_MENU_SETTINGS "Ayarlar…"
     IDS_MENU_CLOSE "Çıkış"
     IDS_MENU_CONNECT "Bağlan"
     IDS_MENU_DISCONNECT "Bağlantıyı Kes"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "Durum"
     IDS_MENU_VIEWLOG "Günlüğe Bak"
     IDS_MENU_EDITCONFIG "Ayarlar"
     IDS_MENU_PASSPHRASE "Şifreyi Değiştir"
+    IDS_MENU_CLEARPASS  "Clear Saved Passwords"
     IDS_MENU_SERVICE_START "Başla"
     IDS_MENU_SERVICE_STOP "Durdur"
     IDS_MENU_SERVICE_RESTART "Yeniden Başlat"
@@ -265,6 +268,18 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI %d den fazla konfigürasyonu desteklemiyor. Eğer daha fazlasına ihtiyacınız varsa lütfen hak sahibi ile görüşün."
+    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n"\
+                       "Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in "\
+                                  """%s"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Do you want to add yourself to this group?\n"\
+                                  "This action may prompt for administrative password or consent."
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in "\
+                                  """%s"" group.\n\n"\
+                                  "Please complete the previous authorization dialog."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "OpenVPN 2.0-beta6 sürümünden daha eski bir versiyon açıkken, aynı anda sadece bir bağlantı açabilirsiniz!"
     IDS_ERR_STOP_SERV_OLD_VER "OpenVPN servisi çalışırken (OpenVPN ver.1.5/1.6) OpenVPN GUI ile bağlantı yapamazsınız. OpenVPN GUI yi kullanacaksanız, öncelikle OpenVPN servisini durdurmanız gerekmektedir."
     IDS_ERR_CREATE_EVENT "Çıkılırken hata oluştu: %s"
@@ -311,6 +326,7 @@ BEGIN
 				 "kayıt edemezsiniz."
     /* main - Resources */
     IDS_ERR_OPEN_DEBUG_FILE "Debug dosyası açılırken hata oluştu (%s)"
+    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
     IDS_ERR_LOAD_RICHED20 "RICHED20.DLL yüklenemedi."
     IDS_ERR_SHELL_DLL_VERSION "Sistemde bulunan shell32.dll verdsiyonu eski. (0x%lx). En az 5.0 versiyonuna sahip olmalısınız."
     IDS_NFO_SERVICE_STARTED "OpenVPN Servisi başlatıldı."
@@ -325,6 +341,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: Yardım mesajını gözter.\n" \
                   "--connect cnn \t\t: Başlangıçta otomatik olarak ""cnn"" e bağlan. (uzantılar dahil edilmelidir.)\n" \
                   "\t\t\t   Örnek: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+                  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "Registry ayarları için:\n" \
                   "--exe_path\t\t: openvpn.exe yolu.\n" \
@@ -402,9 +428,16 @@ BEGIN
     IDS_ERR_OPEN_SCMGR "OpenSCManager başarısız oldu. (%d)"
     IDS_ERR_STOP_SERVICE "OpenVPN Servisini durdurma girişimi başarısız oldu."
     IDS_NFO_RESTARTED "OpenVPN Servisi başlatıldı."
+    IDS_ERR_ACCESS_SERVICE_PIPE "Access to service pipe failed."
+    IDS_ERR_WRITE_SERVICE_PIPE "Writing to service pipe failed."
+    IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is not installed.\n"
+                                 "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
+                                 "Tasks requiring administrative access may not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Windows dizinine erişim başarısız oldu."
+    IDS_ERR_GET_PROFILE_DIR "Error getting User Profile Directory."
     IDS_ERR_GET_PROGRAM_DIR """Program"" dizine erişim başarısız oldu ."
     IDS_ERR_OPEN_REGISTRY "Registry açılamadı(HKLM\\SOFTWARE\\OpenVPN).\n " \
                       "Muhtemelen OpenVPN yüklü değil."
@@ -418,4 +451,28 @@ BEGIN
                        "sistem yönetici haklarına sahip olmanız gerekmektedir.."
     IDS_ERR_READ_SET_KEY """%s"" anahtarı ayarlanırken hata oluştu."
     IDS_ERR_WRITE_REGVALUE """HKEY_CURRENT_USER\\%s\\%s"" anahtarı yazılırken hata oluştu."
+
+    /* importation */
+    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n" \
+                          "%s\n\nMake sure you have the right permissions."
+    IDS_NFO_IMPORT_SUCCESS "File imported successfully."
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+
+    /* save/delete password */
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+
+    /* Token password related */
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+
 END

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -459,6 +459,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "文件导入失败。无法建立下列路径。\n\n" \
                           "%s\n\n请确定您有正确的系统权限。"
     IDS_NFO_IMPORT_SUCCESS "已成功导入文件。"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "请按「确定」删除「%s」连接配置文件的已存密码。"

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -250,6 +250,7 @@ BEGIN
     IDS_MENU_CLOSE "離開"
     IDS_MENU_CONNECT "連線"
     IDS_MENU_DISCONNECT "斷線"
+    IDS_MENU_RECONNECT "Reconnect"
     IDS_MENU_STATUS "顯示狀態"
     IDS_MENU_VIEWLOG "顯示紀錄"
     IDS_MENU_EDITCONFIG "編輯設定檔"
@@ -343,6 +344,16 @@ BEGIN
     IDS_NFO_USAGE "--help\t\t\t: 顯示此訊息。\n" \
                   "--connect cnn \t\t: 啟動時連線至 ""cnn""。\n" \
                   "\t\t\t   舉例: openvpn-gui --connect office.ovpn\n" \
+                  "--command cmd [args]\t: Send a command to a running instance of the GUI\n" \
+                  "Supported commands:\n"\
+                  "    connect cnn            \t: connect the config named ""cnn""\n"\
+                  "    disconnect cnn         \t: disconnect the config named ""cnn""\n"\
+                  "    reconnect cnn          \t: reconnect the config named ""cnn""\n"\
+                  "    disconnect_all         \t: disconnect all connected configs\n"\
+                  "    exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n"\
+                  "    status cnn           \t\t: show the status window of config ""cnn"" if connected\n"\
+                  "    silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n"\
+                  "\t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n"\
                   "\n" \
                   "可覆蓋系統登錄表設定的選項:\n" \
                   "--exe_path\t\t: openvpn.exe 的路徑。\n" \
@@ -448,6 +459,8 @@ BEGIN
     IDS_ERR_IMPORT_FAILED "檔案匯入失敗。無法建立下列路徑。\n\n" \
                           "%s\n\n請確定您有正確的系統權限。"
     IDS_NFO_IMPORT_SUCCESS "已成功匯入檔案。"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "請按「確定」刪除「%s」連線設定檔的已存密碼。"
@@ -455,5 +468,13 @@ BEGIN
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Token 密碼"
     IDS_NFO_TOKEN_PASSWORD_REQUEST "請輸入 Token「%S」的密碼或 PIN"
+
+    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
+    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
+    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
+    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
+    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
 
 END


### PR DESCRIPTION
- All missing strings are copied from the English version
  which is the default.
- Description of "--command cmd" is also copied from the
  English version where missing.
- Some white-space changes for consistent formatting of all files

  No user-visible changes except for the --help output
  which will now include a description of the "--command cmd"
  option in English when a translation is not available.

Signed-off-by: Selva Nair <selva.nair@gmail.com>