### PR TITLE
Retry on management timeout instead of aborting

### DIFF
--- a/main.c
+++ b/main.c
@@ -188,6 +188,7 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
       { echo_,     OnEcho },
       { bytecount_,OnByteCount },
       { infomsg_,  OnInfoMsg },
+      { timeout_,  OnTimeout },
       { 0,        NULL }
   };
   InitManagement(handler);

--- a/manage.c
+++ b/manage.c
@@ -209,10 +209,9 @@ OnManagement(SOCKET sk, LPARAM lParam)
             else
             {
                 /* Connection to MI timed out. */
-                if (c->state != disconnected)
-                    c->state = timedout;
                 CloseManagement (c);
-                rtmsg_handler[stop_](c, "");
+                if (c->state != disconnected)
+                    rtmsg_handler[timeout_](c, "");
             }
         }
         else

--- a/manage.h
+++ b/manage.h
@@ -38,6 +38,7 @@ typedef enum {
     needstr_,
     pkcs11_id_count_,
     infomsg_,
+    timeout_,
     mgmt_rtmsg_type_max
 } mgmt_rtmsg_type;
 

--- a/openvpn.h
+++ b/openvpn.h
@@ -43,6 +43,7 @@ void OnNeedStr(connection_t *, char *);
 void OnEcho(connection_t *, char *);
 void OnByteCount(connection_t *, char *);
 void OnInfoMsg(connection_t*, char*);
+void OnTimeout(connection_t *, char *);
 
 void ResetSavePasswords(connection_t *);
 

--- a/options.h
+++ b/options.h
@@ -71,7 +71,6 @@ typedef enum {
     suspending,
     suspended,
     resuming,
-    timedout
 } conn_state_t;
 
 /* Interactive Service IO parameters */


### PR DESCRIPTION
In  some cases the service may take a while to startup openvpn.exe,
causing connection to the management interface to timeout. This could
leave  behind the OpenVPN process if/when it eventually starts up.
(Trac 905, 1050).

As errors in starting up the OpenVPN daemon are independently
handled, its better to keep retrying the management interface connection
until aborted due to errors or by the user.

- On timeout, log a message on the status window and retry the
  management interface connection

- Eliminate the timed-out state that is no longer used

- Call StopOpenVPN() before abort so that OpenVPN daemon
  is not left running in case it starts up later.

- In the unlikely event that OpenManagement() fails, show an error

- User can abort by pressing disconnect

A "retrying.." message is logged on to the status window every
15 seconds.

See Trac: #905, #1050

Signed-off-by: Selva Nair <selva.nair@gmail.com>