### PR TITLE
Introduce "Always use interactive service" option

### DIFF
--- a/localization.c
+++ b/localization.c
@@ -467,6 +467,8 @@ GeneralSettingsDlgProc(HWND hwndDlg, UINT msg, UNUSED WPARAM wParam, LPARAM lPar
             Button_SetCheck(GetDlgItem(hwndDlg, ID_CHK_LOG_APPEND), BST_CHECKED);
         if (o.silent_connection)
             Button_SetCheck(GetDlgItem(hwndDlg, ID_CHK_SILENT), BST_CHECKED);
+        if (o.iservice_admin)
+            Button_SetCheck(GetDlgItem(hwndDlg, ID_CHK_ALWAYS_USE_ISERVICE), BST_CHECKED);
         if (o.show_balloon == 0)
             CheckRadioButton (hwndDlg, ID_RB_BALLOON0, ID_RB_BALLOON2, ID_RB_BALLOON0);
         else if (o.show_balloon == 1)
@@ -494,6 +496,8 @@ GeneralSettingsDlgProc(HWND hwndDlg, UINT msg, UNUSED WPARAM wParam, LPARAM lPar
                 (Button_GetCheck(GetDlgItem(hwndDlg, ID_CHK_LOG_APPEND)) == BST_CHECKED);
             o.silent_connection =
                 (Button_GetCheck(GetDlgItem(hwndDlg, ID_CHK_SILENT)) == BST_CHECKED);
+            o.iservice_admin =
+                (Button_GetCheck(GetDlgItem(hwndDlg, ID_CHK_ALWAYS_USE_ISERVICE)) == BST_CHECKED);
             if (IsDlgButtonChecked(hwndDlg, ID_RB_BALLOON0))
                 o.show_balloon = 0;
             else if (IsDlgButtonChecked(hwndDlg, ID_RB_BALLOON2))

--- a/main.c
+++ b/main.c
@@ -28,6 +28,7 @@
 #endif
 
 #include <windows.h>
+#include <versionhelpers.h>
 #include <shlwapi.h>
 #include <wtsapi32.h>
 #include <prsht.h>
@@ -263,7 +264,8 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
     exit(1);
   }
 
-  if (!IsUserAdmin() && strtod(o.ovpn_version, NULL) > 2.3 && !o.silent_connection)
+  BOOL use_iservice = (o.iservice_admin && IsWindows7OrGreater()) || !IsUserAdmin();
+  if (use_iservice && strtod(o.ovpn_version, NULL) > 2.3 && !o.silent_connection)
     CheckIServiceStatus(TRUE);
 
   BuildFileList();

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -97,6 +97,7 @@
 #define ID_RB_BALLOON1                   240
 #define ID_RB_BALLOON2                   241
 #define ID_CHK_SHOW_SCRIPT_WIN           242
+#define ID_CHK_ALWAYS_USE_ISERVICE       243
 
 /* Proxy Auth Dialog */
 #define ID_DLG_PROXY_AUTH                250
@@ -283,6 +284,7 @@
 #define IDS_ERR_WRITE_SERVICE_PIPE      1710
 #define IDS_ERR_NOTSTARTED_ISERVICE     1711
 #define IDS_ERR_INSTALL_ISERVICE        1712
+#define IDS_ERR_NOTSTARTED_ISERVICE_ADM 1713
 
 /* Registry Related */
 #define IDS_ERR_GET_WINDOWS_DIR         1801

--- a/openvpn.c
+++ b/openvpn.c
@@ -27,6 +27,7 @@
 
 #include <windows.h>
 #include <windowsx.h>
+#include <versionhelpers.h>
 #include <tchar.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -1936,8 +1937,9 @@ StartOpenVPN(connection_t *c)
         inet_ntoa(c->manage.skaddr.sin_addr), ntohs(c->manage.skaddr.sin_port),
         (o.proxy_source != config ? _T("--management-query-proxy ") : _T("")));
 
+    BOOL use_iservice = (o.iservice_admin && IsWindows7OrGreater()) || !IsUserAdmin();
     /* Try to open the service pipe */
-    if (!IsUserAdmin() && InitServiceIO (&c->iserv))
+    if (use_iservice && InitServiceIO(&c->iserv))
     {
         DWORD size = _tcslen(c->config_dir) + _tcslen(options) + sizeof(c->manage.password) + 3;
         TCHAR startup_info[1024];

--- a/options.c
+++ b/options.c
@@ -151,6 +151,11 @@ add_option(options_t *options, int i, TCHAR **p)
         ++i;
         options->log_append = _ttoi(p[1]) ? 1 : 0;
     }
+    else if ((streq(p[0], _T("iservice_admin"))) && p[1])
+    {
+        ++i;
+        options->iservice_admin = _ttoi(p[1]) ? 1 : 0;
+    }
     else if (streq(p[0], _T("log_viewer")) && p[1])
     {
         ++i;

--- a/options.h
+++ b/options.h
@@ -197,6 +197,7 @@ typedef struct {
     TCHAR editor[MAX_PATH];
     DWORD silent_connection;
     DWORD service_only;
+    DWORD iservice_admin;
     DWORD show_balloon;
     DWORD show_script_window;
     DWORD connectscript_timeout;        /* Connect Script execution timeout (sec) */

--- a/registry.c
+++ b/registry.c
@@ -54,6 +54,7 @@ struct regkey_int {
     DWORD value;
 } regkey_int[] = {
       {L"log_append", &o.log_append, 0},
+      {L"iservice_admin", &o.iservice_admin, 1},
       {L"show_balloon", &o.show_balloon, 1},
       {L"silent_connection", &o.silent_connection, 0},
       {L"preconnectscript_timeout", &o.preconnectscript_timeout, 10},

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -157,14 +157,15 @@ BEGIN
     GROUPBOX "Spuštění", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Spustit při startu Windows", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Volby", 202, 6, 82, 235, 90
+    GROUPBOX "Volby", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Připojovat záznamy na konec logu", ID_CHK_LOG_APPEND, 17, 95, 130, 10
     AUTOCHECKBOX "Zobrazit okno skriptu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Tiché spojení", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Ukazovat upozornění", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "Při připojení", ID_RB_BALLOON1, 28, 155, 53, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Při připojení/obnovení spojení", ID_RB_BALLOON2, 86, 155, 115, 10
-    AUTORADIOBUTTON "Nikdy", ID_RB_BALLOON0, 203, 155, 35, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Ukazovat upozornění", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "Při připojení", ID_RB_BALLOON1, 28, 170, 53, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Při připojení/obnovení spojení", ID_RB_BALLOON2, 86, 170, 115, 10
+    AUTORADIOBUTTON "Nikdy", ID_RB_BALLOON0, 203, 170, 35, 10
 END
 
 /* Advanced Dialog */
@@ -436,6 +437,8 @@ BEGIN
                                  "Úlohy vyžadující oprávnění správce nemusí fungovat."
     IDS_ERR_NOTSTARTED_ISERVICE  "Služba ""OpenVPNServiceInteractive"" není spuštěna.\n"
                                  "Úlohy vyžadující oprávnění správce nemusí fungovat."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  "Služba ""OpenVPNServiceInteractive"" není spuštěna.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Nepodařilo se získat umístění složky Windows."

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -154,7 +154,7 @@ BEGIN
     LTEXT "Spr&ache:", ID_TXT_LANGUAGE, 17, 25, 29, 12
     COMBOBOX ID_CMB_LANGUAGE, 51, 23, 177, 400, CBS_DROPDOWNLIST | WS_TABSTOP
 
-    GROUPBOX "Einstellungen", 202, 6, 82, 235, 90
+    GROUPBOX "Einstellungen", 202, 6, 82, 235, 105
     GROUPBOX "Systemstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Mit &Windows starten", ID_CHK_STARTUP, 17, 59, 200, 12
 
@@ -162,10 +162,11 @@ BEGIN
     AUTOCHECKBOX "An &Log anhängen", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "&Skriptfenster zeigen", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille &Verbindung", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Zeige Benachrichtigung", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "Beim Verb&inden", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Beim Verbinden/&erneut Verbinden", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "&Nie", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Interactive Service immer verwenden", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Zeige Benachrichtigung", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "Beim Verb&inden", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Beim Verbinden/&erneut Verbinden", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "&Nie", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -438,6 +439,8 @@ BEGIN
                                  "Aufgaben, die administrativen Zugriff benötigen, funktionieren möglicherweise nicht."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" wurde nicht gestartet.\n"
                                  "Aufgaben, die administrativen Zugriff benötigen, funktionieren möglicherweise nicht."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" wurde nicht gestartet.\n"
+                                     "Wintun-Treiber kann nicht verwendet werden."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Konnte den Pfad der Windows-Installation nicht ermitteln."

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -157,14 +157,15 @@ BEGIN
     GROUPBOX "Autostart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Start med Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Indstillinger", 202, 6, 82, 235, 90
+    GROUPBOX "Indstillinger", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Tilføj til log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Vis script vindue", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille forbindelse", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Vis Notifikation", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "Ved forbind", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Ved forbind/genforbind", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "Aldrig", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Vis Notifikation", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "Ved forbind", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Ved forbind/genforbind", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Aldrig", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -435,6 +436,8 @@ BEGIN
                                  "Tasks requiring administrative access may not work."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
                                  "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" is not started.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Kunne ikke finde mappen hvor Windows er installeret."

--- a/res/openvpn-gui-res-en-msvc.rc
+++ b/res/openvpn-gui-res-en-msvc.rc
@@ -155,14 +155,15 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows &startup", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 90
+    GROUPBOX "Preferences", 202, 6, 82, 235, 105
     AUTOCHECKBOX "A&ppend to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script &window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "S&ilent connection", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "On &connect", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "On connect/&reconnect", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "&Never", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "&Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "On &connect", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "On connect/&reconnect", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "&Never", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -370,8 +371,9 @@ BEGIN
     IDS_NFO_RESTARTED "OpenVPN Service restarted."
     IDS_ERR_ACCESS_SERVICE_PIPE "Access to service pipe failed."
     IDS_ERR_WRITE_SERVICE_PIPE "Writing to service pipe failed."
-    IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is not installed.\nTasks requiring administrative access may not work."
-    IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\nTasks requiring administrative access may not work."
+    IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is not installed.\nWintun driver and tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\nWintun driver and tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" is not started.\nWintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Error getting Windows Directory."

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -158,14 +158,15 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on User &Logon", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 90
+    GROUPBOX "Preferences", 202, 6, 82, 235, 105
     AUTOCHECKBOX "A&ppend to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script &window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "S&ilent connection", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "On &connect", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "On connect/&reconnect", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "&Never", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "&Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "On &connect", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "On connect/&reconnect", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "&Never", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -435,9 +436,11 @@ BEGIN
     IDS_ERR_ACCESS_SERVICE_PIPE "Access to service pipe failed."
     IDS_ERR_WRITE_SERVICE_PIPE "Writing to service pipe failed."
     IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is not installed.\n"
-                                 "Tasks requiring administrative access may not work."
+                                 "Wintun driver and tasks requiring administrative access may not work."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
-                                 "Tasks requiring administrative access may not work."
+                                 "Wintun driver and tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" is not started.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Error getting Windows Directory."

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -155,14 +155,15 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 90
+    GROUPBOX "Preferences", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -432,6 +433,8 @@ BEGIN
                                  "Tasks requiring administrative access may not work."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
                                  "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" is not started.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Error al obtener el directorio de Windows."

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -156,14 +156,15 @@ BEGIN
     GROUPBOX "Käynnistäminen", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Käynnistä Windowsiin kirjautuessa", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Valinnat", 202, 6, 82, 235, 90
+    GROUPBOX "Valinnat", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Lisää lokitiedostoon", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Näytä komentosarjaikkuna", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Yhdistä taustalla", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Näytä puhekupla", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "Yhdistettäessä", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Myös uudelleenyhd.", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "Ei", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Käytä aina interaktiivista palvelua", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Näytä puhekupla", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "Yhdistettäessä", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Myös uudelleenyhd.", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Ei", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -433,9 +434,11 @@ BEGIN
     IDS_ERR_ACCESS_SERVICE_PIPE "Access to service pipe failed."
     IDS_ERR_WRITE_SERVICE_PIPE "Writing to service pipe failed."
     IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" ei ole asennettu.\n"
-                                 "Ylläpitäjän oikeuksia vaativat toimet eivät välttämättä onnistu."
+                                 "Wintun-ajuria ja ylläpitäjän oikeuksia vaativat toimet eivät välttämättä onnistu."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" ei ole käynnissä.\n"
-                                 "Ylläpitäjän oikeuksia vaativat toimet eivät välttämättä onnistu."
+                                 "Wintun-ajuria ja ylläpitäjän oikeuksia vaativat toimet eivät välttämättä onnistu."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" ei ole käynnissä.\n"
+                                     "Wintun-ajuri ei toimi."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Virhe avattaessa Windows-kansiota."

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -156,14 +156,15 @@ BEGIN
     GROUPBOX "Démarrage", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Lancer au démarrage de Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Préférences", 202, 6, 82, 235, 90
+    GROUPBOX "Préférences", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Ajouter au fichier log", ID_CHK_LOG_APPEND, 17, 95, 81, 10
     AUTOCHECKBOX "Afficher la fenêtre des scripts", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connexion silencieuse", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Afficher une bulle d'information", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "Connexion", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Connexion/Reconnexion", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "Jamais", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Afficher une bulle d'information", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "Connexion", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Connexion/Reconnexion", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Jamais", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -435,6 +436,8 @@ BEGIN
                                  "Les tâches nécessitant un accès administratif peuvent ne pas fonctionner."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" n'est pas démarré.\n"
                                  "Les tâches nécessitant un accès administratif peuvent ne pas fonctionner."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" n'est pas démarré.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Impossible d'obtenir le Répertoire Windows."

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -156,14 +156,15 @@ BEGIN
     GROUPBOX "Avvio", 202, 6, 47, 235, 30
     AUTOCHECKBOX "&Avvia all'apertura di Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferenze", 202, 6, 82, 235, 120
+    GROUPBOX "Preferenze", 202, 6, 82, 235, 135
     AUTOCHECKBOX "Aggiungi in coda al f&ile di log", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Mostra &finestra script", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connessione &silenziosa", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Mostra notifica", ID_TXT_BALLOON, 17, 140, 150, 10
-    AUTORADIOBUTTON "Alla &connessione", ID_RB_BALLOON1, 28, 155, 200, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Alla connessione/&riconnessione", ID_RB_BALLOON2, 28, 170, 200, 10
-    AUTORADIOBUTTON "&Mai", ID_RB_BALLOON0, 28, 185, 200, 10
+    AUTOCHECKBOX "Utilizza sempre il servizio interattivo", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Mostra notifica", ID_TXT_BALLOON, 17, 155, 150, 10
+    AUTORADIOBUTTON "Alla &connessione", ID_RB_BALLOON1, 28, 170, 200, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Alla connessione/&riconnessione", ID_RB_BALLOON2, 28, 185, 200, 10
+    AUTORADIOBUTTON "&Mai", ID_RB_BALLOON0, 28, 200, 200, 10
 END
 
 /* Advanced Dialog */
@@ -435,6 +436,8 @@ BEGIN
                                  "Le operazioni che richiedono accesso amministrativo potrebbero non funzionare."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" non è stato avviato.\n"
                                  "Le operazioni che richiedono accesso amministrativo potrebbero non funzionare."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" non è stato avviato.\n"
+                                     "Il driver Wintun non potrà funzionare."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Errore nell'ottenere la cartella di Windows."

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -157,14 +157,15 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 90
+    GROUPBOX "Preferences", 202, 6, 82, 235, 105
     AUTOCHECKBOX "ログファイルに追記", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "スクリプト実行ウィンドウを表示する", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "接続時にステータスダイアログを表示しない", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "初期接続時", ID_RB_BALLOON1, 22, 155, 60, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "毎回の接続時", ID_RB_BALLOON2, 96, 155, 90, 10
-    AUTORADIOBUTTON "表示しない", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "初期接続時", ID_RB_BALLOON1, 22, 170, 60, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "毎回の接続時", ID_RB_BALLOON2, 96, 170, 90, 10
+    AUTORADIOBUTTON "表示しない", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -434,6 +435,8 @@ BEGIN
                                  "Tasks requiring administrative access may not work."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
                                  "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" is not started.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Windowsディレクトリが取得できませんでした。"

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -158,14 +158,15 @@ BEGIN
     GROUPBOX "시작 설정", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Windows 시작 시에 실행", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "환경 설정", 202, 6, 82, 235, 90
+    GROUPBOX "환경 설정", 202, 6, 82, 235, 105
     AUTOCHECKBOX "로그 파일에 추가", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "스크립트 창 보기", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "연결 시 상태 대화 상자 표시하지 않기", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "풍선말 보기", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "연결 시", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "연결/재연결 시", ID_RB_BALLOON2, 86, 155, 88, 10
-    AUTORADIOBUTTON "표시 안함", ID_RB_BALLOON0, 176, 155, 45, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "풍선말 보기", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "연결 시", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "연결/재연결 시", ID_RB_BALLOON2, 86, 170, 88, 10
+    AUTORADIOBUTTON "표시 안함", ID_RB_BALLOON0, 176, 170, 45, 10
 END
 
 /* Advanced Dialog */
@@ -433,6 +434,8 @@ BEGIN
                                  "Tasks requiring administrative access may not work."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
                                  "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" is not started.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Windows 디렉토리 경로를 알 수 없습니다."

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -157,14 +157,15 @@ BEGIN
     GROUPBOX "Opstarten", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Opstarten met Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Voorkeuren", 202, 6, 82, 235, 90
+    GROUPBOX "Voorkeuren", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Aan logbestand toevoegen", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Script-venster tonen", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille verbinding", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Laat ballontip zien", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "Bij verbinden", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Bij opnieuw verbinden", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "Nooit", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Gebruik altijd interactieve service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Laat ballontip zien", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "Bij verbinden", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Bij opnieuw verbinden", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Nooit", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -434,9 +435,11 @@ BEGIN
     IDS_ERR_ACCESS_SERVICE_PIPE "Toegang tot service pipe mislukt."
     IDS_ERR_WRITE_SERVICE_PIPE "Schrijven naar service pipe mislukt."
     IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" is niet geinstalleerd.\n"
-                                 "Taken die administratieve rechten nodig hebben werken mogelijk niet."
+                                 "Wintun driver en taken die administratieve rechten vereisen werken mogelijk niet."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is niet gestart.\n"
-                                 "Taken die administratieve rechten nodig hebben werken mogelijk niet."
+                                 "Wintun driver en taken die administratieve rechten vereisen werken mogelijk niet."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" is niet gestart.\n"
+                                     "Wintun driver wil niet werken."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Fout tijdens opvragen Windows-map."

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -156,14 +156,15 @@ BEGIN
     GROUPBOX "Oppstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Kjør automatisk når Windows starter", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Innstillinger", 202, 6, 82, 235, 90
+    GROUPBOX "Innstillinger", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Tilføy til eksisterende logg", ID_CHK_LOG_APPEND, 17, 95, 93, 10
     AUTOCHECKBOX "Vis scriptvindu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Skjul statusvindu ved tilkobling", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Vis ballong", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "Ved tilkobling", ID_RB_BALLOON1, 28, 155, 58, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Ved tilkobling/gjenoppkobling", ID_RB_BALLOON2, 87, 155, 103, 10
-    AUTORADIOBUTTON "Aldri", ID_RB_BALLOON0, 200, 155, 27, 10
+    AUTOCHECKBOX "Bruk alltid Interactive Service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Vis ballong", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "Ved tilkobling", ID_RB_BALLOON1, 28, 170, 58, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Ved tilkobling/gjenoppkobling", ID_RB_BALLOON2, 87, 170, 103, 10
+    AUTORADIOBUTTON "Aldri", ID_RB_BALLOON0, 200, 170, 27, 10
 END
 
 /* Advanced Dialog */
@@ -428,6 +429,8 @@ BEGIN
                                  "Denne oppgaven fungerer kanskje ikke uten administrator-rettigheter."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" er ikke startet.\n"
                                  "Denne oppgaven fungerer kanskje ikke uten administrator-rettigheter."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" er ikke startet.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Kunne ikke finne mappen hvor Windows er installert."

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -157,14 +157,15 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 90
+    GROUPBOX "Preferences", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -434,6 +435,8 @@ BEGIN
                                  "Tasks requiring administrative access may not work."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
                                  "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" is not started.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Błąd przy pobieraniu nazwy katalogu systemowego Windows."

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -155,14 +155,15 @@ BEGIN
     GROUPBOX "Inicialização", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Executar ao iniciar o Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 90
+    GROUPBOX "Preferences", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -434,6 +435,8 @@ BEGIN
                                  "Operações que requeiram acesso de administrador podem não funcionar."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" não foi iniciado.\n"
                                  "Operações que requeiram acesso de administrador podem não funcionar."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" não foi iniciado.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Erro ao localizar o diretório do Windows."

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -158,14 +158,15 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускать при старте Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Настройки", 202, 6, 82, 235, 90
+    GROUPBOX "Настройки", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Дописывать, а не перезаписывать журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показывать окно выполнения", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихое» подключение", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Отображать всплывающее окно при:", ID_TXT_BALLOON, 17, 140, 128, 10
-    AUTORADIOBUTTON "Подключении", ID_RB_BALLOON1, 20, 155, 62, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Под- и переподключении", ID_RB_BALLOON2, 85, 155, 100, 10
-    AUTORADIOBUTTON "Никогда", ID_RB_BALLOON0, 190, 155, 43, 10
+    AUTOCHECKBOX "Всегда использовать интерактивный сервис", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Отображать всплывающее окно при:", ID_TXT_BALLOON, 17, 155, 128, 10
+    AUTORADIOBUTTON "Подключении", ID_RB_BALLOON1, 20, 170, 62, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Под- и переподключении", ID_RB_BALLOON2, 85, 170, 100, 10
+    AUTORADIOBUTTON "Никогда", ID_RB_BALLOON0, 190, 170, 43, 10
 END
 
 /* Advanced Dialog */
@@ -432,9 +433,11 @@ BEGIN
     IDS_ERR_ACCESS_SERVICE_PIPE "Попытка доступа к пайпу службы не удалась."
     IDS_ERR_WRITE_SERVICE_PIPE "Попытка записи в пайп службы не удалась."
     IDS_ERR_INSTALL_ISERVICE     """OpenVPNServiceInteractive"" не установлен.\n"
-                                 "Функциональность, требующая прав администратора, может не работать."
+                                 "Wintun драйвер и функциональность, требующая прав администратора, может не работать."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" не запущен.\n"
-                                 "Функциональность, требующая прав администратора, может не работать."
+                                 "Wintun драйвер и функциональность, требующая прав администратора, может не работать."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" не запущен.\n"
+                                     "Wintun драйвер не будет работать."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Ошибка получения пути к папке ""Windows""."

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -155,14 +155,15 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 90
+    GROUPBOX "Preferences", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -431,6 +432,8 @@ BEGIN
                                  "Tasks requiring administrative access may not work."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
                                  "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" inte startad.\n"
+                                     "Wintun driver ska inte fungera."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Kunde inte hitta i vilken katalog Windows är installerat."

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -157,14 +157,15 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 90
+    GROUPBOX "Preferences", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 155, 40, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 170, 40, 10
 END
 
 /* Advanced Dialog */
@@ -434,6 +435,8 @@ BEGIN
                                  "Tasks requiring administrative access may not work."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" is not started.\n"
                                  "Tasks requiring administrative access may not work."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" is not started.\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Windows dizinine erişim başarısız oldu."

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -156,14 +156,15 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускати при старті Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Налаштування", 202, 6, 82, 235, 90
+    GROUPBOX "Налаштування", 202, 6, 82, 235, 105
     AUTOCHECKBOX "Додати, а не перезаписувати журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показывати вікно виконання", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихе» підключення", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "Відображати спливаюче вікно при:", ID_TXT_BALLOON, 17, 140, 128, 10
-    AUTORADIOBUTTON "Підключенні", ID_RB_BALLOON1, 20, 155, 62, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Під- та перепідключенні", ID_RB_BALLOON2, 85, 155, 100, 10
-    AUTORADIOBUTTON "Ніколи", ID_RB_BALLOON0, 190, 155, 43, 10
+    AUTOCHECKBOX "Завжди використовувати інтерактивний сервіс", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Відображати спливаюче вікно при:", ID_TXT_BALLOON, 17, 155, 128, 10
+    AUTORADIOBUTTON "Підключенні", ID_RB_BALLOON1, 20, 170, 62, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Під- та перепідключенні", ID_RB_BALLOON2, 85, 170, 100, 10
+    AUTORADIOBUTTON "Ніколи", ID_RB_BALLOON0, 190, 170, 43, 10
 END
 
 /* Advanced Dialog */
@@ -434,6 +435,8 @@ BEGIN
                                  "Функціональність, що потребує прав адміністратора, може не працювати."
     IDS_ERR_NOTSTARTED_ISERVICE  """OpenVPNServiceInteractive"" не запущено.\n"
                                  "Функціональність, що потребує прав адміністратора, може не працювати."
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  """OpenVPNServiceInteractive"" не запущено.\n"
+                                     "Wintun драйвер не буде працювати."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "Помилка отримання розташування ""Windows""."

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -159,14 +159,15 @@ BEGIN
     GROUPBOX "启动", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 开机时启动", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好设置", 202, 6, 82, 235, 90
+    GROUPBOX "偏好设置", 202, 6, 82, 235, 105
     AUTOCHECKBOX "追加日志文件", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "显示脚本窗口", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "静默连接", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "显示通知", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "连接时", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "连接时、重新连接时", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "从不", ID_RB_BALLOON0, 181, 155, 50, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "显示通知", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "连接时", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "连接时、重新连接时", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "从不", ID_RB_BALLOON0, 181, 170, 50, 10
 END
 
 /* Advanced Dialog */
@@ -437,6 +438,8 @@ BEGIN
                                  "需要管理员权限的任务可能无法正常执行。"
     IDS_ERR_NOTSTARTED_ISERVICE  "未启动「OpenVPNServiceInteractive」。\n"
                                  "需要管理员权限的任务可能无法正常执行。"
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  "未启动「OpenVPNServiceInteractive」。"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "获取 Windows 目录时发生错误。"

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -159,14 +159,15 @@ BEGIN
     GROUPBOX "啟動", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 開機時執行", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好設定", 202, 6, 82, 235, 90
+    GROUPBOX "偏好設定", 202, 6, 82, 235, 105
     AUTOCHECKBOX "附加記錄檔", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "顯示指令碼視窗", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "寧靜連線", ID_CHK_SILENT, 17, 125, 200, 10
-    LTEXT "顯示通知氣球", ID_TXT_BALLOON, 17, 140, 100, 10
-    AUTORADIOBUTTON "連上線時", ID_RB_BALLOON1, 28, 155, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "連上線、重新連線時", ID_RB_BALLOON2, 86, 155, 90, 10
-    AUTORADIOBUTTON "永不顯示", ID_RB_BALLOON0, 181, 155, 50, 10
+    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "顯示通知氣球", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "連上線時", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "連上線、重新連線時", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "永不顯示", ID_RB_BALLOON0, 181, 170, 50, 10
 END
 
 /* Advanced Dialog */
@@ -437,6 +438,8 @@ BEGIN
                                  "需要管理員權限的任務可能無法正常執行。"
     IDS_ERR_NOTSTARTED_ISERVICE  "未啟動「OpenVPNServiceInteractive」。\n"
                                  "需要管理員權限的任務可能無法正常執行。"
+    IDS_ERR_NOTSTARTED_ISERVICE_ADM  "未啟動「OpenVPNServiceInteractive」。\n"
+                                     "Wintun driver will not work."
 
     /* registry */
     IDS_ERR_GET_WINDOWS_DIR "取得 Windows 目錄時發生錯誤。"

--- a/service.c
+++ b/service.c
@@ -32,6 +32,7 @@
 #include "options.h"
 #include "scripts.h"
 #include "main.h"
+#include "misc.h"
 #include "openvpn-gui-res.h"
 #include "localization.h"
 
@@ -283,7 +284,12 @@ CheckIServiceStatus(BOOL warn)
     {
         /* warn that iservice is not started */
         if (warn)
-            ShowLocalizedMsg(IDS_ERR_NOTSTARTED_ISERVICE);
+        {
+            if (IsUserAdmin())
+                ShowLocalizedMsg(IDS_ERR_NOTSTARTED_ISERVICE_ADM);
+            else
+                ShowLocalizedMsg(IDS_ERR_NOTSTARTED_ISERVICE);
+        }
         goto out;
     }
     ret = true;


### PR DESCRIPTION
We didn't use interactive service when gui was running
under admin because of some privilege escalation vulnerability in Vista.

Apparently this issue doesn't exist on Win7 and newer versions so
it is safe to use iservice on those systems.

Introduce "Always use interactive service" option,
which is "on" by default. This should enable users,
who by various reasons run gui as admin, use Wintun.

When gui is running as admin and interactive service
cannot be started or not installed, warn that wintun will not work.

Signed-off-by: Lev Stipakov <lev@openvpn.net>