### PR TITLE
Apply transparency mask to the connecting-state checkmark image

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -108,7 +108,8 @@ openvpn_gui_LDADD = \
 	-lnetapi32 \
 	-lole32 \
 	-lshlwapi \
-	-lsecur32
+	-lsecur32 \
+	-lmsimg32
 
 openvpn-gui-res.o: $(openvpn_gui_RESOURCES) $(srcdir)/openvpn-gui-res.h
 	$(RCCOMPILE) -i $< -o $@

--- a/openvpn-gui.vcxproj
+++ b/openvpn-gui.vcxproj
@@ -117,7 +117,7 @@
       <PreprocessorDefinitions>HAVE_CONFIG_H;_MSC_VER</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Netapi32.lib;Wtsapi32.lib;Comctl32.lib;Secur32.lib;Ws2_32.lib;Crypt32.lib;Shlwapi.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Netapi32.lib;Wtsapi32.lib;Comctl32.lib;Secur32.lib;Ws2_32.lib;Crypt32.lib;Shlwapi.lib;Winhttp.lib;Msimg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>copy config-msvc.h config.h</Command>
@@ -132,7 +132,7 @@
       <PreprocessorDefinitions>_INC_MATH;WIN32_LEAN_AND_MEAN;UNICODE;_UNICODE;_CRT_NON_CONFORMING_WCSTOK;HAVE_CONFIG_H</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Netapi32.lib;Wtsapi32.lib;Comctl32.lib;Secur32.lib;Ws2_32.lib;Crypt32.lib;Shlwapi.lib;Winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Netapi32.lib;Wtsapi32.lib;Comctl32.lib;Secur32.lib;Ws2_32.lib;Crypt32.lib;Shlwapi.lib;Winhttp.lib;Msimg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Ref: https://github.com/OpenVPN/openvpn-gui/pull/390#pullrequestreview-560539108
Lack of transparency of the image added in PR 390 kept bugging me too.. So this PR:

Combine the image and mask in the connecting-state icon to form a bitmap
with transparency for use as the checkmark.

MSDN docs on SetMenuItemBitmaps is unclear about the use of
color bitmaps for checkmarks, but this appears to display well.
(Tested on Windows 10 only).

Signed-off-by: Selva Nair <selva.nair@gmail.com>