### PR TITLE
Close cr-text challenge dialog on state change

### DIFF
--- a/main.h
+++ b/main.h
@@ -61,6 +61,7 @@
 #define WM_OVPN_IMPORT         (WM_APP + 20)
 #define WM_OVPN_RESCAN         (WM_APP + 21)
 #define WM_OVPN_ECHOMSG        (WM_APP + 22)
+#define WM_OVPN_STATE          (WM_APP + 23)
 
 /* bool definitions */
 #define bool int

--- a/openvpn.c
+++ b/openvpn.c
@@ -660,19 +660,6 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
         {
             SetDlgItemTextW(hwndDlg, ID_TXT_DESCRIPTION, wstr);
 
-            /* If response is not required show a message box with the challenge
-             * text and autosubmit an empty password (see management-notes.txt)
-             */
-            if ((param->flags & FLAG_CR_RESPONSE) == 0)
-            {
-                wchar_t title[256];
-                GetWindowTextW(hwndDlg, title, _countof(title));
-                if (MessageBoxExW(NULL, wstr, title, MB_OKCANCEL|MB_SETFOREGROUND|MB_TOPMOST, GetGUILanguage()) == IDOK)
-                    SimulateButtonPress(hwndDlg, IDOK);
-                else
-                    SimulateButtonPress(hwndDlg, IDCANCEL);
-            }
-
             /* Set password echo on if needed */
             if (param->flags & FLAG_CR_ECHO)
                 SendMessage(GetDlgItem(hwndDlg, ID_EDT_RESPONSE), EM_SETPASSWORDCHAR, 0, 0);
@@ -695,8 +682,18 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
         else
             SetForegroundWindow(hwndDlg);
 
-        /* disable OK button by default - not disabled in resources */
-        EnableWindow(GetDlgItem(hwndDlg, IDOK), FALSE);
+        /* If response is not required hide the response field */
+        if ((param->flags & FLAG_CR_TYPE_CRV1 || param->flags & FLAG_CR_TYPE_CRTEXT)
+            && !(param->flags & FLAG_CR_RESPONSE))
+        {
+            ShowWindow(GetDlgItem(hwndDlg, ID_LTEXT_RESPONSE), SW_HIDE);
+            ShowWindow(GetDlgItem(hwndDlg, ID_EDT_RESPONSE), SW_HIDE);
+        }
+        else
+        {
+            /* disable OK button until response is filled-in */
+            EnableWindow(GetDlgItem(hwndDlg, IDOK), FALSE);
+        }
 
         break;
 


### PR DESCRIPTION
- All windows are notified when OpenVPN state changes -- cr-text dialog is made to close on receiving this (see issue #440)
- Change the way "challenges" that require no response are processed -- required to handle state-change notification
- Fix a bug in the parsing of the challenge text (we were truncating strings that contain colons)