### PR TITLE
Do not allow empty password input

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -664,6 +664,9 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
         else
             SetForegroundWindow(hwndDlg);
 
+        /* disable OK button by default - not disabled in resources */
+        EnableWindow(GetDlgItem(hwndDlg, IDOK), FALSE);
+
         break;
 
     case WM_COMMAND:
@@ -672,6 +675,15 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
         char *fmt;
         switch (LOWORD(wParam))
         {
+        case ID_EDT_RESPONSE:
+            if (HIWORD(wParam) == EN_UPDATE)
+            {
+                /* enable OK if response is non-empty */
+                BOOL enableOK = GetWindowTextLength((HWND) lParam);
+                EnableWindow(GetDlgItem(hwndDlg, IDOK), enableOK);
+            }
+            break;
+
         case IDOK:
             if (GetDlgItemTextW(hwndDlg, ID_EDT_RESPONSE, password, _countof(password))
                 && !validate_input(password, L"\n"))
@@ -782,6 +794,9 @@ PrivKeyPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             ForceForegroundWindow(hwndDlg);
         else
             SetForegroundWindow(hwndDlg);
+
+        /* disable OK button by default - not disabled in resources */
+        EnableWindow(GetDlgItem(hwndDlg, IDOK), FALSE);
         break;
 
     case WM_COMMAND:
@@ -796,6 +811,15 @@ PrivKeyPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             {
                 Button_SetCheck (GetDlgItem (hwndDlg, ID_CHK_SAVE_PASS), BST_UNCHECKED);
                 DeleteSavedKeyPass(c->config_name);
+            }
+            break;
+
+        case ID_EDT_PASSPHRASE:
+            if (HIWORD(wParam) == EN_UPDATE)
+            {
+                /* enable OK if response is non-empty */
+                BOOL enableOK = GetWindowTextLength((HWND) lParam);
+                EnableWindow(GetDlgItem(hwndDlg, IDOK), enableOK);
             }
             break;
 

--- a/openvpn.c
+++ b/openvpn.c
@@ -519,15 +519,18 @@ UserAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
         switch (LOWORD(wParam))
         {
         case ID_EDT_AUTH_USER:
+        case ID_EDT_AUTH_PASS:
+        case ID_EDT_AUTH_CHALLENGE:
             if (HIWORD(wParam) == EN_UPDATE)
             {
-                int len = Edit_GetTextLength((HWND) lParam);
-                EnableWindow(GetDlgItem(hwndDlg, IDOK), (len ? TRUE : FALSE));
+                /* enable OK button only if username and either password or response are filled */
+                BOOL enableOK = GetWindowTextLength(GetDlgItem(hwndDlg, ID_EDT_AUTH_USER))
+                                && (GetWindowTextLength(GetDlgItem(hwndDlg, ID_EDT_AUTH_PASS))
+                                    || ((param->flags & FLAG_CR_TYPE_SCRV1)
+                                        && GetWindowTextLength(GetDlgItem(hwndDlg, ID_EDT_AUTH_CHALLENGE)))
+                                   );
+                EnableWindow(GetDlgItem(hwndDlg, IDOK), enableOK);
             }
-            AutoCloseCancel(hwndDlg); /* user interrupt */
-            break;
-
-        case ID_EDT_AUTH_PASS:
             AutoCloseCancel(hwndDlg); /* user interrupt */
             break;
 


### PR DESCRIPTION
- In User-Auth dialog require non-empty password or PIN
- In generic password dialogs require non-empty inputs
- Fix handling of dynamic challenge when response is not required

Issue: #417 