### PR TITLE
Allow clearing of key password in ChangePassphraseDialogFunc

### DIFF
--- a/passphrase.c
+++ b/passphrase.c
@@ -371,17 +371,18 @@ ChangePassphraseDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, UNUSED LPARAM 
               break;
             }
 
-          /* Check minimum length of password */
-          if (NewPasswordLengh(hwndDlg) < MIN_PASSWORD_LEN)
+          /* Confirm if the new password is empty. */
+          if (NewPasswordLengh(hwndDlg) == 0)
+            {
+               if (ShowLocalizedMsgEx(MB_YESNO, _T(PACKAGE_NAME), IDS_NFO_EMPTY_PWD) == IDNO)
+                  break;
+            }
+          /* Else check minimum length of password */
+          else if (NewPasswordLengh(hwndDlg) < MIN_PASSWORD_LEN)
             {
               ShowLocalizedMsg(IDS_ERR_PWD_TO_SHORT, MIN_PASSWORD_LEN);
               break;
             }
-
-          /* Confirm if the new password is empty. */
-          if (NewPasswordLengh(hwndDlg) == 0
-          && ShowLocalizedMsgEx(MB_YESNO, _T(PACKAGE_NAME), IDS_NFO_EMPTY_PWD) == IDNO)
-            break;
 
           GetDlgItemText(hwndDlg, ID_TXT_KEYFILE, keyfile, _countof(keyfile) - 1);
           keyfile_format=GetDlgItemInt(hwndDlg, ID_TXT_KEYFORMAT, &Translated, FALSE);


### PR DESCRIPTION
Use an empty password to clear any existing password in the
private key file. If not empty, the requirement of minimum 8
characters is retained.

For PEM key file, an empty password will clear encryption on
the key. For pkcs12 files it will set an empty password.
As use of an empty password is the default first try in
OpenVPN.exe when reading pkcs12 file, this effectively leads
to the user not prompted for a private key password during
connection setup.

Signed-off-by: Selva Nair <selva.nair@gmail.com>

See #422 