### PR TITLE
swprintf > _snwprintf

### DIFF
--- a/echo.c
+++ b/echo.c
@@ -224,7 +224,7 @@ echo_msg_append(connection_t *c, time_t UNUSED timestamp, const char *msg, BOOL 
         WriteStatusLog(c, L"GUI> ", L"Error: out of memory while processing echo msg", false);
         goto out;
     }
-    swprintf(s + c->echo_msg.txtlen, len - c->echo_msg.txtlen,  L"%s%s", wmsg, eol);
+    _snwprintf(s + c->echo_msg.txtlen, len - c->echo_msg.txtlen,  L"%s%s", wmsg, eol);
 
     s[len-1] = L'\0';
     c->echo_msg.text = s;

--- a/misc.c
+++ b/misc.c
@@ -469,11 +469,11 @@ wcs_concat2(WCHAR *dest, int len, const WCHAR *src1, const WCHAR *src2, const WC
         return;
 
     if (src1 && src2 && src1[0] && src2[0])
-        n = swprintf(dest, len, L"%s%s%s", src1, sep, src2);
+        n = _snwprintf(dest, len, L"%s%s%s", src1, sep, src2);
     else if (src1 && src1[0])
-        n = swprintf(dest, len, L"%s", src1);
+        n = _snwprintf(dest, len, L"%s", src1);
     else if (src2 && src2[0])
-        n = swprintf(dest, len, L"%s", src2);
+        n = _snwprintf(dest, len, L"%s", src2);
 
     if (n < 0 || n >= len) /*swprintf failed */
         n = 0;

--- a/openvpn.c
+++ b/openvpn.c
@@ -1218,7 +1218,7 @@ format_bytecount(wchar_t *buf, size_t len, unsigned long long c)
 
     if (c <= 1024)
     {
-        swprintf(buf, len, L"%I64u B", c);
+        _snwprintf(buf, len, L"%I64u B", c);
         buf[len-1] = L'\0';
         return buf;
     }
@@ -1227,7 +1227,7 @@ format_bytecount(wchar_t *buf, size_t len, unsigned long long c)
         x /= 1024.0;
         s++;
     }
-    swprintf(buf, len, L"%I64u (%.1f %hs)", c, x, *s);
+    _snwprintf(buf, len, L"%I64u (%.1f %hs)", c, x, *s);
     buf[len-1] = L'\0';
 
     return buf;


### PR DESCRIPTION
#397 MinGW treats %s in swprintf as a narrow string specifier while in _snwprintf does not