### PR TITLE
Have unique and non-zero IDs for all controls

### DIFF
--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -30,10 +30,15 @@
 
 /* About Dialog */
 #define ID_DLG_ABOUT                     100
+#define ID_ICON_ABOUT                    110
+#define ID_LTEXT_ABOUT2                  122
+#define ID_LTEXT_ABOUT3                  123
+#define ID_LTEXT_ABOUT4                  124
 
 /* Ask for Passphrase Dialog */
 #define ID_DLG_PASSPHRASE                150
 #define ID_EDT_PASSPHRASE                151
+#define ID_LTEXT_PASSWORD                152
 
 /* Status Dialog */
 #define ID_DLG_STATUS                    160
@@ -65,6 +70,8 @@
 #define ID_EDT_AUTH_CHALLENGE            185
 #define ID_CHK_SAVE_PASS                 186
 #define ID_TXT_WARNING                   187
+#define ID_LTEXT_USERNAME                188
+#define ID_LTEXT_RESPONSE                189
 
 /* Challenege Response Dialog */
 #define ID_DLG_CHALLENGE_RESPONSE        190
@@ -73,6 +80,12 @@
 
 /* Proxy Settings Dialog */
 #define ID_DLG_PROXY                     200
+#define ID_GROUPBOX1                     201
+#define ID_GROUPBOX2                     202
+#define ID_GROUPBOX3                     203
+#define ID_GROUPBOX4                     204
+#define ID_LTEXT_PORT_OFFSET             205
+#define ID_GROUPBOX5                     206
 #define ID_RB_PROXY_OPENVPN              210
 #define ID_RB_PROXY_MSIE                 211
 #define ID_RB_PROXY_MANUAL               212
@@ -120,6 +133,7 @@
 #define ID_EDT_CONNECT_TIMEOUT           283
 #define ID_EDT_DISCONNECT_TIMEOUT        284
 #define ID_EDT_MGMT_PORT                 285
+#define ID_TXT_FOLDER1                   286
 
 /* Connections dialog */
 #define ID_DLG_CONNECTIONS               290

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -43,8 +43,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Jméno:", 0, 6, 9, 50, 10
-    LTEXT "Heslo:", 0, 6, 26, 50, 10
+    LTEXT "Jméno:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Heslo:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Uložit heslo", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -60,9 +60,9 @@ CAPTION "OpenVPN - Ověření uživatele"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Jméno:", 0, 6, 9, 50, 10
-    LTEXT "Heslo:", 0, 6, 26, 50, 10
-    LTEXT "Odpověď:", 0, 6, 60, 50, 10
+    LTEXT "Jméno:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Heslo:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Odpověď:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -81,7 +81,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Odpověď:", 0, 6, 30, 50, 10
+    LTEXT "Odpověď:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Zrušit", IDCANCEL, 90, 51, 52, 14
@@ -157,7 +157,7 @@ BEGIN
     GROUPBOX "Spuštění", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Spustit při startu Windows", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Volby", 202, 6, 82, 235, 105
+    GROUPBOX "Volby", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Připojovat záznamy na konec logu", ID_CHK_LOG_APPEND, 17, 95, 130, 10
     AUTOCHECKBOX "Zobrazit okno skriptu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Tiché spojení", ID_CHK_SILENT, 17, 125, 200, 10
@@ -183,7 +183,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Logy", 202, 6, 62, 235, 30
-    LTEXT "Složka:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Složka:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -212,19 +212,19 @@ CAPTION "O aplikaci"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - GUI pro OpenVPN ve Windows\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI přispěvatelé\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - Aplikace pro vytváření bezpečných tunelů sítí IP \
 přes jediný port TCP/UDP s podporou SSL/TLS autentifikace sezení \
 a výměn klíčů, šifrování paketů, autentifikace paketů \
 a komprese paketů.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -43,9 +43,9 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_GERMAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "&Benutzer:", 0, 6, 9, 50, 10
+    LTEXT "&Benutzer:", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "&Passwort:", 0, 6, 26, 50, 10
+    LTEXT "&Passwort:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Passwort &speichern", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "&OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
@@ -60,11 +60,11 @@ CAPTION "OpenVPN – Benutzer-Authentifizierung"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_GERMAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "&Benutzer:", 0, 6, 9, 50, 10
+    LTEXT "&Benutzer:", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "&Passwort:", 0, 6, 26, 50, 10
+    LTEXT "&Passwort:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
-    LTEXT "&Response:", 0, 6, 60, 50, 10
+    LTEXT "&Response:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
     EDITTEXT ID_EDT_AUTH_CHALLENGE, 60, 57, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Passwort &speichern", ID_CHK_SAVE_PASS, 6, 76, 100, 10
@@ -81,7 +81,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_GERMAN, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "&Response:", 0, 6, 30, 50, 10
+    LTEXT "&Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "&OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "&Abbrechen", IDCANCEL, 90, 51, 52, 14
@@ -154,7 +154,7 @@ BEGIN
     LTEXT "Spr&ache:", ID_TXT_LANGUAGE, 17, 25, 29, 12
     COMBOBOX ID_CMB_LANGUAGE, 51, 23, 177, 400, CBS_DROPDOWNLIST | WS_TABSTOP
 
-    GROUPBOX "Einstellungen", 202, 6, 82, 235, 105
+    GROUPBOX "Einstellungen", ID_GROUPBOX3, 6, 82, 235, 105
     GROUPBOX "Systemstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Mit &Windows starten", ID_CHK_STARTUP, 17, 59, 200, 12
 
@@ -184,7 +184,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Logdateien", 202, 6, 62, 235, 30
-    LTEXT "O&rdner:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "O&rdner:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -213,20 +213,20 @@ CAPTION "Über"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_GERMAN, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s – Eine grafische Benutzeroberfläche für OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 50
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 50
     LTEXT "OpenVPN – Eine Applikation zum sicheren Tunneln eines IP-\
 Netzwerks über einen einzelnen TCP/UDP-Port, mit Unterstützung \
 von SSL/TLS-basierter Session-Authentisierung, Schlüssel-\
 austausch, Paketverschlüsselung, Paket-Authentisierung und \
 Paket-Kompression.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -44,8 +44,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DANISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Brugernavn:", 0, 6, 9, 50, 10
-    LTEXT "Kodeord:", 0, 6, 26, 50, 10
+    LTEXT "Brugernavn:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Kodeord:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Husk kodeord", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -61,9 +61,9 @@ CAPTION "OpenVPN - User Authentication"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DANISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Brugernavn:", 0, 6, 9, 50, 10
-    LTEXT "Kodeord:", 0, 6, 26, 50, 10
-    LTEXT "Response:", 0, 6, 60, 50, 10
+    LTEXT "Brugernavn:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Kodeord:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -82,7 +82,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DANISH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Response:", 0, 6, 30, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Annuller", IDCANCEL, 90, 51, 52, 14
@@ -157,7 +157,7 @@ BEGIN
     GROUPBOX "Autostart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Start med Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Indstillinger", 202, 6, 82, 235, 105
+    GROUPBOX "Indstillinger", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Tilføj til log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Vis script vindue", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille forbindelse", ID_CHK_SILENT, 17, 125, 200, 10
@@ -183,7 +183,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Log Filer", 202, 6, 62, 235, 30
-    LTEXT "Mappe:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Mappe:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -212,19 +212,19 @@ CAPTION "Om"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DANISH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - Et Windows-brugerprogram til OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 50
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 50
     LTEXT "OpenVPN - Et program til sikker overførsel af IP netværk \
 over en enkelt TCP/UDP port, med støtte til SSL/TLS-baseret \
 sessions autentisering og nøgle håndtering, pakke- \
 kryptering, -autentisering og -komprimering.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -43,9 +43,9 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "&Username:", 0, 6, 9, 50, 10
+    LTEXT "&Username:", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "&Password:", 0, 6, 26, 50, 10
+    LTEXT "&Password:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "&Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "&OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
@@ -60,11 +60,11 @@ CAPTION "OpenVPN – User Authentication"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "&Username:", 0, 6, 9, 50, 10
+    LTEXT "&Username:", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "&Password:", 0, 6, 26, 50, 10
+    LTEXT "&Password:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
-    LTEXT "&Response:", 0, 6, 60, 50, 10
+    LTEXT "&Response:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
     EDITTEXT ID_EDT_AUTH_CHALLENGE, 60, 57, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "&Save password", ID_CHK_SAVE_PASS, 6, 76, 100, 10
@@ -81,7 +81,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "&Response:", 0, 6, 30, 50, 10
+    LTEXT "&Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "&OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "&Cancel", IDCANCEL, 90, 51, 52, 14
@@ -172,7 +172,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on User &Logon", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 105
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "A&ppend to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script &window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "S&ilent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -198,7 +198,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Log Files", 202, 6, 62, 235, 30
-    LTEXT "F&older:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "F&older:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -227,19 +227,19 @@ CAPTION "About"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s – A Windows GUI for OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN – An application to securely tunnel IP networks \
 over a single TCP/UDP port, with support for SSL/TLS-based \
 session authentication and key exchange, packet \
 encryption, packet authentication, and packet compression.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -42,8 +42,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SPANISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Usuario:", 0, 6, 9, 50, 10
-    LTEXT "Password:", 0, 6, 26, 50, 10
+    LTEXT "Usuario:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Password:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -59,9 +59,9 @@ CAPTION "OpenVPN - User Authentication"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SPANISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Usuario:", 0, 6, 9, 50, 10
-    LTEXT "Password:", 0, 6, 26, 50, 10
-    LTEXT "Response:", 0, 6, 60, 50, 10
+    LTEXT "Usuario:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Password:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -80,7 +80,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SPANISH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Response:", 0, 6, 30, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Cancelar", IDCANCEL, 90, 51, 52, 14
@@ -155,7 +155,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 105
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -181,7 +181,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Log Files", 202, 6, 62, 235, 30
-    LTEXT "Folder:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Folder:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -210,19 +210,19 @@ CAPTION "Acerca de"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SPANISH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - Un frontend de Windows para OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 50
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 50
     LTEXT "OpenVPN - Una aplicación para tunelizar de forma segura redes IP \
 contra un puerto TCP/UDP, con soporte para autenticación de sesión basada \
 en SSL/TLS e intercambio de claves, encriptación de paquetes, con \
 encriptación de paquetes y compresión de paquetes opcional.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -44,9 +44,9 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FARSI, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "نام کاربری :", 0, 6, 9, 50, 10
+    LTEXT "نام کاربری :", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "رمز عبور :", 0, 6, 26, 50, 10
+    LTEXT "رمز عبور :", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "نگه داشتن رمز عبور", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "بسیار خوب", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
@@ -61,11 +61,11 @@ CAPTION "OpenVPN – احراز هویت کاربر"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FARSI, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "نام کاربری :", 0, 6, 9, 50, 10
+    LTEXT "نام کاربری :", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "رمز عبور :", 0, 6, 26, 50, 10
+    LTEXT "رمز عبور :", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
-    LTEXT "پاسخ :", 0, 6, 60, 50, 10
+    LTEXT "پاسخ :", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
     EDITTEXT ID_EDT_AUTH_CHALLENGE, 60, 57, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "نگه داشتن رمز عبور", ID_CHK_SAVE_PASS, 6, 76, 100, 10
@@ -82,7 +82,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FARSI, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "پاسخ :", 0, 6, 30, 50, 10
+    LTEXT "پاسخ :", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "بسیار خوب", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "لغو", IDCANCEL, 90, 51, 52, 14
@@ -159,7 +159,7 @@ BEGIN
     GROUPBOX "شروع به کار", 202, 6, 47, 235, 30
     AUTOCHECKBOX "شروع به کار - وقتی کاربر وارد شد", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "تنظیمات", 202, 6, 82, 235, 105
+    GROUPBOX "تنظیمات", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "چسباندن به گزارشات", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "نمایش پنجره اسکریپت", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "بی صدا(اعلان) متصل شدن", ID_CHK_SILENT, 17, 125, 200, 10
@@ -185,7 +185,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "سند گزارشات", 202, 6, 62, 235, 30
-    LTEXT "پوشه :", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "پوشه :", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -214,19 +214,19 @@ CAPTION "درباره"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FARSI, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s – یک رابط کاربر گرفیکی برای کانکشن OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI مشارکت کنندگان\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN – برنامه ای برای تونل ایمن شبکه های آی پی \
 با پشتیبانی از پورت های : TCP/UDP , به همراه SSL/TLS-based \
 جلسه احراز هویت و تغییر کلید و بسته ها \
 رمز نگاری و بسته احراز هویت و بسته فشرده سازی.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 شرکت،تکنولوژی OpenVPN <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -43,8 +43,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FINNISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Käyttäjänimi:", 0, 6, 9, 50, 10
-    LTEXT "Salasana:", 0, 6, 26, 50, 10
+    LTEXT "Käyttäjänimi:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Salasana:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Tallenna salasana", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -60,9 +60,9 @@ CAPTION "OpenVPN - Käyttäjän todennus"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FINNISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Käyttäjänimi:", 0, 6, 9, 50, 10
-    LTEXT "Salasana:", 0, 6, 26, 50, 10
-    LTEXT "Vastaus:", 0, 6, 60, 50, 10
+    LTEXT "Käyttäjänimi:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Salasana:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Vastaus:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -81,7 +81,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FINNISH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Vastaus:", 0, 6, 30, 50, 10
+    LTEXT "Vastaus:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Peruuta", IDCANCEL, 90, 51, 52, 14
@@ -156,7 +156,7 @@ BEGIN
     GROUPBOX "Käynnistäminen", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Käynnistä Windowsiin kirjautuessa", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Valinnat", 202, 6, 82, 235, 105
+    GROUPBOX "Valinnat", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Lisää lokitiedostoon", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Näytä komentosarjaikkuna", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Yhdistä taustalla", ID_CHK_SILENT, 17, 125, 200, 10
@@ -182,7 +182,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Lokitiedostot", 202, 6, 62, 235, 30
-    LTEXT "Kansio:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Kansio:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -211,19 +211,19 @@ CAPTION "Tietoja"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FINNISH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - Graafinen käyttöliittymä OpenVPN:lle\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN mahdollistaa IP-verkkojen yhdistämisen toisiinsa \
 suojatulla TCP/UDP-yhteydellä. Se tukee mm. SSL/TLS\
 -pohjaista istuntojen todennusta ja avainten vaihtoa \
 sekä pakettien salausta, todennusta ja pakkausta.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -42,8 +42,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FRENCH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Utilisateur:", 0, 6, 9, 50, 10
-    LTEXT "Mot de passe:", 0, 6, 26, 50, 10
+    LTEXT "Utilisateur:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Mot de passe:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Se souvenir du mot de passe", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -59,9 +59,9 @@ CAPTION "OpenVPN - User Authentication"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FRENCH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Utilisateur:", 0, 6, 9, 50, 10
-    LTEXT "Mot de passe:", 0, 6, 26, 50, 10
-    LTEXT "Réponse:", 0, 6, 60, 50, 10
+    LTEXT "Utilisateur:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Mot de passe:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Réponse:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -80,7 +80,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FRENCH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Réponse:", 0, 6, 30, 50, 10
+    LTEXT "Réponse:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Annuler", IDCANCEL, 90, 51, 52, 14
@@ -156,7 +156,7 @@ BEGIN
     GROUPBOX "Démarrage", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Lancer au démarrage de Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Préférences", 202, 6, 82, 235, 105
+    GROUPBOX "Préférences", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Ajouter au fichier log", ID_CHK_LOG_APPEND, 17, 95, 81, 10
     AUTOCHECKBOX "Afficher la fenêtre des scripts", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connexion silencieuse", ID_CHK_SILENT, 17, 125, 200, 10
@@ -182,7 +182,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Fichiers log", 202, 6, 62, 235, 30
-    LTEXT "Dossier:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Dossier:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -211,19 +211,19 @@ CAPTION "A Propos"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FRENCH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - A Windows GUI for OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - Une application permettant d'ouvrir un tunnel IP sécurisé \
 sur un simple port TCP/UDP avec un support SSL/TLS pour l'authentification de \
 session, échange de clés, cryptage de paquets, authentification des \
 paquets, et compression de paquets.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -42,8 +42,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ITALIAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Nome &utente:", 0, 6, 9, 50, 10
-    LTEXT "&Password:", 0, 6, 26, 50, 10
+    LTEXT "Nome &utente:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "&Password:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "&Ricorda password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -59,11 +59,11 @@ CAPTION "OpenVPN - Autenticazione utente"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ITALIAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Nome &utente:", 0, 6, 9, 50, 10
+    LTEXT "Nome &utente:", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "&Password:", 0, 6, 26, 50, 10
+    LTEXT "&Password:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
-    LTEXT "&Risposta:", 0, 6, 60, 50, 10
+    LTEXT "&Risposta:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
     EDITTEXT ID_EDT_AUTH_CHALLENGE, 60, 57, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "&Ricorda password", ID_CHK_SAVE_PASS, 6, 76, 100, 10
@@ -80,7 +80,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ITALIAN, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "&Risposta:", 0, 6, 30, 50, 10
+    LTEXT "&Risposta:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "&OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "&Annulla", IDCANCEL, 90, 51, 52, 14
@@ -156,7 +156,7 @@ BEGIN
     GROUPBOX "Avvio", 202, 6, 47, 235, 30
     AUTOCHECKBOX "&Avvia all'apertura di Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferenze", 202, 6, 82, 235, 135
+    GROUPBOX "Preferenze", ID_GROUPBOX3, 6, 82, 235, 135
     AUTOCHECKBOX "Aggiungi in coda al f&ile di log", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Mostra &finestra script", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connessione &silenziosa", ID_CHK_SILENT, 17, 125, 200, 10
@@ -182,7 +182,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "File di log", 202, 6, 62, 235, 30
-    LTEXT "C&artella:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "C&artella:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -211,19 +211,19 @@ CAPTION "Informazioni"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ITALIAN, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - Interfaccia per Windows di OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 50
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 50
           
     LTEXT "OpenVPN - Un'applicazione che permette di creare tunnel sicuri su reti IP \
 con una singola porta TCP/UDP, con il supporto basato sull'autenticazione e lo scambio \
 di chiavi SSL/TLS, cifratura, autenticazione e compressione dei pacchetti.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -45,8 +45,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "ユーザー名:", 0, 6, 9, 50, 10
-    LTEXT "パスワード:", 0, 6, 26, 50, 10
+    LTEXT "ユーザー名:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "パスワード:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -62,9 +62,9 @@ CAPTION "OpenVPN - User Authentication"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "ユーザー名:", 0, 6, 9, 50, 10
-    LTEXT "パスワード:", 0, 6, 26, 50, 10
-    LTEXT "Response:", 0, 6, 60, 50, 10
+    LTEXT "ユーザー名:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "パスワード:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -82,7 +82,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Response:", 0, 6, 30, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "キャンセル", IDCANCEL, 90, 51, 52, 14
@@ -157,7 +157,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 105
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "ログファイルに追記", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "スクリプト実行ウィンドウを表示する", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "接続時にステータスダイアログを表示しない", ID_CHK_SILENT, 17, 125, 200, 10
@@ -183,7 +183,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "ログファイル", 202, 6, 62, 235, 30
-    LTEXT "ディレクトリ:", ID_TXT_FOLDER, 17, 74, 52, 10
+    LTEXT "ディレクトリ:", ID_TXT_FOLDER1, 17, 74, 52, 10
     EDITTEXT ID_EDT_LOG_DIR, 58, 72, 145, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -212,19 +212,19 @@ CAPTION "バージョン情報"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - A Windows GUI for OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - An application to securely tunnel IP networks \
 over a single TCP/UDP port, with support for SSL/TLS-based \
 session authentication and key exchange, packet \
 encryption, packet authentication, and packet compression.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -44,8 +44,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 9, "맑은 고딕"
 LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "사용자:", 0, 6, 9, 30, 10
-    LTEXT "암호:", 0, 6, 26, 30, 10
+    LTEXT "사용자:", ID_LTEXT_USERNAME, 6, 9, 30, 10
+    LTEXT "암호:", ID_LTEXT_PASSWORD, 6, 26, 30, 10
     EDITTEXT ID_EDT_AUTH_USER, 35, 6, 115, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 35, 23, 115, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "암호 저장", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -61,11 +61,11 @@ CAPTION "OpenVPN - 사용자 인증"
 FONT 9, "맑은 고딕"
 LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "사용자:", 0, 6, 9, 50, 10
+    LTEXT "사용자:", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "암호:", 0, 6, 26, 50, 10
+    LTEXT "암호:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
-    LTEXT "요청값:", 0, 6, 60, 50, 10
+    LTEXT "요청값:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
     EDITTEXT ID_EDT_AUTH_CHALLENGE, 60, 57, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "암호 저장", ID_CHK_SAVE_PASS, 6, 76, 100, 10
@@ -82,7 +82,7 @@ FONT 9, "맑은 고딕"
 LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "요청값:", 0, 6, 30, 50, 10
+    LTEXT "요청값:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "확인", IDOK, 25, 58, 50, 14, BS_PUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "취소", IDCANCEL, 85, 58, 52, 14
@@ -158,7 +158,7 @@ BEGIN
     GROUPBOX "시작 설정", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Windows 시작 시에 실행", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "환경 설정", 202, 6, 82, 235, 105
+    GROUPBOX "환경 설정", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "로그 파일에 추가", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "스크립트 창 보기", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "연결 시 상태 대화 상자 표시하지 않기", ID_CHK_SILENT, 17, 125, 200, 10
@@ -184,7 +184,7 @@ BEGIN
     PUSHBUTTON "선택", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "로그 파일", 202, 6, 62, 235, 30
-    LTEXT "폴더:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "폴더:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "선택", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -213,18 +213,18 @@ CAPTION "정보"
 FONT 9, "맑은 고딕"
 LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - A Windows GUI for OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - SSL/TLS 기반의 세션 인증, 키 교환, 패킷 암호화, \
 패킷 인증 및 패킷 압축을 지원하여 단일 TCP/UDP 포트를 통해 \
 IP 네트워크를 안전하게 터널링하는 응용 프로그램 입니다.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -42,9 +42,9 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DUTCH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Gebruikersnaam:", 0, 6, 9, 54, 10
+    LTEXT "Gebruikersnaam:", ID_LTEXT_USERNAME, 6, 9, 54, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "Wachtwoord:", 0, 6, 26, 50, 10
+    LTEXT "Wachtwoord:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Wachtwoord opslaan", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "OK", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
@@ -59,11 +59,11 @@ CAPTION "OpenVPN - Gebruikersauthenticatie"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DUTCH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Gebruikersnaam:", 0, 6, 9, 54, 10
+    LTEXT "Gebruikersnaam:", ID_LTEXT_USERNAME, 6, 9, 54, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "Wachtwoord:", 0, 6, 26, 50, 10
+    LTEXT "Wachtwoord:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
-    LTEXT "Response:", 0, 6, 60, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
     EDITTEXT ID_EDT_AUTH_CHALLENGE, 60, 57, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Wachtwoord opslaan", ID_CHK_SAVE_PASS, 6, 76, 100, 10
@@ -80,7 +80,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DUTCH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Response:", 0, 6, 30, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Annuleren", IDCANCEL, 90, 51, 52, 14
@@ -157,7 +157,7 @@ BEGIN
     GROUPBOX "Opstarten", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Opstarten met Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Voorkeuren", 202, 6, 82, 235, 105
+    GROUPBOX "Voorkeuren", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Aan logbestand toevoegen", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Script-venster tonen", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille verbinding", ID_CHK_SILENT, 17, 125, 200, 10
@@ -183,7 +183,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Logbestanden", 202, 6, 62, 235, 30
-    LTEXT "Map:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Map:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -212,19 +212,19 @@ CAPTION "Info"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DUTCH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - Een Windows GUI voor OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - Een programma om veilig IP-netwerken te tunnelen \
 over een enkele TCP/UDP poort, met ondersteuning voor SSL/TLS-gebaseerde \
 sessie-authenticatie en sleuteluitwisseling, pakketversleuteling, \
 pakket-authenticatie en pakketcompressie.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -43,8 +43,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_NORWEGIAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Brukernavn:", 0, 6, 9, 50, 10
-    LTEXT "Passord:", 0, 6, 26, 50, 10
+    LTEXT "Brukernavn:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Passord:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Husk passord", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -60,9 +60,9 @@ CAPTION "OpenVPN - Brukerautentisering"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_NORWEGIAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Brukernavn:", 0, 6, 9, 50, 10
-    LTEXT "Passord:", 0, 6, 26, 50, 10
-    LTEXT "Respons:", 0, 6, 60, 50, 10
+    LTEXT "Brukernavn:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Passord:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Respons:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -81,7 +81,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_NORWEGIAN, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Response:", 0, 6, 30, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Avbryt", IDCANCEL, 90, 51, 52, 14
@@ -156,7 +156,7 @@ BEGIN
     GROUPBOX "Oppstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Kjør automatisk når Windows starter", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Innstillinger", 202, 6, 82, 235, 105
+    GROUPBOX "Innstillinger", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Tilføy til eksisterende logg", ID_CHK_LOG_APPEND, 17, 95, 93, 10
     AUTOCHECKBOX "Vis scriptvindu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Skjul statusvindu ved tilkobling", ID_CHK_SILENT, 17, 125, 200, 10
@@ -182,7 +182,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 211, 23, 25, 12
 
     GROUPBOX "Loggfiler", 202, 6, 62, 235, 30
-    LTEXT "Mappe:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Mappe:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -211,19 +211,19 @@ CAPTION "Om"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_NORWEGIAN, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - Et Windows-grensesnitt mot OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 50
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 50
     LTEXT "OpenVPN - En applikasjon for sikker kommunikasjon mellom nettverk over en usikker \
 kommunikasjonskanal på én enkelt port, med støtte for SSL/TLS-basert \
 sesjonsautentisering og nøkkelhåndtering, pakkekryptering,  \
 -autentisering og -komprimering.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -44,8 +44,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Użytkownik:", 0, 6, 9, 50, 10
-    LTEXT "Hasło:", 0, 6, 26, 50, 10
+    LTEXT "Użytkownik:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Hasło:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Zapisz hasło", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -61,9 +61,9 @@ CAPTION "OpenVPN - Uwierzytelnienie użytkownika"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Użytkownik:", 0, 6, 9, 50, 10
-    LTEXT "Hasło:", 0, 6, 26, 50, 10
-    LTEXT "Odpowiedź:", 0, 6, 60, 50, 10
+    LTEXT "Użytkownik:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Hasło:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Odpowiedź:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -82,7 +82,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Odpowiedź:", 0, 6, 30, 50, 10
+    LTEXT "Odpowiedź:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Anuluj", IDCANCEL, 90, 51, 52, 14
@@ -157,7 +157,7 @@ BEGIN
     GROUPBOX "Uruchamianie", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Uruchamiaj po zalogowaniu się użytkownika", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferencje", 202, 6, 82, 235, 105
+    GROUPBOX "Preferencje", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Dodaj do dziennika", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Pokaż okno skryptu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Połączenie dyskretne", ID_CHK_SILENT, 17, 125, 200, 10
@@ -183,7 +183,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Pliki dziennika", 202, 6, 62, 235, 30
-    LTEXT "Folder:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Folder:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -212,19 +212,19 @@ CAPTION "O programie"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - Windows GUI dla OpenVPN-a\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - Aplikacja do bezpiecznego tunelowania sieci IP\
 przy pomocy pojedynczego portu TCP/UDP, z autentykacją sesji,\
 wymianą klucza, szyfrowaniem, kompresją i autentykacją\
 pakietów opartą na protokole SSL/TLS\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -42,8 +42,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_PORTUGUESE, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Usuário:", 0, 6, 9, 50, 10
-    LTEXT "Senha:", 0, 6, 26, 50, 10
+    LTEXT "Usuário:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Senha:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Salvar senha", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -59,9 +59,9 @@ CAPTION "OpenVPN - Autenticação de usuário"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_PORTUGUESE, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Usuário:", 0, 6, 9, 50, 10
-    LTEXT "Senha:", 0, 6, 26, 50, 10
-    LTEXT "Resposta:", 0, 6, 60, 50, 10
+    LTEXT "Usuário:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Senha:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Resposta:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -80,7 +80,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_PORTUGUESE, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Resposta:", 0, 6, 30, 50, 10
+    LTEXT "Resposta:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Cancelar", IDCANCEL, 90, 51, 52, 14
@@ -155,7 +155,7 @@ BEGIN
     GROUPBOX "Inicialização", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Executar ao iniciar o Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferências", 202, 6, 82, 235, 105
+    GROUPBOX "Preferências", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Anexar ao log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Mostrar janela de script", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Conexão silenciosa", ID_CHK_SILENT, 17, 125, 200, 10
@@ -181,7 +181,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Arquivos de Log", 202, 6, 62, 235, 30
-    LTEXT "Pasta:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Pasta:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -210,19 +210,19 @@ CAPTION "Sobre"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_PORTUGUESE, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - Interface Windows para o OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 Colaboradores do OpenVPN GUI\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - Um aplicativo para direcionar de forma segura os \
 IPs de rede sobre uma única porta TCP/UDP, com suporte para \
 autenticação de sessão e troca de chave, criptografia de pacotes, \
 autenticação de pacotes e compressão de pacotes baseada em SSL/TLS.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -44,8 +44,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Имя пользователя:", 0, 6, 9, 70, 10
-    LTEXT "Пароль:", 0, 6, 26, 70, 10
+    LTEXT "Имя пользователя:", ID_LTEXT_USERNAME, 6, 9, 70, 10
+    LTEXT "Пароль:", ID_LTEXT_PASSWORD, 6, 26, 70, 10
     EDITTEXT ID_EDT_AUTH_USER, 80, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 80, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Запомнить", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -61,9 +61,9 @@ CAPTION "OpenVPN - Аутентификация пользователя"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Имя пользователя:", 0, 6, 9, 50, 10
-    LTEXT "Пароль:", 0, 6, 26, 50, 10
-    LTEXT "Ответный код:", 0, 6, 60, 50, 10
+    LTEXT "Имя пользователя:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Пароль:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Ответный код:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -82,7 +82,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Response:", 0, 6, 30, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Отмена", IDCANCEL, 90, 51, 52, 14
@@ -158,7 +158,7 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускать при старте Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Настройки", 202, 6, 82, 235, 105
+    GROUPBOX "Настройки", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Дописывать, а не перезаписывать журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показывать окно выполнения", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихое» подключение", ID_CHK_SILENT, 17, 125, 200, 10
@@ -184,7 +184,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Файлы журнала", 202, 6, 62, 235, 30
-    LTEXT "Папка:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Папка:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 63, 72, 140, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -213,19 +213,19 @@ CAPTION "О программе"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - графический интерфейс OpenVPN для Windows\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 50
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 50
     LTEXT "OpenVPN - приложение для безопасного туннелирования IP-сетей \
 через единственный UDP или TCP-порт с поддержкой аутентификации сессий \
 и обмена ключами на основе SSL/TLS, шифрования, аутентификации \
 и сжатия пакетов.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -42,8 +42,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SWEDISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Användarnamn:", 0, 6, 9, 50, 10
-    LTEXT "Lösenord:", 0, 6, 26, 50, 10
+    LTEXT "Användarnamn:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Lösenord:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -59,9 +59,9 @@ CAPTION "OpenVPN - User Authentication"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SWEDISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Användarnamn:", 0, 6, 9, 50, 10
-    LTEXT "Lösenord:", 0, 6, 26, 50, 10
-    LTEXT "Response:", 0, 6, 60, 50, 10
+    LTEXT "Användarnamn:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Lösenord:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -80,7 +80,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SWEDISH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Response:", 0, 6, 30, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Avbryt", IDCANCEL, 90, 51, 52, 14
@@ -155,7 +155,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 105
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -181,7 +181,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Log Files", 202, 6, 62, 235, 30
-    LTEXT "Folder:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Folder:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -210,19 +210,19 @@ CAPTION "Om"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SWEDISH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - Ett Windows GUI för OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - En applikation för säker överföring av IP nät \
 över en enda TCP/UDP port, med support för SSL/TLS-baserad \
 session autentisering och nyckel hantering, paket \
 kryptering, paket autentisering, and paket komprimering.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -44,8 +44,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Kullanıcı Adı:", 0, 6, 9, 50, 10
-    LTEXT "Şifre:", 0, 6, 26, 50, 10
+    LTEXT "Kullanıcı Adı:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Şifre:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 50, 6, 104, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 50, 23, 104, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -61,9 +61,9 @@ CAPTION "OpenVPN - User Authentication"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Kullanıcı Adı:", 0, 6, 9, 50, 10
-    LTEXT "Şifre:", 0, 6, 26, 50, 10
-    LTEXT "Response:", 0, 6, 60, 50, 10
+    LTEXT "Kullanıcı Adı:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Şifre:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -82,7 +82,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Response:", 0, 6, 30, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "Tamam", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Çıkış", IDCANCEL, 90, 51, 52, 14
@@ -157,7 +157,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", 202, 6, 82, 235, 105
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -183,7 +183,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Log Files", 202, 6, 62, 235, 30
-    LTEXT "Folder:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Folder:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -212,19 +212,19 @@ CAPTION "Hakkında"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - OpenVPN için Windows Arayüzü\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - SSL/TLS tabanlı güvenli oturumlar, anahtar doğrulama \
 paket şifreleme, paket sıkıştırma ve paket doğrulama işlemlerini \
 tek bir TCP/UDP portu üzerinden güvenli IP tünelleri oluşturarak \
 yapabilen bir uygulamadır.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -42,8 +42,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_UKRAINIAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Ім'я користувача:", 0, 6, 9, 70, 10
-    LTEXT "Пароль:", 0, 6, 26, 70, 10
+    LTEXT "Ім'я користувача:", ID_LTEXT_USERNAME, 6, 9, 70, 10
+    LTEXT "Пароль:", ID_LTEXT_PASSWORD, 6, 26, 70, 10
     EDITTEXT ID_EDT_AUTH_USER, 80, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 80, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "Запам'ятати", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -59,9 +59,9 @@ CAPTION "OpenVPN - Аутентіфикація користувача"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_UKRAINIAN, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "Ім'я користувача:", 0, 6, 9, 50, 10
-    LTEXT "Пароль:", 0, 6, 26, 50, 10
-    LTEXT "Код відповіді:", 0, 6, 60, 50, 10
+    LTEXT "Ім'я користувача:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "Пароль:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "Код відповіді:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -80,7 +80,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_UKRAINIAN, SUBLANG_DEFAULT
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "Response:", 0, 6, 30, 50, 10
+    LTEXT "Response:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "OK", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "Скасувати", IDCANCEL, 90, 51, 52, 14
@@ -156,7 +156,7 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускати при старті Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Налаштування", 202, 6, 82, 235, 105
+    GROUPBOX "Налаштування", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "Додати, а не перезаписувати журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показывати вікно виконання", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихе» підключення", ID_CHK_SILENT, 17, 125, 200, 10
@@ -182,7 +182,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "Файли журнала", 202, 6, 62, 235, 30
-    LTEXT "Папка:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "Папка:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 63, 72, 140, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -211,20 +211,20 @@ CAPTION "Про программне забеспечення OPENVPN"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_UKRAINIAN, SUBLANG_DEFAULT
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - графічний інтерфейс Windows для OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN - программне забеспечення, для безпечного тунелювання IP-мереж \
 через єдиний UDP або TCP-порт із підтримкою підтверження достовірності сесій \
 і пересилання(обміном) ключів SSL/TLS, шифруванням, аутентіфікацієй \
 і з компрессією пакетів.\n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "Copyright (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
 With support from - За підтримки - При подддержке http://picku.pp.ua/\n\
-https://openvpn.net/", 0, 8, 106, 240, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 240, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -45,9 +45,9 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 BEGIN
-    LTEXT "用户名称:", 0, 6, 9, 50, 10
+    LTEXT "用户名称:", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "密码:", 0, 6, 26, 50, 10
+    LTEXT "密码:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "保存密码", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "确定", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
@@ -62,11 +62,11 @@ CAPTION "OpenVPN - 用户认证"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 BEGIN
-    LTEXT "用户名称:", 0, 6, 9, 50, 10
+    LTEXT "用户名称:", ID_LTEXT_USERNAME, 6, 9, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
-    LTEXT "密码:", 0, 6, 26, 50, 10
+    LTEXT "密码:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
-    LTEXT "响应:", 0, 6, 60, 50, 10
+    LTEXT "响应:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
     EDITTEXT ID_EDT_AUTH_CHALLENGE, 60, 57, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "保存密码", ID_CHK_SAVE_PASS, 6, 76, 100, 10
@@ -83,7 +83,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "响应:", 0, 6, 30, 50, 10
+    LTEXT "响应:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "确定", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "取消", IDCANCEL, 90, 51, 52, 14
@@ -159,7 +159,7 @@ BEGIN
     GROUPBOX "启动", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 开机时启动", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好设置", 202, 6, 82, 235, 105
+    GROUPBOX "偏好设置", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "追加日志文件", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "显示脚本窗口", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "静默连接", ID_CHK_SILENT, 17, 125, 200, 10
@@ -185,7 +185,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "日志文件", 202, 6, 62, 235, 30
-    LTEXT "文件夹:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "文件夹:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -214,19 +214,19 @@ CAPTION "关于"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - OpenVPN 的 Windows 图形化界面\n\
 版权所有 (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 版权所有 (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 版权所有 (C) 2012-2021 OpenVPN GUI 贡献者\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN 是一套可以安全地通过单一 TCP/UDP 端口在 IP 网络建立隧道\
 的应用程序。它支持 SSL/TLS 为基础的连接验证与密钥交换、封包加密、\
 封包验证，以及封包压缩。\
 \n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "版权所有 (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 234, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 234, 64
 END
 
 /* Proxy Authentication Dialog */

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -45,8 +45,8 @@ EXSTYLE WS_EX_TOPMOST
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL
 BEGIN
-    LTEXT "使用者名稱:", 0, 6, 9, 50, 10
-    LTEXT "密碼:", 0, 6, 26, 50, 10
+    LTEXT "使用者名稱:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "密碼:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     CHECKBOX "儲存密碼", ID_CHK_SAVE_PASS, 6, 42, 100, 10
@@ -62,9 +62,9 @@ CAPTION "OpenVPN - 使用者驗證"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL
 BEGIN
-    LTEXT "使用者名稱:", 0, 6, 9, 50, 10
-    LTEXT "密碼:", 0, 6, 26, 50, 10
-    LTEXT "回應:", 0, 6, 60, 50, 10
+    LTEXT "使用者名稱:", ID_LTEXT_USERNAME, 6, 9, 50, 10
+    LTEXT "密碼:", ID_LTEXT_PASSWORD, 6, 26, 50, 10
+    LTEXT "回應:", ID_LTEXT_RESPONSE, 6, 60, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 6, 94, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 60, 23, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
@@ -83,7 +83,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL
 BEGIN
     LTEXT "", ID_TXT_DESCRIPTION, 6, 9, 208, 10
-    LTEXT "回應:", 0, 6, 30, 50, 10
+    LTEXT "回應:", ID_LTEXT_RESPONSE, 6, 30, 50, 10
     EDITTEXT ID_EDT_RESPONSE, 60, 27, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     PUSHBUTTON "確認", IDOK, 20, 51, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     PUSHBUTTON "取消", IDCANCEL, 90, 51, 52, 14
@@ -159,7 +159,7 @@ BEGIN
     GROUPBOX "啟動", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 開機時執行", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好設定", 202, 6, 82, 235, 105
+    GROUPBOX "偏好設定", ID_GROUPBOX3, 6, 82, 235, 105
     AUTOCHECKBOX "附加記錄檔", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "顯示指令碼視窗", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "寧靜連線", ID_CHK_SILENT, 17, 125, 200, 10
@@ -185,7 +185,7 @@ BEGIN
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
     GROUPBOX "記錄檔", 202, 6, 62, 235, 30
-    LTEXT "資料夾:", ID_TXT_FOLDER, 17, 74, 32, 10
+    LTEXT "資料夾:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
@@ -214,19 +214,19 @@ CAPTION "關於"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL
 BEGIN
-    ICON ID_ICO_APP, 0, 8, 16, 21, 20
+    ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
     LTEXT "OpenVPN GUI v%s - OpenVPN 的 Windows 圖形化介面\n\
 版權所有 (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 版權所有 (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 版權所有 (C) 2012-2021 OpenVPN GUI 貢獻者\n", ID_TXT_VERSION, 36, 15, 206, 50
-    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_TXT_VERSION, 36, 55, 206, 42
+    LTEXT "https://github.com/OpenVPN/openvpn-gui/", ID_LTEXT_ABOUT2, 36, 55, 206, 42
     LTEXT "OpenVPN 是一套可安全地透過單一 TCP/UDP 通訊埠穿隧 IP 網路\
 的應用程式。支援以 SSL/TLS 為基礎的連線驗證與金鑰交換\
 、封包加密、封包驗證，以及封包壓縮。\
 \n\
-\n", 0, 8, 70, 240, 64
+\n", ID_LTEXT_ABOUT3, 8, 70, 240, 64
     LTEXT "版權所有 (C) 2002-2021 OpenVPN Technologies, Inc <info@openvpn.net>\n\
-https://openvpn.net/", 0, 8, 106, 234, 64
+https://openvpn.net/", ID_LTEXT_ABOUT4, 8, 106, 234, 64
 END
 
 /* Proxy Authentication Dialog */


### PR DESCRIPTION
Should fix duplicate control id warnings from resource
compiler.

Signed-off-by: Selva Nair <selva.nair@gmail.com>