### PR TITLE
Import command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,9 @@ exit
 rescan
      Rescan the config folders for changes
 
+import ``path``
+     Import the config file pointed to by ``path``.
+
 If no running instance of the GUI is found, these commands do nothing
 except for *--command connect config-name* which gets interpreted
 as *--connect config-name*

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -337,6 +337,7 @@
 #define IDS_NFO_IMPORT_SUCCESS          1903
 #define IDS_NFO_IMPORT_OVERWRITE        1904
 #define IDS_ERR_IMPORT_SOURCE           1905
+#define IDS_ERR_IMPORT_ACCESS           1906
 
 /* Save password related messages */
 #define IDS_NFO_DELETE_PASS             2001

--- a/options.c
+++ b/options.c
@@ -120,6 +120,15 @@ add_option(options_t *options, int i, TCHAR **p)
             options->action_arg = p[1];
         }
     }
+    else if (streq(p[0], L"import") && p[1])
+    {
+        ++i;
+        /* This is interpreted directly or as a command depending
+         * on we are the first instance or not. So, set as an action.
+         */
+        options->action = WM_OVPN_IMPORT;
+        options->action_arg = p[1];
+    }
     else if (streq(p[0], _T("exe_path")) && p[1])
     {
         ++i;
@@ -259,6 +268,12 @@ add_option(options_t *options, int i, TCHAR **p)
         {
             ++i;
             options->action = WM_OVPN_SHOWSTATUS;
+            options->action_arg = p[2];
+        }
+        else if (streq(p[1], L"import") && p[2])
+        {
+            ++i;
+            options->action = WM_OVPN_IMPORT;
             options->action_arg = p[2];
         }
         else if (streq(p[1], _T("silent_connection")))

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -390,6 +390,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Volby k použití explicitního nastavení namísto výchozího z registru:\n\
@@ -412,7 +413,12 @@ Volby k použití explicitního nastavení namísto výchozího z registru:\n\
 --passphrase_attempts\t: Počet možných pokusů o zadání hesla.\n\
 --connectscript_timeout\t: Časový limit skriptu v průběhu připojování.\n\
 --disconnectscript_timeout\t: Časový limit skriptu při odpojování.\n\
---preconnectscript_timeout\t: Časový limit skriptu před připojením.\n"
+--preconnectscript_timeout\t: Časový limit skriptu před připojením.\n\
+--iservice_admin\t\t: 0=Do not use interactive service when started as admin (default is 1 for Windows 7 and newer)\n\
+--disable_popup_messages\t: Do not popup (i.e., show) the echo message window. Default is to show.\n\
+--popup_mute_interval\t: Time in hours for which a previously shown echo message is not re-displayed. Default=24 hours.\n\
+--management_port_offset\t: Offset value added to config index to determine the management port for a connection.\n\
+\t\t\t Must be in the range 1 to 61000. Maximum number of configs is limited by 65536 minus this value. Default=25340.\n"
 
     IDS_NFO_USAGECAPTION "Použití OpenVPN GUI"
     IDS_ERR_BAD_PARAMETER "Parametr ""%s"" nebyl úspěšně zpracován, \
@@ -501,6 +507,7 @@ jednou jako správce, aby se registr aktualizoval."
     IDS_NFO_IMPORT_SUCCESS "Konfigurace úspěšně importována."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Stiskněte OK pro odstranění uložených hesel pro konfiguraci ""%s"""

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -392,6 +392,7 @@ Unterstützte Befehle:\n\
     exit                 \t\t: Beende die laufende Instanz der GUI (muss evtl. bestätigt werden)\n\
     status cnn           \t\t: Zeige das Satusfenster der Konfiguration ""cnn"", falls verbunden\n\
     silent_connection [0|1]\t: Schalte die silent_connection-Option ein (1) oder aus (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Option zum Überschreiben der Registry Einstellungen:\n\
@@ -509,6 +510,7 @@ als Administrator ausführen, um die Registry zu aktualisieren."
     IDS_NFO_IMPORT_SUCCESS "Die Konfigurationsdatei wurde erfolgreich importiert."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Drücken Sie OK um die gespeicherten Passwörter für die Konfiguration ""%s"" zu löschen."

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -389,6 +389,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Parametre som vil tilsidesætte indstillinger i registreringsdatabasen:\n\
@@ -506,6 +507,7 @@ en gang som administrator for at opdatere registret."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -404,6 +404,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn             \t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Options to override registry settings:\n\
@@ -520,6 +521,7 @@ once as Administrator to update the registry."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -386,6 +386,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Opciones para sobreescribir opciones del registro:\n\
@@ -503,6 +504,7 @@ nuevo como Administrator para actualizar el registro."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -392,6 +392,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Options to override registry settings:\n\
@@ -509,6 +510,7 @@ once as Administrator to update the registry."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "بسیار خوب (OK) را بزن تا رمز عبور ذخیره شده برای پیکر بندی حذف شود ""%s"""

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -389,6 +389,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Rekisterin asetukset kumoavat valinnat:\n\
@@ -507,6 +508,7 @@ ajaa ylläpitäjän oikeuksin, jotta se saa lisättyä rekisteriin tietoja."
     IDS_NFO_IMPORT_SUCCESS "Asetustiedoston tuonti onnistui."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Napsauta OK poistaaksesi asetustiedostoon ""%s"" liitetyt salasanat."

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -389,6 +389,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Options pour corriger la configuration de registre:\n\
@@ -506,6 +507,7 @@ en tant qu'Administrator pour mettre à jour la base de registre."
     IDS_NFO_IMPORT_SUCCESS "Fichier importé avec succès."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Appuyez sur OK pour supprimer les mots de passe enregistrés pour config ""%s"""

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -389,6 +389,7 @@ Comandi supportati:\n\
     exit                 \t\t: termina l'istanza aperta dell'interfaccia (può chiedere conferma)\n\
     status cnn           \t\t: mostra lo stato della configurazione ""cnn"" se connessa\n\
     silent_connection [0|1]\t: imposta la flag silent_connection on (1) oppure off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tEsempio: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Opzioni per ignorare il registro di sistema:\n\
@@ -506,6 +507,7 @@ una volta che l'amministratore ha aggiornato il registro."
     IDS_NFO_IMPORT_SUCCESS "File importato con successo."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Premi OK per cancellare le password salvate per la configurazione ""%s"""

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -390,6 +390,7 @@ OpenVPN GUIをこのまま終了しますか？"
     exit                 \t\t: OpenVPN GUIインスタンスを終了する（確認メッセージが表示されます）\n\
     status cnn           \t\t: 設定 ""cnn"" のステータスウィンドウを表示（接続時のみ）\n\
     silent_connection [0|1]\t: サイレント接続フラグをON (1) または OFF (0) に設定する\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\t例: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 各オプションはレジストリの設定に優先されます:\n\
@@ -506,6 +507,7 @@ OpenVPNがインストールされていない可能性があります。"
     IDS_NFO_IMPORT_SUCCESS "ファイルが正しくインポートされました。"
     IDS_NFO_IMPORT_OVERWRITE "設定 ""%s"" は既に存在しています。上書きしますか？"
     IDS_ERR_IMPORT_SOURCE "<%s> はグローバル/ローカル設定フォルダにあるためインポートできません。"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "設定 ""%s"" の保存されたパスワードを削除するには OK を押してください。"

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -387,6 +387,7 @@ OpenVPN GUI를 이대로 종료 하겠습니까?"
     exit                 \t\t: 실행중인 GUI 인스턴스 종료 (확인을 물어봄)\n\
     status cnn           \t\t: 연결 되어 있는 ""cnn"" 설정의 상태를 표시\n\
     silent_connection [0|1]\t: silent_connection 플래그를 on(1) 또는 off(0)로 설정\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\t예제: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 각 옵션은 레지스트리 설정보다 우선 합니다:\n\
@@ -504,6 +505,7 @@ Administrator 권한으로 이 프로그램을 실행해야 합니다."
     IDS_NFO_IMPORT_SUCCESS "파일 불러오기 성공."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS """%s"" 설정의 저장된 암호를 삭제 하려면 확인을 누르십시오."

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -390,6 +390,7 @@ Ondersteunde commando's:\n\
     exit                 \t\t: de huidige instantie van de GUI afsluiten (er kan om bevestiging gevraagd worden)\n\
     status cnn           \t\t: het status-scherm van de configuratie ""cnn"" laten zien als de verbinding is gemaakt\n\
     silent_connection [0|1]\t: de vlag ""silent_connection"" aan- (1) of uitzetten (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tVoorbeeld: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Instellingen die de registerinstellingen overschrijven:\n\
@@ -507,6 +508,7 @@ om de registerinstellingen te updaten."
     IDS_NFO_IMPORT_SUCCESS "Importeren bestand gelukt."
     IDS_NFO_IMPORT_OVERWRITE "Een configuratie met de naam ""%s"" bestaat al. Wilt u deze vervangen?"
     IDS_ERR_IMPORT_SOURCE "Het bestand <%s> kan niet worden geïmporteerd omdat het al in de globale of lokale configuratiemap bestaat"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Klik op OK om alle opgeslagen wachtwoorden voor de configuratie ""%s"" te verwijderen"

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -384,6 +384,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Parametere som vil overstyre innstillinger gjort i registeret:\n\
@@ -497,6 +498,7 @@ Wintun driver will not work."
     IDS_NFO_IMPORT_SUCCESS "Importeringen var vellykket."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Klikk OK for å slette lagrede passord for konfigurasjonen ""%s""."

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -388,6 +388,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Opcje oddalające ustawienia rejestru:\n\
@@ -505,6 +506,7 @@ z prawami administratora aby uaktualnić rejestr."
     IDS_NFO_IMPORT_SUCCESS "Plik został zaimportowany."
     IDS_NFO_IMPORT_OVERWRITE "Konfiguracja o nazwie ""%s"" już istnieje. Czy chcesz ją zamienić?"
     IDS_ERR_IMPORT_SOURCE "Nie można zaimportować pliku <%s> ponieważistnieje on już w globalnym lub lokalnym katalogu konfiguracji"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Naciśnij OK aby usunąć zapisane hasła dla konfiguracji ""%s"""

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -388,6 +388,7 @@ Supported commands:\n\
     exit                 \t\t: encerra a instância em execução do GUI (pode solicitar por confirmação)\n\
     status cnn           \t\t: mostra a janela de status da configuração ""cnn"", se conectado\n\
     silent_connection [0|1]\t: define o sinalizador silent_connection em ligado (1) ou desligado (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExemplo: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Opções para sobrescrever opções do registro:\n\
@@ -505,6 +506,7 @@ uma vez como Administrador para alterar o registro."
     IDS_NFO_IMPORT_SUCCESS "Arquivo importado com sucesso."
     IDS_NFO_IMPORT_OVERWRITE "Uma configuração nomeada ""%s"" já existe. Você deseja substituí-la?"
     IDS_ERR_IMPORT_SOURCE "Não é possível importar o arquivo <%s>, pois ele já está na pasta de configurações global ou local"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Pressione OK para excluir as senhas salvas para a configuração ""%s"""

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -389,6 +389,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Опции для переназначения настроек реестра:\n\
@@ -506,6 +507,7 @@ OpenVPN, возможно, не установлен."
     IDS_NFO_IMPORT_SUCCESS "Импорт файла успешно завершен."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Подтвердите удаление сохраненных паролей для ""%s"""

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -385,6 +385,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Parametrar som ersätter inställningar gjorda i registret:\n\
@@ -500,6 +501,7 @@ Wintun driver ska inte fungera."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -388,6 +388,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Registry ayarları için:\n\
@@ -505,6 +506,7 @@ sistem yönetici haklarına sahip olmanız gerekmektedir.."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -388,6 +388,7 @@ BEGIN
     exit                 \t\t: зупинити запущений екземпляр графічного інтерфейсу (може з'явитись підтвердження)\n\
     status cnn           \t\t: показати вікно стану конфігурації ""cnn"", якщо з'єднання активне\n\
     silent_connection [0|1]\t: щоб встановити режим silent_connection, вкажіть (1), Щоб вимкнути, вкажіть (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tНаприклад: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 Опції спрямовані на переконфігурацію налаштувань реєстру:\n\
@@ -506,6 +507,7 @@ OpenVPN, можливо, не встановлений."
     IDS_NFO_IMPORT_SUCCESS "Імпорт файла успішно завершено."
     IDS_NFO_IMPORT_OVERWRITE "Конфігурація з назвою ""%s"" вже існує. Замінити?"
     IDS_ERR_IMPORT_SOURCE "Не вдається імпортувати файл <%s>, оскільки він уже є в глобальному або локальному каталозі конфігурації"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "Підтвердіть видалення збережених паролів для ""%s"""

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -391,6 +391,7 @@ BEGIN
     exit                 \t\t: 退出所有运行中的实例 (可能需要确认)\n\
     status cnn           \t\t: 如果已连接,显示配置""cnn""的状态\n\
     silent_connection [0|1]\t: 设置静默连接开启 (1) 或者关闭 (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\t例如: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 可覆盖系统注册表设定的选项:\n\
@@ -507,6 +508,7 @@ Wintun driver will not work."
     IDS_NFO_IMPORT_SUCCESS "已成功导入文件。"
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "请按「确定」删除「%s」连接配置文件的已存密码。"

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -391,6 +391,7 @@ Supported commands:\n\
     exit                 \t\t: terminate the running GUI instance (may ask for confirmation)\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
+    import path          \t\t: Import the config file pointed to by path\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
 \n\
 可覆蓋系統登錄表設定的選項:\n\
@@ -507,6 +508,7 @@ Wintun driver will not work."
     IDS_NFO_IMPORT_SUCCESS "已成功匯入檔案。"
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
     IDS_NFO_DELETE_PASS "請按「確定」刪除「%s」連線設定檔的已存密碼。"


### PR DESCRIPTION
Add a command-line option
`--command import full-path-of-config` 
(alternatively `--import full-path` also works)

Could be called from a second instance or first instance.

Rationale: `openvpn-gui.exe --command import path` could be used to import a downloaded config. Setting this as the default command for `.ovpn` files would make easy import by double click, right click and choose default action or even automatically with some browser co-operation. 

TODO: set this command as the default shell action during installation. 