### PR TITLE
Web-based extra authentication

### DIFF
--- a/main.c
+++ b/main.c
@@ -186,6 +186,7 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
       { needstr_,  OnNeedStr },
       { echo_,     OnEcho },
       { bytecount_,OnByteCount },
+      { infomsg_,  OnInfoMsg },
       { 0,        NULL }
   };
   InitManagement(handler);

--- a/manage.c
+++ b/manage.c
@@ -332,6 +332,11 @@ OnManagement(SOCKET sk, LPARAM lParam)
                     if (rtmsg_handler[bytecount_])
                         rtmsg_handler[bytecount_](c, pos + 10);
                 }
+                else if (strncmp(pos, "INFOMSG:", 8) == 0)
+                {
+                    if (rtmsg_handler[infomsg_])
+                        rtmsg_handler[infomsg_](c, pos + 8);
+                }
             }
             else if (c->manage.cmd_queue)
             {

--- a/manage.h
+++ b/manage.h
@@ -37,6 +37,7 @@ typedef enum {
     needok_,
     needstr_,
     pkcs11_id_count_,
+    infomsg_,
     mgmt_rtmsg_type_max
 } mgmt_rtmsg_type;
 

--- a/openvpn.h
+++ b/openvpn.h
@@ -40,6 +40,7 @@ void OnNeedOk(connection_t *, char *);
 void OnNeedStr(connection_t *, char *);
 void OnEcho(connection_t *, char *);
 void OnByteCount(connection_t *, char *);
+void OnInfoMsg(connection_t*, char*);
 
 void ResetSavePasswords(connection_t *);
 


### PR DESCRIPTION
This adds support for web-based extra authentication, which may be
used by OpenVPN Cloud. When enabled and client sends IV_SSO=openurl,
server pushes Info command OPEN_URL:<url>. The client opens that URL and
user authenticates.

Signed-off-by: Lev Stipakov <lev@openvpn.net>