### PR TITLE
Open all active status windows on left-double-click

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -1662,6 +1662,12 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 
         /* Set size and position of controls */
         RECT rect;
+        GetWindowRect(hwndDlg, &rect);
+        /* Move the window by upto 100 random pixels to avoid all
+         * status windows fall on top of each other.
+         */
+        SetWindowPos(hwndDlg, HWND_TOP, rect.left + rand()%100,
+                     rect.top + rand()%100, 0, 0, SWP_NOSIZE);
         GetClientRect(hwndDlg, &rect);
         RenderStatusWindow(hwndDlg, rect.right, rect.bottom);
         /* Set focus on the LogWindow so it scrolls automatically */
@@ -1793,6 +1799,7 @@ ThreadOpenVPNStatus(void *p)
     HANDLE wait_event;
 
     CLEAR (msg);
+    srand(time(NULL));
 
     /* Cut of extention from config filename. */
     _tcsncpy(conn_name, c->config_file, _countof(conn_name));

--- a/tray.c
+++ b/tray.c
@@ -254,14 +254,15 @@ OnNotifyTray(LPARAM lParam)
             /* Start connection if only one config exist */
             if (o.num_configs == 1 && o.conn[0].state == disconnected)
                     StartOpenVPN(&o.conn[0]);
-            else if (disconnected_conns == o.num_configs - 1) {
-                /* Show status window if only one connection is running */
+            /* show the status window of all connected/connecting profiles upto a max of 10 */
+            else if (disconnected_conns < o.num_configs) {
                 int i;
+                int num_shown = 0;
                 for (i = 0; i < o.num_configs; i++) {
                     if (o.conn[i].state != disconnected) {
                         ShowWindow(o.conn[i].hwndStatus, SW_SHOW);
                         SetForegroundWindow(o.conn[i].hwndStatus);
-                        break;
+                        if (++num_shown >= 10) break;
                     }
                 }
             }


### PR DESCRIPTION
Currently we pop up the status window on double click only
if one connection is active though there is no strong reason to
limit this behaviour. In fact, when multiple connections are
stuck in the connecting state, its very useful to have a quick
way to examine their progress instead of having to drill down
the menu. Especially so when nested menu is in use.

A random variation of up to 100 pixel is added to the initial
position of the status window to avoid all windows falling on
top of each other.

To prevent an explosion of new windows in the very unlikely event
of numerous active connections, restrict the maximum windows
shown to 10.

Signed-off-by: Selva Nair <selva.nair@gmail.com>

Also see discussion under #372 