### PR TITLE
Increase the buffer size for help message

### DIFF
--- a/main.h
+++ b/main.h
@@ -40,7 +40,7 @@
 #define MAX_LOG_LENGTH      1024/* Max number of characters per log line */
 #define MAX_LOG_LINES		500	/* Max number of lines in LogWindow */
 #define DEL_LOG_LINES		10	/* Number of lines to delete from LogWindow */
-#define USAGE_BUF_SIZE		2048	/* Size of buffer used to display usage message */
+#define USAGE_BUF_SIZE		3000	/* Size of buffer used to display usage message */
 
 /* Authorized group who can use any options and config locations */
 #define OVPN_ADMIN_GROUP TEXT("OpenVPN Administrators") /* May be reset in registry */


### PR DESCRIPTION
The help message is truncated in some languages with
recent increases in textual information in the
usage string. Eg., see "openvpn-gui --help" with
Dutch selected as the language where the text
is about 2300 characters while the buffer is only 2048.

The window still fits on typical screen sizes, so
just increase the buffer size to 3000.

Signed-off-by: Selva Nair <selva.nair@gmail.com>