### PR TITLE
Add script to build with cmake

### DIFF
--- a/build-msvc.ps1
+++ b/build-msvc.ps1
@@ -5,15 +5,23 @@ $CWD = Get-Location
 $CMAKE="C:\Program Files\CMake\bin\cmake.exe"
 $CMAKE_TOOLCHAIN_FILE="C:\users\vagrant\buildbot\windows-server-2019-static-msbuild\vcpkg\scripts\buildsystems\vcpkg.cmake"
 
+# Enable running this script from anywhere
+cd $PSScriptRoot
+
 # Architecture names taken from here:
 #
 # https://docs.microsoft.com/en-us/cpp/build/cmake-presets-vs?view=msvc-160
 "x64", "arm64", "Win32" | ForEach  {
 	$platform = $_
     Write-Host "Building openvpn-gui ${platform}"
-    mkdir build_$platform
+    if ( ( Test-Path "build_${platform}" ) -eq $False )
+	{
+        mkdir build_$platform
+	}
     cd build_$platform
     & "$CMAKE" -A $platform -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE" ..
     & "$CMAKE" --build . --config Release
-    cd $CWD
+    cd $PSScriptRoot
 }
+
+cd $CWD

--- a/build-msvc.ps1
+++ b/build-msvc.ps1
@@ -1,0 +1,19 @@
+# Build openvpn-gui with MSVC
+
+$CWD = Get-Location
+
+$CMAKE="C:\Program Files\CMake\bin\cmake.exe"
+$CMAKE_TOOLCHAIN_FILE="C:\users\vagrant\buildbot\windows-server-2019-static-msbuild\vcpkg\scripts\buildsystems\vcpkg.cmake"
+
+# Architecture names taken from here:
+#
+# https://docs.microsoft.com/en-us/cpp/build/cmake-presets-vs?view=msvc-160
+"x64", "arm64", "Win32" | ForEach  {
+	$platform = $_
+    Write-Host "Building openvpn-gui ${platform}"
+    mkdir build_$platform
+    cd build_$platform
+    & "$CMAKE" -A $platform -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE" ..
+    & "$CMAKE" --build . --config Release
+    cd $CWD
+}


### PR DESCRIPTION
I'm opening this PR for discussion as I'm not sure how we want to handle the "build openvpn-gui on Windows with MSVC" challenge.

The simple script in this PR is good enough for my immediate needs, that is, for building OpenVPN-GUI on a Windows Server 2019 server in the context of my new dockerized buildbot environment:

* https://github.com/OpenVPN/openvpn-vagrant/pull/18

If having a build script like this is ok, I can make it more generic/better. I suppose we could also add support for building openvpn-gui with msbuild, like we do with OpenVPN. I'm not sure how much work that would entail, though.