### PR TITLE
Show a mark against profiles that are in connecting state

### DIFF
--- a/localization.c
+++ b/localization.c
@@ -242,7 +242,7 @@ ShowLocalizedMsg(const UINT stringId, ...)
     va_end(args);
 }
 
-static HICON
+HICON
 LoadLocalizedIconEx(const UINT iconId, int cxDesired, int cyDesired)
 {
     LANGID langId = GetGUILanguage();

--- a/localization.h
+++ b/localization.h
@@ -27,6 +27,7 @@ PTSTR LoadLocalizedString(const UINT, ...);
 int LoadLocalizedStringBuf(PTSTR, const int, const UINT, ...);
 void ShowLocalizedMsg(const UINT, ...);
 int ShowLocalizedMsgEx(const UINT, LPCTSTR, const UINT, ...);
+HICON LoadLocalizedIconEx(const UINT, int cx, int cy);
 HICON LoadLocalizedIcon(const UINT);
 HICON LoadLocalizedSmallIcon(const UINT);
 LPCDLGTEMPLATE LocalizedDialogResource(const UINT);


### PR DESCRIPTION
Currently we show a check mark on connected profiles with no
indication on profiles that may be in the connecting state.

Change this by adding a mark against connecting/reconnecting
profiles. The yellow connecting state icon is used to generate
this mark although a custom designed check mark may look better. 

In case of nested configs, the parent menus are marked with a tick
mark and only the profile is marked with the connecting icon.

Eg., here is one connected and one connecting profile each.

<img width="222" alt="checkmark" src="https://user-images.githubusercontent.com/3981391/103386670-fab74d00-4acd-11eb-8de0-081e13f1c567.png">


No change in behaviour for profiles that are connected or
disconnected.

Trac #1241

Signed-off-by: Selva Nair <selva.nair@gmail.com>