### PR TITLE
Use iservice even when gui is running under admin

### DIFF
--- a/main.c
+++ b/main.c
@@ -28,6 +28,7 @@
 #endif
 
 #include <windows.h>
+#include <versionhelpers.h>
 #include <shlwapi.h>
 #include <wtsapi32.h>
 #include <prsht.h>
@@ -263,7 +264,7 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
     exit(1);
   }
 
-  if (!IsUserAdmin() && strtod(o.ovpn_version, NULL) > 2.3 && !o.silent_connection)
+  if ((!IsUserAdmin() || IsWindows7OrGreater()) && strtod(o.ovpn_version, NULL) > 2.3 && !o.silent_connection)
     CheckIServiceStatus(TRUE);
 
   BuildFileList();

--- a/openvpn.c
+++ b/openvpn.c
@@ -27,6 +27,7 @@
 
 #include <windows.h>
 #include <windowsx.h>
+#include <versionhelpers.h>
 #include <tchar.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -1937,7 +1938,7 @@ StartOpenVPN(connection_t *c)
         (o.proxy_source != config ? _T("--management-query-proxy ") : _T("")));
 
     /* Try to open the service pipe */
-    if (!IsUserAdmin() && InitServiceIO (&c->iserv))
+    if ((!IsUserAdmin() || IsWindows7OrGreater()) && InitServiceIO (&c->iserv))
     {
         DWORD size = _tcslen(c->config_dir) + _tcslen(options) + sizeof(c->manage.password) + 3;
         TCHAR startup_info[1024];


### PR DESCRIPTION
We didn't use interactive service when gui was running
under admin because of some privilege escalation vulnerability in Vista.

Apparently this issue doesn't exist on Win7 and newer versions so
it is safe to use iservice on those systems.

Recent versions of mingw (like on Ubuntu18.04 which we use for
building installer) include versionhelpers.h so no need for compat layer.

Signed-off-by: Lev Stipakov <lev@openvpn.net>