### PR TITLE
Add Farsi language package to tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,7 @@ openvpn_gui_RESOURCES = \
 	res/openvpn-gui-res-dk.rc \
 	res/openvpn-gui-res-en.rc \
 	res/openvpn-gui-res-es.rc \
+	res/openvpn-gui-res-fa.rc \
 	res/openvpn-gui-res-fi.rc \
 	res/openvpn-gui-res-fr.rc \
 	res/openvpn-gui-res-it.rc \


### PR DESCRIPTION
Lack of this caused official release builds to fail:

```
res/openvpn-gui-res.rc:50:10: fatal error: openvpn-gui-res-fa.rc: No such file or directory
  #include "openvpn-gui-res-fa.rc"
          ^~~~~~~~~~~~~~~~~~~~~~~
```