### PR TITLE
Make printf spec C-standard compliant and some minor bug fixes

### DIFF
--- a/access.c
+++ b/access.c
@@ -101,7 +101,7 @@ GetBuiltinAdminGroupName (WCHAR *name, DWORD nlen)
         b = LookupAccountSidW(NULL, admin_sid, name, &nlen, domain, &dlen, &su);
     }
 #ifdef DEBUG
-        PrintDebug (L"builtin admin group name = %s", name);
+        PrintDebug (L"builtin admin group name = %ls", name);
 #endif
 
     free (admin_sid);
@@ -123,7 +123,7 @@ AddUserToGroup (const WCHAR *group)
     WCHAR *params = NULL;
 
     /* command: cmd.exe, params: /c net.exe group /add & net.exe group user /add */
-    const WCHAR *fmt = L"/c %s localgroup \"%s\" /add & %s localgroup \"%s\" \"%s\" /add";
+    const WCHAR *fmt = L"/c %ls localgroup \"%ls\" /add & %ls localgroup \"%ls\" \"%ls\" /add";
     DWORD size;
     DWORD status;
     BOOL retval = FALSE;
@@ -137,7 +137,7 @@ AddUserToGroup (const WCHAR *group)
     if (wcspbrk(group, reject) != NULL)
     {
 #ifdef DEBUG
-        PrintDebug (L"AddUSerToGroup: illegal characters in group name: '%s'.", group);
+        PrintDebug (L"AddUSerToGroup: illegal characters in group name: '%ls'.", group);
 #endif
         return retval;
     }
@@ -151,10 +151,10 @@ AddUserToGroup (const WCHAR *group)
     {
         syspath[size-1] = L'\0';
         size = _countof(cmd);
-        _snwprintf(cmd, size, L"%s\\%s", syspath, L"cmd.exe");
+        _snwprintf(cmd, size, L"%ls\\%ls", syspath, L"cmd.exe");
         cmd[size-1] = L'\0';
         size = _countof(netcmd);
-        _snwprintf(netcmd, size, L"%s\\%s", syspath, L"net.exe");
+        _snwprintf(netcmd, size, L"%ls\\%ls", syspath, L"net.exe");
         netcmd[size-1] = L'\0';
     }
     size = (wcslen(fmt) + wcslen(username) + 2*wcslen(group) + 2*wcslen(netcmd)+ 1);
@@ -170,10 +170,10 @@ AddUserToGroup (const WCHAR *group)
 
 #ifdef DEBUG
     if (status == (DWORD) -1)
-        PrintDebug(L"RunAsAdmin: failed to execute the command [%s %s] : error = 0x%x",
+        PrintDebug(L"RunAsAdmin: failed to execute the command [%ls %ls] : error = 0x%x",
                     cmd, params, GetLastError());
     else if (status)
-        PrintDebug(L"RunAsAdmin: command [%s %s] returned exit_code = %lu",
+        PrintDebug(L"RunAsAdmin: command [%ls %ls] returned exit_code = %lu",
                     cmd, params, status);
 #endif
 
@@ -224,7 +224,7 @@ AuthorizeConfig(const connection_t *c)
     else
         admin_group = L"Administrators";
 
-    PrintDebug(L"Authorized groups: '%s', '%s'", admin_group, o.ovpn_admin_group);
+    PrintDebug(L"Authorized groups: '%ls', '%ls'", admin_group, o.ovpn_admin_group);
 
     if (CheckConfigPath(c->config_dir))
         return TRUE;
@@ -296,7 +296,7 @@ LookupSID(const WCHAR *name, PSID sid, DWORD sid_size)
 
     if (!LookupAccountName(NULL, name, sid, &sid_size, domain, &dlen, &su))
     {
-        PrintDebug(L"LookupSID failed for '%s'", name);
+        PrintDebug(L"LookupSID failed for '%ls'", name);
         return FALSE;
     }
     return TRUE;
@@ -394,9 +394,9 @@ IsUserInGroup(PSID sid, const PTOKEN_GROUPS token_groups, const WCHAR *group_nam
     } while (err == ERROR_MORE_DATA && nloop++ < 100);
 
     if (err != NERR_Success && err != NERR_GroupNotFound)
-        PrintDebug(L"NetLocalGroupGetMembers for group '%s' failed: error = %lu", group_name, err);
+        PrintDebug(L"NetLocalGroupGetMembers for group '%ls' failed: error = %lu", group_name, err);
     if (ret)
-        PrintDebug(L"User is in group '%s'", group_name);
+        PrintDebug(L"User is in group '%ls'", group_name);
     return ret;
 }
 

--- a/as.c
+++ b/as.c
@@ -481,7 +481,7 @@ again:
         MessageBoxW(hWnd, L"Failed to get TMP path", _T(PACKAGE_NAME), MB_OK);
         goto done;
     }
-    swprintf(out_path, out_path_size, L"%s%s", out_path, name);
+    swprintf(out_path, out_path_size, L"%ls%ls", out_path, name);
     out_path[out_path_size - 1] = '\0';
     FILE* f = _wfopen(out_path, L"w");
     if (f == NULL) {

--- a/as.c
+++ b/as.c
@@ -88,10 +88,10 @@ ExtractProfileName(const WCHAR *profile, const WCHAR *default_name, WCHAR *out_n
     out_name[out_name_length - 1] = L'\0';
 
     /* sanitize profile name */
-    const char *reserved = "<>:\"/\\|?*;"; /* remap these and ascii 1 to 31 */
+    const WCHAR *reserved = L"<>:\"/\\|?*;"; /* remap these and ascii 1 to 31 */
     while (*out_name) {
         wchar_t c = *out_name;
-        if (c < 32 || strchr(reserved, c))
+        if (c < 32 || wcschr(reserved, c))
             *out_name = L'_';
         ++out_name;
     }

--- a/echo.c
+++ b/echo.c
@@ -227,7 +227,7 @@ echo_msg_append(connection_t *c, time_t UNUSED timestamp, const char *msg, BOOL 
         WriteStatusLog(c, L"GUI> ", L"Error: out of memory while processing echo msg", false);
         goto out;
     }
-    swprintf(s + c->echo_msg.txtlen, len - c->echo_msg.txtlen,  L"%s%s", wmsg, eol);
+    swprintf(s + c->echo_msg.txtlen, len - c->echo_msg.txtlen,  L"%ls%ls", wmsg, eol);
 
     s[len-1] = L'\0';
     c->echo_msg.text = s;
@@ -552,7 +552,7 @@ MessageDialogFunc(HWND hwnd, UINT msg, UNUSED WPARAM wParam, LPARAM lParam)
         {
             connection_t *c = (connection_t *) lParam;
             wchar_t from[256];
-            _sntprintf_0(from, L"From: %s %s", c->config_name, _wctime(&c->echo_msg.fp.timestamp));
+            _sntprintf_0(from, L"From: %ls %ls", c->config_name, _wctime(&c->echo_msg.fp.timestamp));
 
             /* strip \n added by _wctime */
             if (wcslen(from) > 0)

--- a/main.c
+++ b/main.c
@@ -126,7 +126,7 @@ NotifyRunningInstance()
             config_data.cbData = (wcslen(o.action_arg)+1)*sizeof(o.action_arg[0]);
             config_data.lpData = (void *) o.action_arg;
         }
-        PrintDebug(L"Instance 2: called with action %d : %s", o.action, o.action_arg);
+        PrintDebug(L"Instance 2: called with action %d : %ls", o.action, o.action_arg);
         if (!SendMessageTimeout (hwnd_master, WM_COPYDATA, 0,
                                  (LPARAM) &config_data, 0, timeout, NULL))
         {
@@ -206,7 +206,7 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
       ShowLocalizedMsg(IDS_ERR_OPEN_DEBUG_FILE, DEBUG_FILE);
       exit(1);
     }
-  PrintDebug(_T("Starting OpenVPN GUI v%S"), PACKAGE_VERSION);
+  PrintDebug(_T("Starting OpenVPN GUI v%hs"), PACKAGE_VERSION);
 #endif
 
 
@@ -429,7 +429,7 @@ HandleCopyDataMessage(const COPYDATASTRUCT *copy_data)
 {
     WCHAR *str = NULL;
     connection_t *c = NULL;
-    PrintDebug (L"WM_COPYDATA message received. (dwData: %lu, cbData: %lu, lpData: %s)",
+    PrintDebug (L"WM_COPYDATA message received. (dwData: %lu, cbData: %lu, lpData: %ls)",
                 copy_data->dwData, copy_data->cbData, copy_data->lpData);
     if (copy_data->cbData >= sizeof(WCHAR) && copy_data->lpData)
     {
@@ -484,7 +484,7 @@ HandleCopyDataMessage(const COPYDATASTRUCT *copy_data)
     else
     {
         MsgToEventLog(EVENTLOG_ERROR_TYPE,
-                      L"Unknown WM_COPYDATA message ignored. (dwData: %lu, cbData: %lu, lpData: %s)",
+                      L"Unknown WM_COPYDATA message ignored. (dwData: %lu, cbData: %lu, lpData: %ls)",
                       copy_data->dwData, copy_data->cbData, copy_data->lpData);
         return FALSE;
     }
@@ -774,7 +774,7 @@ ImportConfigFileFromDisk()
 {
     TCHAR filter[2*_countof(o.ext_string)+5];
 
-    _sntprintf_0(filter, _T("*.%s%c*.%s%c"), o.ext_string, _T('\0'), o.ext_string, _T('\0'));
+    _sntprintf_0(filter, _T("*.%ls%lc*.%ls%lc"), o.ext_string, _T('\0'), o.ext_string, _T('\0'));
 
     OPENFILENAME fn;
     TCHAR source[MAX_PATH] = _T("");
@@ -815,7 +815,7 @@ void PrintDebugMsg(TCHAR *msg)
                  time_struct->tm_min,
                  time_struct->tm_sec);
 
-  _ftprintf(o.debug_fp, _T("%s %s\n"), date, msg);
+  _ftprintf(o.debug_fp, _T("%ls %ls\n"), date, msg);
   fflush(o.debug_fp);
 }
 #endif

--- a/misc.c
+++ b/misc.c
@@ -60,7 +60,7 @@ Base64Encode(const char *input, int input_len, char **output)
         flags, NULL, &output_len) || output_len == 0)
     {
 #ifdef DEBUG
-        PrintDebug (L"Error in CryptBinaryToStringA: input = '%.*S'", input_len, input);
+        PrintDebug (L"Error in CryptBinaryToStringA: input = '%.*hs'", input_len, input);
 #endif
         *output = NULL;
         return FALSE;
@@ -73,7 +73,7 @@ Base64Encode(const char *input, int input_len, char **output)
         flags, *output, &output_len))
     {
 #ifdef DEBUG
-        PrintDebug (L"Error in CryptBinaryToStringA: input = '%.*S'", input_len, input);
+        PrintDebug (L"Error in CryptBinaryToStringA: input = '%.*hs'", input_len, input);
 #endif
         free(*output);
         *output = NULL;
@@ -96,7 +96,7 @@ Base64Decode(const char *input, char **output)
 {
     DWORD len;
 
-    PrintDebug (L"decoding %S", input);
+    PrintDebug (L"decoding %hs", input);
     if (!CryptStringToBinaryA(input, 0, CRYPT_STRING_BASE64_ANY,
                               NULL, &len, NULL, NULL) || len == 0)
     {
@@ -118,7 +118,7 @@ Base64Decode(const char *input, char **output)
 
     /* NUL terminate output */
     (*output)[len] = '\0';
-    PrintDebug (L"Decoded output %S", *output);
+    PrintDebug (L"Decoded output %hs", *output);
 
     return len;
 }
@@ -510,11 +510,11 @@ wcs_concat2(WCHAR *dest, int len, const WCHAR *src1, const WCHAR *src2, const WC
         return;
 
     if (src1 && src2 && src1[0] && src2[0])
-        n = swprintf(dest, len, L"%s%s%s", src1, sep, src2);
+        n = swprintf(dest, len, L"%ls%ls%ls", src1, sep, src2);
     else if (src1 && src1[0])
-        n = swprintf(dest, len, L"%s", src1);
+        n = swprintf(dest, len, L"%ls", src1);
     else if (src2 && src2[0])
-        n = swprintf(dest, len, L"%s", src2);
+        n = swprintf(dest, len, L"%ls", src2);
 
     if (n < 0 || n >= len) /*swprintf failed */
         n = 0;
@@ -626,7 +626,7 @@ open_url(const wchar_t *url)
 
     if (ret <= (HINSTANCE) 32)
     {
-        MsgToEventLog(EVENTLOG_ERROR_TYPE, L"launch_url: ShellExecute <%s> returned error: %d", url, ret);
+        MsgToEventLog(EVENTLOG_ERROR_TYPE, L"launch_url: ShellExecute <%ls> returned error: %d", url, ret);
         return false;
     }
     return true;

--- a/openvpn.c
+++ b/openvpn.c
@@ -82,7 +82,7 @@ AppendTextToCaption (HANDLE hwnd, const WCHAR *str)
     WCHAR old[256];
     WCHAR new[256];
     GetWindowTextW (hwnd, old, _countof(old));
-    _sntprintf_0 (new, L"%s (%s)", old, str);
+    _sntprintf_0 (new, L"%ls (%ls)", old, str);
     SetWindowText (hwnd, new);
 }
 
@@ -741,7 +741,7 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             if (fmt)
             {
                 sprintf(fmt, template, param->id);
-                PrintDebug(L"Send passwd to mgmt with format: '%S'", fmt);
+                PrintDebug(L"Send passwd to mgmt with format: '%hs'", fmt);
                 ManagementCommandFromInput(param->c, fmt, hwndDlg, ID_EDT_RESPONSE);
                 free (fmt);
             }
@@ -1026,7 +1026,7 @@ parse_input_request (const char *msg, auth_param_t *param)
     if (!token[3] || !*token[3]) /* use id as the description if none provided */
         token[3] = token[1];
 
-    PrintDebug (L"Tokens: '%S' '%S' '%S' '%S'", token[0], token[1],
+    PrintDebug (L"Tokens: '%hs' '%hs' '%hs' '%hs'", token[0], token[1],
                 token[2], token[3]);
 
     if (strcmp (token[0], "Need") != 0)
@@ -1052,14 +1052,14 @@ parse_input_request (const char *msg, auth_param_t *param)
     if (param->str == NULL)
         goto out;
 
-    PrintDebug (L"parse_input_request: id = '%S' str = '%S' flags = %u",
+    PrintDebug (L"parse_input_request: id = '%hs' str = '%hs' flags = %u",
                 param->id, param->str, param->flags);
     ret = TRUE;
 
 out:
     free (p);
     if (!ret)
-        PrintDebug (L"Error parsing password/string request msg: <%S>", msg);
+        PrintDebug (L"Error parsing password/string request msg: <%hs>", msg);
     return ret;
 }
 
@@ -1072,7 +1072,7 @@ OnEcho(connection_t *c, char *msg)
 {
     time_t timestamp = strtoul(msg, NULL, 10); /* openvpn prints these as %u */
 
-    PrintDebug(L"OnEcho with msg = %S", msg);
+    PrintDebug(L"OnEcho with msg = %hs", msg);
     if (!(msg = strchr(msg, ',')))
     {
         PrintDebug(L"OnEcho: msg format not recognized");
@@ -1113,7 +1113,7 @@ OnEcho(connection_t *c, char *msg)
 void
 OnPassword(connection_t *c, char *msg)
 {
-    PrintDebug(L"OnPassword with msg = %S", msg);
+    PrintDebug(L"OnPassword with msg = %hs", msg);
     if (strncmp(msg, "Verification Failed", 19) == 0)
     {
         /* If the failure is due to dynamic challenge save the challenge string */
@@ -1129,7 +1129,7 @@ OnPassword(connection_t *c, char *msg)
             if (c->dynamic_cr && (chstr =  strstr (c->dynamic_cr, "']")) != NULL)
                 *chstr = '\0';
 
-            PrintDebug(L"Got dynamic challenge: <%S>", c->dynamic_cr);
+            PrintDebug(L"Got dynamic challenge: <%hs>", c->dynamic_cr);
         }
 
         return;
@@ -1350,7 +1350,7 @@ void OnByteCount(connection_t *c, char *msg)
  */
 void OnInfoMsg(connection_t* c, char* msg)
 {
-    PrintDebug(L"OnInfoMsg with msg = %S", msg);
+    PrintDebug(L"OnInfoMsg with msg = %hs", msg);
 
     if (strbegins(msg, "OPEN_URL:"))
     {
@@ -1446,7 +1446,7 @@ WriteStatusLog (connection_t *c, const WCHAR *prefix, const WCHAR *line, BOOL fi
     log_fd = _tfopen (c->log_path, TEXT("at+,ccs=UTF-8"));
     if (log_fd)
     {
-        fwprintf (log_fd, L"%s%s%s\n", datetime, prefix, line);
+        fwprintf (log_fd, L"%ls%ls%ls\n", datetime, prefix, line);
         fclose (log_fd);
     }
 }
@@ -1801,7 +1801,7 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 
         /* display version string as "OpenVPN GUI gui_version/core_version" */
         wchar_t version[256];
-        _sntprintf_0(version, L"%S %S/%S", PACKAGE_NAME, PACKAGE_VERSION_RESOURCE_STR, o.ovpn_version)
+        _sntprintf_0(version, L"%hs %hs/%hs", PACKAGE_NAME, PACKAGE_VERSION_RESOURCE_STR, o.ovpn_version)
         SetDlgItemText(hwndDlg, ID_TXT_VERSION, version);
 
         /* Set size and position of controls */
@@ -2064,7 +2064,7 @@ StartOpenVPN(connection_t *c)
         }
         return FALSE;
     }
-    PrintDebug(L"Starting openvpn on config %s", c->config_name);
+    PrintDebug(L"Starting openvpn on config %ls", c->config_name);
 
     RunPreconnectScript(c);
 
@@ -2089,9 +2089,9 @@ StartOpenVPN(connection_t *c)
     GetRandomPassword(c->manage.password, sizeof(c->manage.password) - 1);
 
     /* Construct command line -- put log first */
-    _sntprintf_0(cmdline, _T("openvpn --log%s \"%s\" --config \"%s\" "
-        "--setenv IV_GUI_VER \"%S\" --setenv IV_SSO openurl,crtext --service %s 0 --auth-retry interact "
-        "--management %S %hd stdin --management-query-passwords %s"
+    _sntprintf_0(cmdline, _T("openvpn --log%ls \"%ls\" --config \"%ls\" "
+        "--setenv IV_GUI_VER \"%hs\" --setenv IV_SSO openurl,crtext --service %ls 0 --auth-retry interact "
+        "--management %hs %hd stdin --management-query-passwords %ls"
         "--management-hold"),
         (o.log_append ? _T("-append") : _T("")), c->log_path,
         c->config_file, PACKAGE_STRING, exit_event_name,
@@ -2119,7 +2119,7 @@ StartOpenVPN(connection_t *c)
         const wchar_t *extra_options = L" --pull-filter ignore route-method";
         size += wcslen(extra_options);
 
-        _sntprintf_0(startup_info, L"%s%c%s%s%c%.*S", c->config_dir, L'\0',
+        _sntprintf_0(startup_info, L"%ls%lc%ls%ls%lc%.*hs", c->config_dir, L'\0',
             options, extra_options, L'\0', sizeof(c->manage.password), c->manage.password);
         c->manage.password[sizeof(c->manage.password) - 1] = '\0';
 
@@ -2258,9 +2258,9 @@ TerminateOpenVPN (connection_t *c)
     {
         retval = TerminateProcess (c->hProcess, 1);
         if (retval)
-            PrintDebug (L"Openvpn Process for config '%s' terminated", c->config_name);
+            PrintDebug (L"Openvpn Process for config '%ls' terminated", c->config_name);
         else
-            PrintDebug (L"Failed to terminate openvpn Process for config '%s'", c->config_name);
+            PrintDebug (L"Failed to terminate openvpn Process for config '%ls'", c->config_name);
     }
     else
         PrintDebug(L"In TerminateOpenVPN: Process is not active");
@@ -2418,7 +2418,7 @@ CheckVersion()
     if (ReadLineFromStdOut(hStdOutRead, line, sizeof(line)))
     {
 #ifdef DEBUG
-        PrintDebug(_T("VersionString: %S"), line);
+        PrintDebug(_T("VersionString: %hs"), line);
 #endif
         /* OpenVPN version 2.x */
         char *p = strstr(line, match_version);

--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -70,7 +70,7 @@ CheckReadAccess (const TCHAR *dir, const TCHAR *file)
 {
     TCHAR path[MAX_PATH];
 
-    _sntprintf_0 (path, _T("%s\\%s"), dir, file);
+    _sntprintf_0 (path, _T("%ls\\%ls"), dir, file);
 
     return CheckFileAccess (path, GENERIC_READ);
 }
@@ -99,7 +99,7 @@ AddConfigFileToList(int config, const TCHAR *filename, const TCHAR *config_dir)
     _tcsncpy(c->config_dir, config_dir, _countof(c->config_dir) - 1);
     _tcsncpy(c->config_name, c->config_file, _countof(c->config_name) - 1);
     c->config_name[_tcslen(c->config_name) - _tcslen(o.ext_string) - 1] = _T('\0');
-    _sntprintf_0(c->log_path, _T("%s\\%s.log"), o.log_dir, c->config_name);
+    _sntprintf_0(c->log_path, _T("%ls\\%ls.log"), o.log_dir, c->config_name);
 
     c->manage.sk = INVALID_SOCKET;
     c->manage.skaddr.sin_family = AF_INET;
@@ -172,7 +172,7 @@ NewConfigGroup(const wchar_t *name, int parent, int flags)
     config_group_t *cg = &o.groups[o.num_groups];
     memset(cg, 0, sizeof(*cg));
 
-    _sntprintf_0(cg->name, L"%s", name);
+    _sntprintf_0(cg->name, L"%ls", name);
     cg->id = o.num_groups++;
     cg->parent = parent;
     cg->active = false; /* activated later if not empty */
@@ -268,7 +268,7 @@ BuildFileList0(const TCHAR *config_dir, int recurse_depth, int group, int flags)
     TCHAR find_string[MAX_PATH];
     TCHAR subdir_name[MAX_PATH];
 
-    _sntprintf_0(find_string, _T("%s\\*"), config_dir);
+    _sntprintf_0(find_string, _T("%ls\\*"), config_dir);
     find_handle = FindFirstFile(find_string, &find_obj);
     if (find_handle == INVALID_HANDLE_VALUE)
         return;
@@ -326,7 +326,7 @@ BuildFileList0(const TCHAR *config_dir, int recurse_depth, int group, int flags)
                 &&  wcscmp(find_obj.cFileName, _T("..")))
             {
                 /* recurse into subdirectory */
-                _sntprintf_0(subdir_name, _T("%s\\%s"), config_dir, find_obj.cFileName);
+                _sntprintf_0(subdir_name, _T("%ls\\%ls"), config_dir, find_obj.cFileName);
                 int sub_group = NewConfigGroup(find_obj.cFileName, group, flags);
 
                 BuildFileList0(subdir_name, recurse_depth - 1, sub_group, flags);

--- a/options.c
+++ b/options.c
@@ -490,7 +490,7 @@ static BOOL
 BrowseFolder (const WCHAR* initial_path, WCHAR* selected_path, size_t selected_path_size)
 {
     IFileOpenDialog* pfd;
-    HRESULT initResult, result, dialogResult;
+    HRESULT initResult, result, dialogResult = E_FAIL;
 
     // Create dialog
     initResult = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);

--- a/options.c
+++ b/options.c
@@ -64,7 +64,7 @@ ExpandString (WCHAR *str, int max_len)
 
   if (len > max_len || len > (int) _countof(expanded_string))
   {
-      PrintDebug (L"Failed to expanded env vars in '%s'. String too long", str);
+      PrintDebug (L"Failed to expanded env vars in '%ls'. String too long", str);
       return;
   }
   wcsncpy (str, expanded_string, max_len);
@@ -178,22 +178,22 @@ add_option(options_t *options, int i, TCHAR **p)
     else if (streq(p[0], _T("allow_edit")) && p[1])
     {
         ++i;
-        PrintDebug (L"Deprecated option: '%s' ignored.", p[0]);
+        PrintDebug (L"Deprecated option: '%ls' ignored.", p[0]);
     }
     else if (streq(p[0], _T("allow_service")) && p[1])
     {
         ++i;
-        PrintDebug (L"Deprecated option: '%s' ignored.", p[0]);
+        PrintDebug (L"Deprecated option: '%ls' ignored.", p[0]);
     }
     else if (streq(p[0], _T("allow_password")) && p[1])
     {
         ++i;
-        PrintDebug (L"Deprecated option: '%s' ignored.", p[0]);
+        PrintDebug (L"Deprecated option: '%ls' ignored.", p[0]);
     }
     else if (streq(p[0], _T("allow_proxy")) && p[1])
     {
         ++i;
-        PrintDebug (L"Deprecated option: '%s' ignored.", p[0]);
+        PrintDebug (L"Deprecated option: '%ls' ignored.", p[0]);
     }
     else if (streq(p[0], _T("show_balloon")) && p[1])
     {
@@ -218,7 +218,7 @@ add_option(options_t *options, int i, TCHAR **p)
     else if (streq(p[0], _T("passphrase_attempts")) && p[1])
     {
         ++i;
-        PrintDebug (L"Deprecated option: '%s' ignored.", p[0]);
+        PrintDebug (L"Deprecated option: '%ls' ignored.", p[0]);
     }
     else if (streq(p[0], _T("connectscript_timeout")) && p[1])
     {

--- a/proxy.c
+++ b/proxy.c
@@ -266,7 +266,7 @@ SaveProxySettings(HWND hwndDlg)
     }
 
     /* Open Registry for writing */
-    _sntprintf_0(proxy_subkey, _T("%s\\proxy"), GUI_REGKEY_HKCU);
+    _sntprintf_0(proxy_subkey, _T("%ls\\proxy"), GUI_REGKEY_HKCU);
     if (RegCreateKeyEx(HKEY_CURRENT_USER, proxy_subkey, 0, _T(""), REG_OPTION_NON_VOLATILE,
                        KEY_WRITE, NULL, &regkey, &dwDispos) != ERROR_SUCCESS)
     {
@@ -297,7 +297,7 @@ GetProxyRegistrySettings()
     TCHAR proxy_subkey[MAX_PATH];
 
     /* Open Registry for reading */
-    _sntprintf_0(proxy_subkey, _T("%s\\proxy"), GUI_REGKEY_HKCU);
+    _sntprintf_0(proxy_subkey, _T("%ls\\proxy"), GUI_REGKEY_HKCU);
     status = RegOpenKeyEx(HKEY_CURRENT_USER, proxy_subkey, 0, KEY_READ, &regkey);
     if (status != ERROR_SUCCESS)
         return;
@@ -433,11 +433,11 @@ QueryWindowsProxySettings(const url_scheme scheme, LPCSTR host)
             WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
         if (session)
         {
-            int size = _snwprintf(NULL, 0, L"%s://%S", UrlSchemeStr(scheme), host) + 1;
+            int size = _snwprintf(NULL, 0, L"%ls://%hs", UrlSchemeStr(scheme), host) + 1;
             LPWSTR url = malloc(size * sizeof(WCHAR));
             if (url)
             {
-                _snwprintf(url, size, L"%s://%S", UrlSchemeStr(scheme), host);
+                _snwprintf(url, size, L"%ls://%hs", UrlSchemeStr(scheme), host);
 
                 LPWSTR old_proxy = proxy;
                 WINHTTP_PROXY_INFO proxy_info;

--- a/registry.c
+++ b/registry.c
@@ -89,8 +89,8 @@ GetGlobalRegistryKeys()
   }
 
   /* set default editor and log_viewer as a fallback for opening config/log files */
-  _sntprintf_0(o.editor, L"%s\\%s", windows_dir, L"System32\\notepad.exe");
-  _sntprintf_0(o.log_viewer, L"%s", o.editor);
+  _sntprintf_0(o.editor, L"%ls\\%ls", windows_dir, L"System32\\notepad.exe");
+  _sntprintf_0(o.log_viewer, L"%ls", o.editor);
 
   /* Get path to OpenVPN installation. */
   if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, _T("SOFTWARE\\OpenVPN"), 0, KEY_READ, &regkey)
@@ -107,7 +107,7 @@ GetGlobalRegistryKeys()
       if (regkey)
           ShowLocalizedMsg(IDS_ERR_READING_REGISTRY);
       /* Use a sane default value */
-      _sntprintf_0(openvpn_path, _T("%s"), _T("C:\\Program Files\\OpenVPN\\"));
+      _sntprintf_0(openvpn_path, _T("%ls"), _T("C:\\Program Files\\OpenVPN\\"));
     }
   if (openvpn_path[_tcslen(openvpn_path) - 1] != _T('\\'))
     _tcscat(openvpn_path, _T("\\"));
@@ -116,7 +116,7 @@ GetGlobalRegistryKeys()
   if (!regkey || !GetRegistryValue(regkey, _T("config_dir"), o.global_config_dir, _countof(o.global_config_dir)))
     {
       /* use default = openvpnpath\config */
-      _sntprintf_0(o.global_config_dir, _T("%sconfig"), openvpn_path);
+      _sntprintf_0(o.global_config_dir, _T("%lsconfig"), openvpn_path);
     }
 
   if (!regkey || !GetRegistryValue(regkey, _T("ovpn_admin_group"), o.ovpn_admin_group, _countof(o.ovpn_admin_group)))
@@ -126,7 +126,7 @@ GetGlobalRegistryKeys()
 
   if (!regkey || !GetRegistryValue(regkey, _T("exe_path"), o.exe_path, _countof(o.exe_path)))
     {
-      _sntprintf_0(o.exe_path, _T("%sbin\\openvpn.exe"), openvpn_path);
+      _sntprintf_0(o.exe_path, _T("%lsbin\\openvpn.exe"), openvpn_path);
     }
 
   if (!regkey || !GetRegistryValue(regkey, _T("priority"), o.priority_string, _countof(o.priority_string)))
@@ -162,10 +162,10 @@ GetRegistryKeys ()
             /* no value found in registry, use the default */
             wcsncpy (regkey_str[i].var, regkey_str[i].value, regkey_str[i].len);
             regkey_str[i].var[regkey_str[i].len-1] = L'\0';
-            PrintDebug(L"default: %s = %s", regkey_str[i].name, regkey_str[i].var);
+            PrintDebug(L"default: %ls = %ls", regkey_str[i].name, regkey_str[i].var);
         }
         else
-            PrintDebug(L"from registry: %s = %s", regkey_str[i].name, regkey_str[i].var);
+            PrintDebug(L"from registry: %ls = %ls", regkey_str[i].name, regkey_str[i].var);
     }
 
     for (i = 0 ; i < (int) _countof (regkey_int); ++i)
@@ -175,10 +175,10 @@ GetRegistryKeys ()
         {
             /* no value found in registry, use the default */
             *regkey_int[i].var = regkey_int[i].value;
-            PrintDebug(L"default: %s = %lu", regkey_int[i].name, *regkey_int[i].var);
+            PrintDebug(L"default: %ls = %lu", regkey_int[i].name, *regkey_int[i].var);
         }
         else
-            PrintDebug(L"from registry: %s = %lu", regkey_int[i].name, *regkey_int[i].var);
+            PrintDebug(L"from registry: %ls = %lu", regkey_int[i].name, *regkey_int[i].var);
     }
 
     if ( status == ERROR_SUCCESS)
@@ -280,7 +280,7 @@ SetRegistryVersion (const version_t *v)
         RegCloseKey(regkey);
     }
     else
-       PrintDebug (L"Eror opening/creating 'HKCU\\%s' registry key", GUI_REGKEY_HKCU);
+       PrintDebug (L"Eror opening/creating 'HKCU\\%ls' registry key", GUI_REGKEY_HKCU);
     return ret;
 }
 
@@ -324,7 +324,7 @@ MigrateNilingsKeys()
         RegCloseKey (regkey_proxy);
     }
     else
-        PrintDebug (L"Error creating key 'proxy' in HKCU\\%s", GUI_REGKEY_HKCU);
+        PrintDebug (L"Error creating key 'proxy' in HKCU\\%ls", GUI_REGKEY_HKCU);
 
     RegCloseKey (regkey);
     RegCloseKey (regkey_nilings);
@@ -429,7 +429,7 @@ static int
 OpenConfigRegistryKey(const WCHAR *config_name, HKEY *regkey, BOOL create)
 {
     DWORD status;
-    const WCHAR fmt[] = L"SOFTWARE\\OpenVPN-GUI\\configs\\%s";
+    const WCHAR fmt[] = L"SOFTWARE\\OpenVPN-GUI\\configs\\%ls";
     int count = (wcslen(config_name) + wcslen(fmt) + 1);
     WCHAR *name = malloc(count * sizeof(WCHAR));
 

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -221,7 +221,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - GUI pro OpenVPN ve Windows\n\
+    LTEXT "OpenVPN GUI v%ls - GUI pro OpenVPN ve Windows\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI přispěvatelé\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -277,7 +277,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nPřipojeno: "
     IDS_TIP_CONNECTING "\nPřipojování: "
     IDS_TIP_CONNECTED_SINCE "\nPřipojeno od: "
-    IDS_TIP_ASSIGNED_IP "\nPřiřazená IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nPřiřazená IP: %ls"
     IDS_MENU_SERVICE "Služba OpenVPN"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -302,28 +302,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Opravdu se chcete odpojit (Zastavit službu OpenVPN)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Došlo k chybě při spouštění nástroje pro zobrazení logu: %s"
-    IDS_ERR_START_CONF_EDITOR "Došlo k chybě při spouštění nástroje pro úpravu konfigurace: %s"
+    IDS_ERR_START_LOG_VIEWER "Došlo k chybě při spouštění nástroje pro zobrazení logu: %ls"
+    IDS_ERR_START_CONF_EDITOR "Došlo k chybě při spouštění nástroje pro úpravu konfigurace: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI nepodporuje více než %d konfigurací. Prosím kontaktujte autora, pokud jich potřebujete více."
     IDS_NFO_NO_CONFIGS "Nebyly nalezeny žádné soubory konfigurací spojení.\n\
-Použijte volbu menu ""Import souboru konfigurace…"" nebo zkopírujte konfigurační soubory do ""%s"" nebo ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Vytvoření tohoto spojení (%s) vyžaduje členství ve skupině \
-""%s"". Kontaktujte svého správce systému.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Vytvoření tohoto spojení (%s) vyžaduje členství ve skupině \
-""%s"".\n\n\
+Použijte volbu menu ""Import souboru konfigurace…"" nebo zkopírujte konfigurační soubory do ""%ls"" nebo ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Vytvoření tohoto spojení (%ls) vyžaduje členství ve skupině \
+""%ls"". Kontaktujte svého správce systému.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Vytvoření tohoto spojení (%ls) vyžaduje členství ve skupině \
+""%ls"".\n\n\
 Chcete se přidat do této skupiny?\n\
 Tato akce může vyžadovat svolení nebo heslo správce."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Vytvoření tohoto spojení (%s) vyžaduje členství ve skupině \
-""%s"".\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Vytvoření tohoto spojení (%ls) vyžaduje členství ve skupině \
+""%ls"".\n\n\
 Prosím dokončete předchozí autorizační dialog."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Přidání uživatele do skupiny ""%s"" nebylo úspěšné."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Přidání uživatele do skupiny ""%ls"" nebylo úspěšné."
     IDS_ERR_ONE_CONN_OLD_VER "V případě, že používáte OpenVPN starší než verze 2.0-beta6, můžete mít aktivní pouze jedno spojení."
     IDS_ERR_STOP_SERV_OLD_VER "Není možno použít OpenVPN GUI pro vytvoření spojení, pokud již běží služba OpenVPN (verze OpenVPN 1.5/1.6). Prosím zastavte nejprve službu OpenVPN."
-    IDS_ERR_CREATE_EVENT "Selhala akce CreateEvent při ukončení události: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Neznámý název priority: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Přepínač přidávání na konec logu (identifikovaný jako '%s') musí nabývat hodnot '0' nebo '1'"
+    IDS_ERR_CREATE_EVENT "Selhala akce CreateEvent při ukončení události: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Neznámý název priority: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Přepínač přidávání na konec logu (identifikovaný jako '%ls') musí nabývat hodnot '0' nebo '1'"
     IDS_ERR_GET_MSIE_PROXY "Nepodařilo se načíst nastavení proxy z MSIE."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor selhal."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl selhal."
@@ -331,43 +331,43 @@ Prosím dokončete předchozí autorizační dialog."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe na hInputRead selhal."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle na hOutputRead selhal."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle na hInputWrite selhal."
-    IDS_ERR_CREATE_PROCESS "CreateProcess selhal, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess selhal, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread k zobrazení stavu selhal."
     IDS_NFO_STATE_WAIT_TERM "Aktuální stav: Čekání, než se OpenVPN ukončí…"
     IDS_NFO_STATE_CONNECTED "Aktuální stav: Připojeno"
-    IDS_NFO_NOW_CONNECTED "%s je nyní připojeno."
-    IDS_NFO_ASSIGN_IP "Přiřazená IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls je nyní připojeno."
+    IDS_NFO_ASSIGN_IP "Přiřazená IP: %ls"
     IDS_ERR_CERT_EXPIRED "Spojení nelze navázat, protože certifikát expiroval, nebo není správně nastaven systémový čas."
     IDS_ERR_CERT_NOT_YET_VALID "Spojení nelze navázat, protože certifikát ještě není platný. Prosím zkontrolujte, že je správně nastaven systémový čas."
     IDS_NFO_STATE_RECONNECTING "Aktuální stav: Restartování"
     IDS_NFO_STATE_DISCONNECTED "Aktuální stav: Odpojeno"
-    IDS_NFO_CONN_TERMINATED "Připojení k %s bylo přerušeno."
+    IDS_NFO_CONN_TERMINATED "Připojení k %ls bylo přerušeno."
     IDS_NFO_STATE_FAILED "Aktuální stav: Nepodařilo se připojit"
-    IDS_NFO_CONN_FAILED "Připojování k %s selhalo."
+    IDS_NFO_CONN_FAILED "Připojování k %ls selhalo."
     IDS_NFO_STATE_FAILED_RECONN "Aktuální stav: Nepodařilo se restartovat"
-    IDS_NFO_RECONN_FAILED "Restartování spojení k %s selhalo."
+    IDS_NFO_RECONN_FAILED "Restartování spojení k %ls selhalo."
     IDS_NFO_STATE_SUSPENDED "Aktuální stav: Pozastaveno"
     IDS_ERR_READ_STDOUT_PIPE "Došlo k chybě při čtení z OpenVPN StdOut Pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Došlo k chybě při vytváření okna s formátovaným logem."
     IDS_ERR_SET_SIZE "Selhalo nastavení velikosti."
-    IDS_ERR_AUTOSTART_CONF "Nebylo možné najít požadovanou konfiguraci k automatickému spojení: %s"
+    IDS_ERR_AUTOSTART_CONF "Nebylo možné najít požadovanou konfiguraci k automatickému spojení: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe na hInputRead selhal."
     IDS_NFO_STATE_CONNECTING "Aktuální stav: Připojování"
-    IDS_NFO_CONNECTION_XXX "OpenVPN spojení (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN spojení (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Aktuální stav: Spouštění skriptu při připojení"
     IDS_NFO_STATE_DISCONN_SCRIPT "Aktuální stav: Spouštění skriptu při odpojení"
-    IDS_ERR_RUN_CONN_SCRIPT "Došlo k chybě při při běhu skriptu při připojení: %s"
-    IDS_ERR_GET_EXIT_CODE "Nepodařilo se získat ExitCode skriptu při připojení (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Došlo k chybě při při běhu skriptu při připojení: %ls"
+    IDS_ERR_GET_EXIT_CODE "Nepodařilo se získat ExitCode skriptu při připojení (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Skript při připojení selhal. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Skript při připojení selhal. Čas spojení vypršel po %ds."
-    IDS_ERR_CONFIG_EXIST "Konfigurační soubor s názvem '%s' již existuje. Je nutné jeden z konfiguračních \
+    IDS_ERR_CONFIG_EXIST "Konfigurační soubor s názvem '%ls' již existuje. Je nutné jeden z konfiguračních \
 souborů stejného názvu přejmenovat, i když se \
 nachází v jiné složce."
     IDS_NFO_CONN_TIMEOUT "Připojení k rozhraní správy selhalo.\n\
-Více informací najdete v logu (%s)."
+Více informací najdete v logu (%ls)."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Nelze otevřít soubor pro zápis ladění (%s)."
-    IDS_ERR_CREATE_PATH "Nepodařilo se vytvořit %s složku:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Nelze otevřít soubor pro zápis ladění (%ls)."
+    IDS_ERR_CREATE_PATH "Nepodařilo se vytvořit %ls složku:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Nepodařilo se načíst riched20.dll."
     IDS_ERR_SHELL_DLL_VERSION "Verze vaší knihovny shell32.dll je příliš nízká (0x%lx). Potřebujete verzi 5.0 nebo novější."
     IDS_NFO_SERVICE_STARTED "Služba OpenVPN spuštěna."
@@ -422,26 +422,26 @@ Volby k použití explicitního nastavení namísto výchozího z registru:\n\
 \t\t\t Must be in the range 1 to 61000. Maximum number of configs is limited by 65536 minus this value. Default=25340.\n"
 
     IDS_NFO_USAGECAPTION "Použití OpenVPN GUI"
-    IDS_ERR_BAD_PARAMETER "Parametr ""%s"" nebyl úspěšně zpracován, \
+    IDS_ERR_BAD_PARAMETER "Parametr ""%ls"" nebyl úspěšně zpracován, \
 zkuste před něj dát '--'."
-    IDS_ERR_BAD_OPTION "Nepovolená hodnota: Neznámá volba nebo chybějící parametr: --%s\n\
+    IDS_ERR_BAD_OPTION "Nepovolená hodnota: Neznámá volba nebo chybějící parametr: --%ls\n\
 Použijte openvpn-gui --help pro více informací."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "Selhal CreateThread při vytváření dialogu Změna hesla privátního klíče."
-    IDS_NFO_CHANGE_PWD "Změna hesla privátního klíče (%s)"
+    IDS_NFO_CHANGE_PWD "Změna hesla privátního klíče (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Zadaná hesla se neshodují. Zkuste to prosím znovu."
     IDS_ERR_PWD_TO_SHORT "Minimální délka hesla je %d znaků."
     IDS_NFO_EMPTY_PWD "Opravdu chcete nastavit prázdné heslo?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Neznámý formát souboru klíče."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Došlo k chybě při načítání souboru privátního klíče (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Došlo k chybě při načítání souboru privátního klíče (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Staré heslo není správné."
-    IDS_ERR_OPEN_WRITE_KEY "Nepodařilo se zapsat do souboru privátního klíče (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Nepodařilo se vytvořit nový soubor privátního klíče (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Nepodařilo se zapsat do souboru privátního klíče (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Nepodařilo se vytvořit nový soubor privátního klíče (%ls)."
     IDS_NFO_PWD_CHANGED "Vaše heslo bylo změněno."
-    IDS_ERR_READ_PKCS12 "Došlo k chybě při načítání souboru PKCS #12 (%s)."
+    IDS_ERR_READ_PKCS12 "Došlo k chybě při načítání souboru PKCS #12 (%ls)."
     IDS_ERR_CREATE_PKCS12 "Došlo k chybě při vytváření nového souboru PKCS #12. Změna hesla se nezdařila."
-    IDS_ERR_OPEN_CONFIG "Nepodařilo se otevřít konfigurační soubor ke čtení: (%s)"
+    IDS_ERR_OPEN_CONFIG "Nepodařilo se otevřít konfigurační soubor ke čtení: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "Není možné mít více než jednu definici ""key"" v konfiguračním souboru."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Není možné mít definice ""key"" a ""pkcs12"" ve stejném konfiguračním souboru."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Není možné mít více než jednu definici ""pkcs12"" v konfiguračním souboru."
@@ -464,7 +464,7 @@ Prosím zadejte jiné."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Je nutné zadat adresu SOCKS proxy."
     IDS_ERR_SOCKS_PROXY_PORT "Je nutné zadat port SOCKS proxy."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Port SOCKS proxy musí být v rozsahu 1-65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "Došlo k chybě při vytváření klíče ""HKCU\\%s"" v registru."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Došlo k chybě při vytváření klíče ""HKCU\\%ls"" v registru."
     IDS_ERR_GET_TEMP_PATH "Došlo k chybě při zjišťování cesty ke složce Temp pomocí GetTempPath(). Bude použito ""C:\\""."
 
     /* service */
@@ -498,24 +498,24 @@ OpenVPN pravděpodobně není nainstalováno."
     IDS_ERR_CREATE_REG_KEY "Nepodařilo se vytvořit klíč HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Nepodařilo se otevřít registr pro zápis. Je nutné spustit aplikaci \
 jednou jako správce, aby se registr aktualizoval."
-    IDS_ERR_READ_SET_KEY "Došlo k chybě při čtení a zápisu klíče registru ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Došlo k chybě při zápisu hodnoty registru ""HKCU\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Došlo k chybě při čtení a zápisu klíče registru ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Došlo k chybě při zápisu hodnoty registru ""HKCU\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Konfigurace s názvem ""%s"" již existuje."
+    IDS_ERR_IMPORT_EXISTS "Konfigurace s názvem ""%ls"" již existuje."
     IDS_ERR_IMPORT_FAILED "Nepodařilo se importovat konfigurační soubor. Následující cestu se nepodařilo vytvořit.\n\n\
-%s\n\nUjistěte se prosím, že máte potřebná oprávnění."
+%ls\n\nUjistěte se prosím, že máte potřebná oprávnění."
     IDS_NFO_IMPORT_SUCCESS "Konfigurace úspěšně importována."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Stiskněte OK pro odstranění uložených hesel pro konfiguraci ""%s"""
+    IDS_NFO_DELETE_PASS "Stiskněte OK pro odstranění uložených hesel pro konfiguraci ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Heslo tokenu"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Prosím zadejte heslo/PIN pro token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Prosím zadejte heslo/PIN pro token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
@@ -523,6 +523,6 @@ jednou jako správce, aby se registr aktualizoval."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -222,7 +222,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_GERMAN, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s – Eine grafische Benutzeroberfläche für OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls – Eine grafische Benutzeroberfläche für OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -279,7 +279,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nVerbunden mit: "
     IDS_TIP_CONNECTING "\nVerbinden mit: "
     IDS_TIP_CONNECTED_SINCE "\nVerbunden seit: "
-    IDS_TIP_ASSIGNED_IP "\nZugewiesene IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nZugewiesene IP: %ls"
     IDS_MENU_SERVICE "OpenVPN-Dienst"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -304,28 +304,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Möchten Sie die Verbindung trennen (beendet den OpenVPN-Dienst)?"
 
     /* Logviewer – Resources */
-    IDS_ERR_START_LOG_VIEWER "Fehler beim Starten der Log-Anzeige: %s"
-    IDS_ERR_START_CONF_EDITOR "Fehler beim Starten des Konfigurations-Editors: %s"
+    IDS_ERR_START_LOG_VIEWER "Fehler beim Starten der Log-Anzeige: %ls"
+    IDS_ERR_START_CONF_EDITOR "Fehler beim Starten des Konfigurations-Editors: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI unterstützt nicht mehr als %d Konfigurationen. Bitte kontaktieren Sie bei Bedarf den Autor."
     IDS_NFO_NO_CONFIGS "Keine lesbaren Konfigurations-Profile (Konfigurationsdateien) gefunden.\n\
-Benutzen Sie das ""Datei importieren…"" Menü oder kopieren Sie Ihre Konfigurationsdateien nach ""%s"" oder ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Zum Starten dieser Verbindung (%s) müssen Sie Mitglied in der\
-Gruppe ""%s"" sein. Kontaktieren Sie Ihren Systemadministrator.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Zum Starten dieser Verbindung (%s) müssen Sie Mitglied in der\
-Gruppe ""%s"" sein.\n\n\
+Benutzen Sie das ""Datei importieren…"" Menü oder kopieren Sie Ihre Konfigurationsdateien nach ""%ls"" oder ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Zum Starten dieser Verbindung (%ls) müssen Sie Mitglied in der\
+Gruppe ""%ls"" sein. Kontaktieren Sie Ihren Systemadministrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Zum Starten dieser Verbindung (%ls) müssen Sie Mitglied in der\
+Gruppe ""%ls"" sein.\n\n\
 Möchten Sie sich selbst zu dieser Gruppe hinzufügen?\n\
 Möglicherweise benötigen Sie hierfür das Passwort oder die Zustimmung eines Administrators."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Zum Starten dieser Verbindung (%s) müssen Sie Mitglied in der\
-Gruppe ""%s"" sein.\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Zum Starten dieser Verbindung (%ls) müssen Sie Mitglied in der\
+Gruppe ""%ls"" sein.\n\n\
 Bitte vervollständigen Sie den vorhergehenden Autorisierungsdialog."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Hinzufügen des Benutzers zur Gruppe ""%s"" ist fehlgeschlagen."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Hinzufügen des Benutzers zur Gruppe ""%ls"" ist fehlgeschlagen."
     IDS_ERR_ONE_CONN_OLD_VER "Sie können nur eine Verbindung zur gleichen Zeit aufbauen, wenn Sie einen ältere Version als 2.0-beta6 von OpenVPN verwenden."
     IDS_ERR_STOP_SERV_OLD_VER "Sie können OpenVPN GUI nicht zum Starten einer Verbindung nutzen, während der OpenVPN-Dienst läuft (mit OpenVPN 1.5/1.6). Beenden Sie den OpenVPN-Dienst, bevor Sie OpenVPN GUI nutzen."
-    IDS_ERR_CREATE_EVENT "CreateEvent fehlgeschlagen beim Beenden. Event: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Unbekannte Priorität: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Logdatei-Anhängen-Flag (aktuell '%s') muss '0' oder '1' sein."
+    IDS_ERR_CREATE_EVENT "CreateEvent fehlgeschlagen beim Beenden. Event: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Unbekannte Priorität: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Logdatei-Anhängen-Flag (aktuell '%ls') muss '0' oder '1' sein."
     IDS_ERR_GET_MSIE_PROXY "Konnte die MSIE-Proxy-Einstellungen nicht übernehmen."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor fehlgeschlagen."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl fehlgeschlagen."
@@ -333,43 +333,43 @@ Bitte vervollständigen Sie den vorhergehenden Autorisierungsdialog."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe on hInputRead fehlgeschlagen."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead fehlgeschlagen."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite fehlgeschlagen."
-    IDS_ERR_CREATE_PROCESS "CreateProcess fehlgeschlagen, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess fehlgeschlagen, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread zum Anzeigen des Status-Fensters ist fehlgeschlagen."
     IDS_NFO_STATE_WAIT_TERM "Aktueller Status: Wartet bis OpenVPN beendet ist…"
     IDS_NFO_STATE_CONNECTED "Aktueller Status: Verbunden"
-    IDS_NFO_NOW_CONNECTED "%s ist nun verbunden."
-    IDS_NFO_ASSIGN_IP "Zugewiesene IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls ist nun verbunden."
+    IDS_NFO_ASSIGN_IP "Zugewiesene IP: %ls"
     IDS_ERR_CERT_EXPIRED "Es konnte keine Verbindung hergestellt werden, weil Ihr Zertifikat abgelaufen ist oder die Systemzeit nicht korrekt eingestellt ist."
     IDS_ERR_CERT_NOT_YET_VALID "Es konnte keine Verbindung hergestellt werden, weil Ihr Zertifikat noch nicht gültig ist. Bitte überprüfen Sie Ihre Systemzeit."
     IDS_NFO_STATE_RECONNECTING "Aktueller Status: Erneut verbinden"
     IDS_NFO_STATE_DISCONNECTED "Aktueller Status: Getrennt"
-    IDS_NFO_CONN_TERMINATED "Verbindung zu %s wurde getrennt."
+    IDS_NFO_CONN_TERMINATED "Verbindung zu %ls wurde getrennt."
     IDS_NFO_STATE_FAILED "Aktueller Status: Konnte Verbindung nicht herstellen"
-    IDS_NFO_CONN_FAILED "Verbindung zu %s ist fehlgeschlagen."
+    IDS_NFO_CONN_FAILED "Verbindung zu %ls ist fehlgeschlagen."
     IDS_NFO_STATE_FAILED_RECONN "Aktueller Status: Konnte Verbindung nicht erneut herstellen."
-    IDS_NFO_RECONN_FAILED "Erneutes Verbinden zu %s ist fehlgeschlagen."
+    IDS_NFO_RECONN_FAILED "Erneutes Verbinden zu %ls ist fehlgeschlagen."
     IDS_NFO_STATE_SUSPENDED "Aktueller Status: Unterbrochen"
     IDS_ERR_READ_STDOUT_PIPE "Fehler beim Lesen der OpenVPN StdOut Pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Erstellen des RichEdit LogWindow fehlgeschlagen!"
     IDS_ERR_SET_SIZE "Setzen der Größe ist fehlgeschlagen!"
-    IDS_ERR_AUTOSTART_CONF "Kann gewünschte Konfigurationsdatei für Autostart nicht finden: %s"
+    IDS_ERR_AUTOSTART_CONF "Kann gewünschte Konfigurationsdatei für Autostart nicht finden: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead fehlgeschlagen."
     IDS_NFO_STATE_CONNECTING "Aktueller Status: Verbinden"
-    IDS_NFO_CONNECTION_XXX "OpenVPN Verbindung (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN Verbindung (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Aktueller Status: Verbindungsskript läuft"
     IDS_NFO_STATE_DISCONN_SCRIPT "Aktueller Status: Trennungsskript läuft"
-    IDS_ERR_RUN_CONN_SCRIPT "Fehler beim Ausführen des Verbindungsskripts: %s"
-    IDS_ERR_GET_EXIT_CODE "Fehler beim Erfassen des Exit-Codes des Verbinungsskripts (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Fehler beim Ausführen des Verbindungsskripts: %ls"
+    IDS_ERR_GET_EXIT_CODE "Fehler beim Erfassen des Exit-Codes des Verbinungsskripts (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Verbindungsskript fehlgeschlagen. (Exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Verbindungsskript fehlgeschlagen. Abgebrochen nach %d Sekunden."
-    IDS_ERR_CONFIG_EXIST "Es existiert bereits eine Konfigurationsdatei mit dem Namen '%s'. Sie könnnen \
+    IDS_ERR_CONFIG_EXIST "Es existiert bereits eine Konfigurationsdatei mit dem Namen '%ls'. Sie könnnen \
 nicht mehrere Konfigurationsdateien mit dem gleichen Namen haben, außer sie \
 liegen in unterschiedlichen Verzeichnissen."
     IDS_NFO_CONN_TIMEOUT "Die Verbindung zur Verwaltungsschnittstelle ist fehlgeschlagen.\n\
-Konsultieren Sie die Log-Datei (%s) für weitere Informationen."
+Konsultieren Sie die Log-Datei (%ls) für weitere Informationen."
     /* main – Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Fehler beim Öffnen der Debugdatei (%s)."
-    IDS_ERR_CREATE_PATH "Fehler beim Erstellen des %s Pfads:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Fehler beim Öffnen der Debugdatei (%ls)."
+    IDS_ERR_CREATE_PATH "Fehler beim Erstellen des %ls Pfads:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Kann RICHED20.DLL nicht laden."
     IDS_ERR_SHELL_DLL_VERSION "Die shell32.dll Versionsnummer ist zu niedrig (0x%lx). Es muss mindestens Version 5.0 installiert sein."
     IDS_NFO_SERVICE_STARTED "OpenVPN-Dienst gestartet."
@@ -425,26 +425,26 @@ Option zum Überschreiben der Registry Einstellungen:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI Verwendung"
-    IDS_ERR_BAD_PARAMETER "Es wurde versucht, ""%s"" als einen Parameter zu parsen, es \
+    IDS_ERR_BAD_PARAMETER "Es wurde versucht, ""%ls"" als einen Parameter zu parsen, es \
 konnte jedoch kein '--' am Anfang des Parameters gefunden werden."
-    IDS_ERR_BAD_OPTION "Fehler: Unbekannte Option oder fehlende(r) Parameter: --%s\n\
+    IDS_ERR_BAD_OPTION "Fehler: Unbekannte Option oder fehlende(r) Parameter: --%ls\n\
 Geben Sie 'openvpn-gui --help' für mehr Informationen ein."
 
     /* passphrase – Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread, welcher den ChangePassphrase Dialog anzeigt, ist fehlgeschlagen."
-    IDS_NFO_CHANGE_PWD "Passwort ändern (%s)"
+    IDS_NFO_CHANGE_PWD "Passwort ändern (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Das eingegebene Passwort ist falsch. Bitte versuchen Sie es erneut."
     IDS_ERR_PWD_TO_SHORT "Das neue Passwort muss mindestens %d Zeichen lang sein."
     IDS_NFO_EMPTY_PWD "Sind Sie sicher, dass Sie ein LEERES Passwort setzen möchten?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Unbekanntes Schlüsseldatei Format."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Fehler beim Öffnen des privaten Schlüssels (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Fehler beim Öffnen des privaten Schlüssels (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Das alte Passwort ist falsch."
-    IDS_ERR_OPEN_WRITE_KEY "Fehler beim Öffnen des privaten Schlüssels (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Fehler beim Schreiben eines neuen privaten Schlüssel (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Fehler beim Öffnen des privaten Schlüssels (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Fehler beim Schreiben eines neuen privaten Schlüssel (%ls)."
     IDS_NFO_PWD_CHANGED "Ihr Passwort wurde geändert."
-    IDS_ERR_READ_PKCS12 "Fehler beim Lesen der PKCS #12 Datei (%s)."
+    IDS_ERR_READ_PKCS12 "Fehler beim Lesen der PKCS #12 Datei (%ls)."
     IDS_ERR_CREATE_PKCS12 "Fehler beim Erstellen eines neuen PKCS #12 Objekts. Das Ändern des Passworts ist fehlgeschlagen."
-    IDS_ERR_OPEN_CONFIG "Die Konfigurationsdatei konnte nicht geöffnet werden: (%s)"
+    IDS_ERR_OPEN_CONFIG "Die Konfigurationsdatei konnte nicht geöffnet werden: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "Sie können nicht mehr als eine ""key"" Optionen in Ihrer Konfiguration verwenden."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Sie können nicht beide ""key"" und ""pkcs12"" Optionen in Ihrer Konfiguration verwenden."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Sie können nicht mehr als eine ""pkcs12"" Option in Ihrer Konfiguration verwenden."
@@ -467,7 +467,7 @@ Bitte verwenden Sie ein anderes Passwort."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Sie müssen eine SOCKS-Proxy-Adresse festlegen."
     IDS_ERR_SOCKS_PROXY_PORT "Sie müssen einen SOCKS-Proxy-Port festlegen."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Sie müssen einen SOCKS-Proxy-Port zwischen 1 und 65535 festlegen."
-    IDS_ERR_CREATE_REG_HKCU_KEY "Fehler beim Erstellen des ""HKEY_CURRENT_USER\\%s"" Schlüssels."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Fehler beim Erstellen des ""HKEY_CURRENT_USER\\%ls"" Schlüssels."
     IDS_ERR_GET_TEMP_PATH "Fehler beim Erkennen des TempPath mit GetTempPath(). Verwende stattdessen ""C:\\"""
 
     /* service */
@@ -501,24 +501,24 @@ OpenVPN ist vermutlich nicht installiert"
     IDS_ERR_CREATE_REG_KEY "Fehler beim Erstellen des Registry-Schlüssels HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Fehler beim Öffnen der Registry. Sie müssen diese Anwendung einmal \
 als Administrator ausführen, um die Registry zu aktualisieren."
-    IDS_ERR_READ_SET_KEY "Fehler beim Lesen und Setzen des Registry-Schlüssels ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Fehler beim Schreiben des Registry-Schlüssels ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Fehler beim Lesen und Setzen des Registry-Schlüssels ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Fehler beim Schreiben des Registry-Schlüssels ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Eine Konfigurationsdatei namens ""%s"" existiert bereits."
+    IDS_ERR_IMPORT_EXISTS "Eine Konfigurationsdatei namens ""%ls"" existiert bereits."
     IDS_ERR_IMPORT_FAILED "Fehler beim Importieren der Konfigurationsdatei. Der folgende Pfad konnte nicht erstellt werden:\n\n\
-%s\n\nVergewissern Sie sich, dass Sie die erforderlichen Berechtigungen besitzen."
+%ls\n\nVergewissern Sie sich, dass Sie die erforderlichen Berechtigungen besitzen."
     IDS_NFO_IMPORT_SUCCESS "Die Konfigurationsdatei wurde erfolgreich importiert."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Drücken Sie OK um die gespeicherten Passwörter für die Konfiguration ""%s"" zu löschen."
+    IDS_NFO_DELETE_PASS "Drücken Sie OK um die gespeicherten Passwörter für die Konfiguration ""%ls"" zu löschen."
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Passwort"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Geben Sie ein Passwort/PIN für das Token '%S' ein"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Geben Sie ein Passwort/PIN für das Token '%hs' ein"
 
     IDS_NFO_AUTH_PASS_RETRY "Falscher Benutzername oder Passwort. Erneut versuchen…"
     IDS_NFO_KEY_PASS_RETRY  "Falsches Passwort. Erneut versuchen…"
@@ -526,6 +526,6 @@ als Administrator ausführen, um die Registry zu aktualisieren."
     IDS_ERR_INVALID_USERNAME_INPUT "Unzulässiges Zeichen im Benutzername"
     IDS_NFO_AUTO_CONNECT    "Verbindet automatisch in %u Sekunden…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI läuft bereits. Klicken Sie rechts auf das Symbol in der Taskleiste, um die Anwendung zu starten."
-    IDS_NFO_BYTECOUNT "Bytes eingehend: %s  ausgehend: %s"
+    IDS_NFO_BYTECOUNT "Bytes eingehend: %ls  ausgehend: %ls"
 
 END

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -221,7 +221,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DANISH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - Et Windows-brugerprogram til OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - Et Windows-brugerprogram til OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -277,7 +277,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nForbundet: "
     IDS_TIP_CONNECTING "\nEtablere forbindelse: "
     IDS_TIP_CONNECTED_SINCE "\nForbundet siden: "
-    IDS_TIP_ASSIGNED_IP "\nTildelt IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nTildelt IP: %ls"
     IDS_MENU_SERVICE "OpenVPN Service"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -302,28 +302,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Vil du afbryde? (Stoppe OpenVPN Service)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Fejl ved start af log fremviser: %s"
-    IDS_ERR_START_CONF_EDITOR "Fejl ved start af konfigurations editor: %s"
+    IDS_ERR_START_LOG_VIEWER "Fejl ved start af log fremviser: %ls"
+    IDS_ERR_START_CONF_EDITOR "Fejl ved start af konfigurations editor: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "Du kan ikke have flere end %d konfigurations-filer. Kontakt udvikleren af OpenVPN GUI hvis du har behov for at håndtere flere."
     IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n\
-Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in \
-""%s"" group. Contact your system administrator.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+Use the ""Import File.."" menu or copy your config files to ""%ls"" or ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%ls) requires membership in \
+""%ls"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Do you want to add yourself to this group?\n\
 This action may prompt for administrative password or consent."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Please complete the previous authorization dialog."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%ls"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Du kan kun have en forbindelse igang samtidig med ældre versioner af OpenVPN end 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Du kan ikke tilslutte med OpenVPN GUI når OpenVPN Service kører. (kun OpenVPN 1.5/1.6). Stop tjenesten først hvis du vil bruge OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "CreateEvent fejlede ved exit event: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Ukendt prioritet: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Log-filens tilføjelses-markering (brugt med '%s') skal være '0' eller '1'"
+    IDS_ERR_CREATE_EVENT "CreateEvent fejlede ved exit event: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Ukendt prioritet: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Log-filens tilføjelses-markering (brugt med '%ls') skal være '0' eller '1'"
     IDS_ERR_GET_MSIE_PROXY "Kunne ikke hente indstillinger for HTTP Proxy fra Internet Explorer."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor fejlramt."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl fejlramt."
@@ -331,41 +331,41 @@ Please complete the previous authorization dialog."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe på hInputRead fejlramt."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle på hOutputRead fejlramt."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle på hInputWrite fejlramt."
-    IDS_ERR_CREATE_PROCESS "CreateProcess fejlramt, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess fejlramt, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread for at vise statusvindue fejlramt."
     IDS_NFO_STATE_WAIT_TERM "Status: Venter på OpenVPN afslutning…"
     IDS_NFO_STATE_CONNECTED "Status: Forbundet"
-    IDS_NFO_NOW_CONNECTED "%s er forbundet."
-    IDS_NFO_ASSIGN_IP "tildelt IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls er forbundet."
+    IDS_NFO_ASSIGN_IP "tildelt IP: %ls"
     IDS_ERR_CERT_EXPIRED "Kunne ikke forbinde, dit certifikat er for gammelt eller uret på din PC er forkert."
     IDS_ERR_CERT_NOT_YET_VALID "Kunne ikke forbinde, dit certifikat er dateret fremad i tiden eller uret på din PC er forkert."
     IDS_NFO_STATE_RECONNECTING "Status: Genforbinder"
     IDS_NFO_STATE_DISCONNECTED "Status: Afbrudt"
-    IDS_NFO_CONN_TERMINATED "Du er blevet frakoblet/afbrudt %s."
+    IDS_NFO_CONN_TERMINATED "Du er blevet frakoblet/afbrudt %ls."
     IDS_NFO_STATE_FAILED "Status: Forbindelse fejlet."
-    IDS_NFO_CONN_FAILED "Forbindelse til %s fejlet."
+    IDS_NFO_CONN_FAILED "Forbindelse til %ls fejlet."
     IDS_NFO_STATE_FAILED_RECONN "Status: Kunne ikke genforbinde"
-    IDS_NFO_RECONN_FAILED "Forbindelse til %s fejlet."
+    IDS_NFO_RECONN_FAILED "Forbindelse til %ls fejlet."
     IDS_NFO_STATE_SUSPENDED "Status: I dvale (midlertidigt afbrudt)"
     IDS_ERR_READ_STDOUT_PIPE "Fejl under læsning fra OpenVPN StdOut pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Oprettelse af RichEdit LogWindow fejlramt!!"
     IDS_ERR_SET_SIZE "Set Size fejlramt!"
-    IDS_ERR_AUTOSTART_CONF "Følgende config kunne ikke starte automatisk: %s"
+    IDS_ERR_AUTOSTART_CONF "Følgende config kunne ikke starte automatisk: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe på hInputRead fejlramt."
     IDS_NFO_STATE_CONNECTING "Status: Forbinder"
-    IDS_NFO_CONNECTION_XXX "OpenVPN forbundet (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN forbundet (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Status: Kører forbind-script"
     IDS_NFO_STATE_DISCONN_SCRIPT "Status: Kører afbryd-script"
-    IDS_ERR_RUN_CONN_SCRIPT "En fejl opstod under kørsel af script: %s"
-    IDS_ERR_GET_EXIT_CODE "Fejlede med at få Exit-kode fra forbind-script: %s"
+    IDS_ERR_RUN_CONN_SCRIPT "En fejl opstod under kørsel af script: %ls"
+    IDS_ERR_GET_EXIT_CODE "Fejlede med at få Exit-kode fra forbind-script: %ls"
     IDS_ERR_CONN_SCRIPT_FAILED "Forbind-scriptet fejlet. (Exit-kode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Forbind-scriptet fik TimeOut efter %d sekunder."
-    IDS_ERR_CONFIG_EXIST "Det findes allerede en konfigurations-fil med navn '%s'. Du kan ikke have flere \
+    IDS_ERR_CONFIG_EXIST "Det findes allerede en konfigurations-fil med navn '%ls'. Du kan ikke have flere \
 konfigurations-filer med samme navn, selv om de \
 ligger i forskellige kataloger."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Fejl under åbning af debug fil. (%s)"
-    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Fejl under åbning af debug fil. (%ls)"
+    IDS_ERR_CREATE_PATH "Could not create %ls path:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Kunne ikke indlæse RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Din shell32.dll version er for lav (0x%lx). Du skal have mindst version 5.0."
     IDS_NFO_SERVICE_STARTED "OpenVPN Service startet."
@@ -422,26 +422,26 @@ Parametre som vil tilsidesætte indstillinger i registreringsdatabasen:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI brug"
-    IDS_ERR_BAD_PARAMETER "Forsøger at tolke ""%s"" som en --option parameter \
+    IDS_ERR_BAD_PARAMETER "Forsøger at tolke ""%ls"" som en --option parameter \
 men kan ikke finde indledende '--'"
-    IDS_ERR_BAD_OPTION "Parameter fejl: Ukendt parameter eller manglende argument: --%s\n\
+    IDS_ERR_BAD_OPTION "Parameter fejl: Ukendt parameter eller manglende argument: --%ls\n\
 Kør openvpn-gui --help for hjælp."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread for at vise at ChangePassphrase dialogen fejlede."
-    IDS_NFO_CHANGE_PWD "Ændre kodeord (%s)"
+    IDS_NFO_CHANGE_PWD "Ændre kodeord (%ls)"
     IDS_ERR_PWD_DONT_MATCH "De indtastede nye kodeord er forskellige. Prøv igen"
     IDS_ERR_PWD_TO_SHORT "Kodeord skal være mindst %d tegn."
     IDS_NFO_EMPTY_PWD "Er du sikker på at du vil bruge et BLANKT kodeord??"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Nøglefilen har ukendt format."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "En fejl opstod under åbning af nøgle-fil (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "En fejl opstod under åbning af nøgle-fil (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Du har indtastet forkert kodeord."
-    IDS_ERR_OPEN_WRITE_KEY "En fejl opstod under åbning af nøgle-fil til skrivning (%s)."
-    IDS_ERR_WRITE_NEW_KEY "En fejl opstod under oprettelse af ny nøgle-fil (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "En fejl opstod under åbning af nøgle-fil til skrivning (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "En fejl opstod under oprettelse af ny nøgle-fil (%ls)."
     IDS_NFO_PWD_CHANGED "Dit kodeord er blevet ændret."
-    IDS_ERR_READ_PKCS12 "Fejl under læsning fra pkcs #12 fil (%s)."
+    IDS_ERR_READ_PKCS12 "Fejl under læsning fra pkcs #12 fil (%ls)."
     IDS_ERR_CREATE_PKCS12 "En fejl opstod under oprettelse af pkcs12 objekt."
-    IDS_ERR_OPEN_CONFIG "En fejl opstod under åbning af følgende konfigurations-fil: %s."
+    IDS_ERR_OPEN_CONFIG "En fejl opstod under åbning af følgende konfigurations-fil: %ls."
     IDS_ERR_ONLY_ONE_KEY_OPTION "Du kan ikke have mere end en ""key"" parameter i din konfigurations-fil."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Du kan ikke have både ""key"" og ""pkcs12"" parametre i din konfigurations-fil."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Du kan ikke have mere end en ""pkcs12"" parameter i din konfigurations-fil."
@@ -464,7 +464,7 @@ Forsøg igen."
     IDS_ERR_SOCKS_PROXY_ADDRESS "SOCKS proxy addresse skal oplyses."
     IDS_ERR_SOCKS_PROXY_PORT "SOCKS proxy port skal oplyses."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "SOCKS proxy port skal være et tal mellem 1 og 65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "En fejl opstod ved oprettelse af register-nøgle ""HKEY_CURRENT_USER\\%s"""
+    IDS_ERR_CREATE_REG_HKCU_KEY "En fejl opstod ved oprettelse af register-nøgle ""HKEY_CURRENT_USER\\%ls"""
     IDS_ERR_GET_TEMP_PATH "En fejl opstod da GetTempPath() skulle bestemmes. Alternativet ""C:\\"" vil blive benyttet."
 
     /* service */
@@ -498,24 +498,24 @@ OpenVPN er måske ikke installeret."
     IDS_ERR_CREATE_REG_KEY "Fejl under oprettelse af register-nøgle HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Fejl under åbning af register til skrivning. Du skal starte programmet \
 en gang som administrator for at opdatere registret."
-    IDS_ERR_READ_SET_KEY "Fejl under læsning og skrivning af register-værdi ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Fejl under skrivning af register-værdi ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Fejl under læsning og skrivning af register-værdi ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Fejl under skrivning af register-værdi ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n\
-%s\n\nMake sure you have the right permissions."
+%ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
@@ -523,6 +523,6 @@ en gang som administrator for at opdatere registret."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -235,7 +235,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ENGLISH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s – A Windows GUI for OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls – A Windows GUI for OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -291,7 +291,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nConnected to: "
     IDS_TIP_CONNECTING "\nConnecting to: "
     IDS_TIP_CONNECTED_SINCE "\nConnected since: "
-    IDS_TIP_ASSIGNED_IP "\nAssigned IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nAssigned IP: %ls"
     IDS_MENU_SERVICE "OpenVPN Service"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -316,28 +316,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Do you want to disconnect (Stop the OpenVPN Service)?"
 
     /* Logviewer – Resources */
-    IDS_ERR_START_LOG_VIEWER "Error starting log-viewer: %s"
-    IDS_ERR_START_CONF_EDITOR "Error starting config-editor: %s"
+    IDS_ERR_START_LOG_VIEWER "Error starting log-viewer: %ls"
+    IDS_ERR_START_CONF_EDITOR "Error starting config-editor: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "For the given parameter set, OpenVPN GUI can not support more than %d configs. Configs beyond this number are ignored."
     IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n\
-Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in \
-""%s"" group. Contact your system administrator.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+Use the ""Import File.."" menu or copy your config files to ""%ls"" or ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%ls) requires membership in \
+""%ls"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Do you want to add yourself to this group?\n\
 This action may prompt for administrative password or consent."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Please complete the previous authorization dialog."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%ls"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "You can only have one connection running at the same time when using an older version on OpenVPN than 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "You cannot use OpenVPN GUI to start a connection while the OpenVPN Service is running (with OpenVPN 1.5/1.6). Stop OpenVPN Service first if you want to use OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "CreateEvent failed on exit event: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Unknown priority name: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Log file append flag (given as '%s') must be '0' or '1'."
+    IDS_ERR_CREATE_EVENT "CreateEvent failed on exit event: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Unknown priority name: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Log file append flag (given as '%ls') must be '0' or '1'."
     IDS_ERR_GET_MSIE_PROXY "Could not to get MSIE proxy settings."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor failed."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl failed."
@@ -345,43 +345,43 @@ Please complete the previous authorization dialog."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe on hInputRead failed."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead failed."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite failed."
-    IDS_ERR_CREATE_PROCESS "CreateProcess failed, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess failed, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread to show Status window Failed."
     IDS_NFO_STATE_WAIT_TERM "Current State: Waiting for OpenVPN to terminate…"
     IDS_NFO_STATE_CONNECTED "Current State: Connected"
-    IDS_NFO_NOW_CONNECTED "%s is now connected."
-    IDS_NFO_ASSIGN_IP "Assigned IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls is now connected."
+    IDS_NFO_ASSIGN_IP "Assigned IP: %ls"
     IDS_ERR_CERT_EXPIRED "Unable to connect because your certificate has expired or the system time is incorrect."
     IDS_ERR_CERT_NOT_YET_VALID "Unable to connect because your certificate is not yet valid. Check that your system time is correct."
     IDS_NFO_STATE_RECONNECTING "Current State: Reconnecting"
     IDS_NFO_STATE_DISCONNECTED "Current State: Disconnected"
-    IDS_NFO_CONN_TERMINATED "Connection to %s was terminated."
+    IDS_NFO_CONN_TERMINATED "Connection to %ls was terminated."
     IDS_NFO_STATE_FAILED "Current State: Failed to connect"
-    IDS_NFO_CONN_FAILED "Connecting to %s has failed."
+    IDS_NFO_CONN_FAILED "Connecting to %ls has failed."
     IDS_NFO_STATE_FAILED_RECONN "Current State: Failed to reconnect"
-    IDS_NFO_RECONN_FAILED "ReConnecting to %s has failed."
+    IDS_NFO_RECONN_FAILED "ReConnecting to %ls has failed."
     IDS_NFO_STATE_SUSPENDED "Current State: Suspended"
     IDS_ERR_READ_STDOUT_PIPE "Error reading from OpenVPN StdOut Pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Creating RichEdit LogWindow Failed!!"
     IDS_ERR_SET_SIZE "Set Size failed!"
-    IDS_ERR_AUTOSTART_CONF "Cannot find requested config to autostart: %s"
+    IDS_ERR_AUTOSTART_CONF "Cannot find requested config to autostart: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead failed."
     IDS_NFO_STATE_CONNECTING "Current State: Connecting"
-    IDS_NFO_CONNECTION_XXX "OpenVPN Connection (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN Connection (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Current State: Running Connect Script"
     IDS_NFO_STATE_DISCONN_SCRIPT "Current State: Running Disconnect Script"
-    IDS_ERR_RUN_CONN_SCRIPT "Error running Connect Script: %s"
-    IDS_ERR_GET_EXIT_CODE "Failed to get ExitCode of Connect Script (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Error running Connect Script: %ls"
+    IDS_ERR_GET_EXIT_CODE "Failed to get ExitCode of Connect Script (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Connect Script failed. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Connect Script failed. TimeOut after %d sec."
-    IDS_ERR_CONFIG_EXIST "There already exist a config file named '%s'. You cannot \
+    IDS_ERR_CONFIG_EXIST "There already exist a config file named '%ls'. You cannot \
 have multiple config files with the same name, even if \
 they reside in different folders."
     IDS_NFO_CONN_TIMEOUT "Connecting to management interface failed.\n\
-View log file (%s) for more details."
+View log file (%ls) for more details."
     /* main – Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Error opening debug file (%s) for output."
-    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Error opening debug file (%ls) for output."
+    IDS_ERR_CREATE_PATH "Could not create %ls path:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Could not load RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Your shell32.dll version is to low (0x%lx). You need at least version 5.0."
     IDS_NFO_SERVICE_STARTED "OpenVPN Service started."
@@ -436,26 +436,26 @@ Options to override registry settings:\n\
 \t\t\t Must be in the range 1 to 61000. Maximum number of configs is limited by 65536 minus this value. Default=25340.\n"
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI Usage"
-    IDS_ERR_BAD_PARAMETER "I'm trying to parse ""%s"" as an --option parameter \
+    IDS_ERR_BAD_PARAMETER "I'm trying to parse ""%ls"" as an --option parameter \
 but I don't see a leading '--'"
-    IDS_ERR_BAD_OPTION "Options error: Unrecognized option or missing parameter(s): --%s\n\
+    IDS_ERR_BAD_OPTION "Options error: Unrecognized option or missing parameter(s): --%ls\n\
 Use openvpn-gui --help for more info."
 
     /* passphrase – Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread to show ChangePassphrase dialog failed."
-    IDS_NFO_CHANGE_PWD "Change Private Key Password (%s)"
+    IDS_NFO_CHANGE_PWD "Change Private Key Password (%ls)"
     IDS_ERR_PWD_DONT_MATCH "The passwords you typed do not match. Try again."
     IDS_ERR_PWD_TO_SHORT "Your new password must be at least %d characters long."
     IDS_NFO_EMPTY_PWD "Are you sure you want to set an EMPTY password?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Unknown keyfile format."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Error opening private key file (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Error opening private key file (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "The old password is incorrect."
-    IDS_ERR_OPEN_WRITE_KEY "Error opening private key file for writing (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Error writing new private key file (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Error opening private key file for writing (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Error writing new private key file (%ls)."
     IDS_NFO_PWD_CHANGED "Your password has been changed."
-    IDS_ERR_READ_PKCS12 "Error reading PKCS #12 file (%s)."
+    IDS_ERR_READ_PKCS12 "Error reading PKCS #12 file (%ls)."
     IDS_ERR_CREATE_PKCS12 "Error creating new PKCS #12 object. Change Password has failed."
-    IDS_ERR_OPEN_CONFIG "Could not open config file for reading: (%s)"
+    IDS_ERR_OPEN_CONFIG "Could not open config file for reading: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "You cannot have more than one ""key"" option in your config."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "You cannot have both ""key"" and ""pkcs12"" options in your config."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "You cannot have more than one ""pkcs12"" option in your config."
@@ -478,7 +478,7 @@ Please choose another one."
     IDS_ERR_SOCKS_PROXY_ADDRESS "You must specify a SOCKS proxy address."
     IDS_ERR_SOCKS_PROXY_PORT "You must specify a SOCKS proxy port."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "You must specify a SOCKS proxy port between 1 and 65535."
-    IDS_ERR_CREATE_REG_HKCU_KEY "Error creating ""HKEY_CURRENT_USER\\%s"" key."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Error creating ""HKEY_CURRENT_USER\\%ls"" key."
     IDS_ERR_GET_TEMP_PATH "Error determining TempPath with GetTempPath(). Using ""C:\\"" instead."
 
     /* service */
@@ -512,24 +512,24 @@ OpenVPN is probably not installed"
     IDS_ERR_CREATE_REG_KEY "Error creating HKLM\\SOFTWARE\\OpenVPN-GUI key."
     IDS_ERR_OPEN_WRITE_REG "Failed to open the registry for writing. You need to run this application \
 once as Administrator to update the registry."
-    IDS_ERR_READ_SET_KEY "Error reading and setting registry key ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Error writing registry value ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Error reading and setting registry key ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Error writing registry value ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n\
-%s\n\nMake sure you have the right permissions."
+%ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
@@ -537,7 +537,7 @@ once as Administrator to update the registry."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -219,7 +219,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SPANISH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - Un frontend de Windows para OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - Un frontend de Windows para OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -275,7 +275,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nConectado a: "
     IDS_TIP_CONNECTING "\nConectando a: "
     IDS_TIP_CONNECTED_SINCE "\nConectado desde: "
-    IDS_TIP_ASSIGNED_IP "\nIP asignada: %s"
+    IDS_TIP_ASSIGNED_IP "\nIP asignada: %ls"
     IDS_MENU_SERVICE "Servicio OpenVPN"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -300,28 +300,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "¿Quiere desconectar (Parar el servicio OpenVPN)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Error arrancando el visor de log: %s"
-    IDS_ERR_START_CONF_EDITOR "Error arrancando el editor de configuración: %s"
+    IDS_ERR_START_LOG_VIEWER "Error arrancando el visor de log: %ls"
+    IDS_ERR_START_CONF_EDITOR "Error arrancando el editor de configuración: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI no soporta más de %d configuraciones. Contacte con el autor si necesita más."
     IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n\
-Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in \
-""%s"" group. Contact your system administrator.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+Use the ""Import File.."" menu or copy your config files to ""%ls"" or ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%ls) requires membership in \
+""%ls"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Do you want to add yourself to this group?\n\
 This action may prompt for administrative password or consent."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Please complete the previous authorization dialog."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%ls"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Sólo se puede tener una conexión activa a la vez usando una version de OpenVPN anterior a la 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "No se puede usar OpenVPN GUI para inicar una conexión mientras el servicio OpenVPN está ejecutándose (con OpenVPN 1.5/1.6). Detenga primero el servicio OpenVPN si quiere utilizar OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "CreateEvent fallido con evento de salida: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Nombre de prioridad desconocido: %s"
-    IDS_ERR_LOG_APPEND_BOOL "El flag de append para el fichero de log (dado como '%s') debe ser '0' ó '1'"
+    IDS_ERR_CREATE_EVENT "CreateEvent fallido con evento de salida: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Nombre de prioridad desconocido: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "El flag de append para el fichero de log (dado como '%ls') debe ser '0' ó '1'"
     IDS_ERR_GET_MSIE_PROXY "Imposible importar la configuración del MSIE."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor fallido."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl fallido."
@@ -329,41 +329,41 @@ Please complete the previous authorization dialog."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe on hInputRead fallido."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead fallido."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite fallido."
-    IDS_ERR_CREATE_PROCESS "CreateProcess fallido, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess fallido, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread para mostrar la Ventana de Estado fallido."
     IDS_NFO_STATE_WAIT_TERM "Estado actual: Esperando que OpenVPN termine…"
     IDS_NFO_STATE_CONNECTED "Estado actual: Conectado."
-    IDS_NFO_NOW_CONNECTED "Conectado a %s."
-    IDS_NFO_ASSIGN_IP "IP asignada: %s"
+    IDS_NFO_NOW_CONNECTED "Conectado a %ls."
+    IDS_NFO_ASSIGN_IP "IP asignada: %ls"
     IDS_ERR_CERT_EXPIRED "Imposible conectar porque su certificado ha expirado o la hora del sistema no es correcta."
     IDS_ERR_CERT_NOT_YET_VALID "Imposible conectar porque su certificado aún no es válido. Compruebe que la hora de su sistema es correcta."
     IDS_NFO_STATE_RECONNECTING "Estado actual: Reconectando"
     IDS_NFO_STATE_DISCONNECTED "Estado actual: Desconectado"
-    IDS_NFO_CONN_TERMINATED "La conexión con %s ha terminado."
+    IDS_NFO_CONN_TERMINATED "La conexión con %ls ha terminado."
     IDS_NFO_STATE_FAILED "Estado actual: Error al conectar"
-    IDS_NFO_CONN_FAILED "La conexión con %s ha fallado."
+    IDS_NFO_CONN_FAILED "La conexión con %ls ha fallado."
     IDS_NFO_STATE_FAILED_RECONN "Current State: Failed to reconnect"
-    IDS_NFO_RECONN_FAILED "ReConnecting to %s has failed."
+    IDS_NFO_RECONN_FAILED "ReConnecting to %ls has failed."
     IDS_NFO_STATE_SUSPENDED "Estado actual: Suspendido"
     IDS_ERR_READ_STDOUT_PIPE "Error leyendo del pipe de OpenVPN StdOut."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "La creación de RichEdit LogWindow falló!!"
     IDS_ERR_SET_SIZE "Set Size falló!"
-    IDS_ERR_AUTOSTART_CONF "No se encuentra la configuración requerida para el autoinicio: %s"
+    IDS_ERR_AUTOSTART_CONF "No se encuentra la configuración requerida para el autoinicio: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead falló."
     IDS_NFO_STATE_CONNECTING "Estado actual: Conectando"
-    IDS_NFO_CONNECTION_XXX "Conexión OpenVPN (%s)"
+    IDS_NFO_CONNECTION_XXX "Conexión OpenVPN (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Estado actual: Ejecutando el script de conexión"
     IDS_NFO_STATE_DISCONN_SCRIPT "Estado actual: Ejecutando el script de desconexión"
-    IDS_ERR_RUN_CONN_SCRIPT "Error ejecutando el script de conexión: %s"
-    IDS_ERR_GET_EXIT_CODE "Error al obtener el ExitCode del script de conexión (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Error ejecutando el script de conexión: %ls"
+    IDS_ERR_GET_EXIT_CODE "Error al obtener el ExitCode del script de conexión (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Script de conexión fallido. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Script de conexión fallido. TimeOut tras %d seg."
-    IDS_ERR_CONFIG_EXIST "Ya existe un fichero de configuración llamado '%s'. No puede \
+    IDS_ERR_CONFIG_EXIST "Ya existe un fichero de configuración llamado '%ls'. No puede \
 haber varios ficheros de configuración con el mismo nombre, incluso si \
 están en directorios diferentes."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Error al abrir el fichero de debug (%s) para salida."
-    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Error al abrir el fichero de debug (%ls) para salida."
+    IDS_ERR_CREATE_PATH "Could not create %ls path:\n%ls"
     IDS_ERR_LOAD_RICHED20 "No se puede cargar RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "La versión del shell32.dll es demasiado antigua (0x%lx). Se necesita al menos la versión 5.0."
     IDS_NFO_SERVICE_STARTED "Servcio OpenVPN iniciado."
@@ -419,26 +419,26 @@ Opciones para sobreescribir opciones del registro:\n\
 
 
     IDS_NFO_USAGECAPTION "Uso de OpenVPN GUI"
-    IDS_ERR_BAD_PARAMETER "Intento parsear ""%s"" como un parámetro de --option \
+    IDS_ERR_BAD_PARAMETER "Intento parsear ""%ls"" como un parámetro de --option \
 pero no veo delante un '--'"
-    IDS_ERR_BAD_OPTION "Error de opciones: Opción no reconocida o falta(n) parámetro(s): --%s\n\
+    IDS_ERR_BAD_OPTION "Error de opciones: Opción no reconocida o falta(n) parámetro(s): --%ls\n\
 Use openvpn-gui --help para más información."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread para mostrar la ventana de ChangePassphrase falló."
-    IDS_NFO_CHANGE_PWD "Cambiar Clave (%s)"
+    IDS_NFO_CHANGE_PWD "Cambiar Clave (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Las claves escritas no coinciden. Inténtelo de nuevo."
     IDS_ERR_PWD_TO_SHORT "La nueva clave ha de ser al menos de %d caracteres de longitud."
     IDS_NFO_EMPTY_PWD "¿Está seguro de querer usar una clave VACIA?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Formato de keyfile desconocido."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Error al abrir el fichero de clave privada (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Error al abrir el fichero de clave privada (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "La clave anterior no es correcta."
-    IDS_ERR_OPEN_WRITE_KEY "Error al abrir el fichero de clave privada para escritura (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Error al escribir el nuevo fichero de clave privada (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Error al abrir el fichero de clave privada para escritura (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Error al escribir el nuevo fichero de clave privada (%ls)."
     IDS_NFO_PWD_CHANGED "Su clave ha sido cambiada."
-    IDS_ERR_READ_PKCS12 "Error al leer el fichero PKCS #12 (%s)."
+    IDS_ERR_READ_PKCS12 "Error al leer el fichero PKCS #12 (%ls)."
     IDS_ERR_CREATE_PKCS12 "Error al crear el nuevo objeto PKCS #12. El cambio de clave ha fallado."
-    IDS_ERR_OPEN_CONFIG "No se pudo abrir el fichero de configuración para lectura: (%s)"
+    IDS_ERR_OPEN_CONFIG "No se pudo abrir el fichero de configuración para lectura: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "No se puede tener más de una opción ""key"" en la configuración."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "No se pueden tener a la vez las opciones de ""key"" y ""pkcs12"" en la configuración."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "No se puede tener más de una opción de ""pkcs12"" en la configuración."
@@ -461,7 +461,7 @@ Por favor elija otra."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Debe especificarse una dirección para el proxy SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT "Debe especificarse un puerto para el proxy SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Debe especificarse un puerto entre 1-65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "Error al crear la clave ""HKEY_CURRENT_USER\\%s""."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Error al crear la clave ""HKEY_CURRENT_USER\\%ls""."
     IDS_ERR_GET_TEMP_PATH "Error al determinar TempPath con GetTempPath(). Usando ""C:\\"" en su lugar."
 
     /* service */
@@ -495,24 +495,24 @@ OpenVPN probablemente no está instalado"
     IDS_ERR_CREATE_REG_KEY "Error al crear la clave HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Error al abrir el registro para escritura. Debe ejecutar ésta aplicación de \
 nuevo como Administrator para actualizar el registro."
-    IDS_ERR_READ_SET_KEY "Error al leer y escribir la clave de registro ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Error al escribir el valor del registro ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Error al leer y escribir la clave de registro ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Error al escribir el valor del registro ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n\
-%s\n\nMake sure you have the right permissions."
+%ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
@@ -520,6 +520,6 @@ nuevo como Administrator para actualizar el registro."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -223,7 +223,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FARSI, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s – یک رابط کاربر گرفیکی برای کانکشن OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls – یک رابط کاربر گرفیکی برای کانکشن OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI مشارکت کنندگان\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -279,7 +279,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nاتصال به: "
     IDS_TIP_CONNECTING "\nدر حال اتصال به: "
     IDS_TIP_CONNECTED_SINCE "\nمتصل شده به: "
-    IDS_TIP_ASSIGNED_IP "\nآی پی اختصاصی: %s"
+    IDS_TIP_ASSIGNED_IP "\nآی پی اختصاصی: %ls"
     IDS_MENU_SERVICE "سرویس OpenVPN"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server..."
@@ -304,28 +304,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "میخواهید اتصال را قطع کنید - سرویس متوقف شود؟"
 
     /* Logviewer – Resources */
-    IDS_ERR_START_LOG_VIEWER "خطای شروع شدن نمایشگر-گزارش: %s"
-    IDS_ERR_START_CONF_EDITOR "خطای شروع شدن ویرایشگر-پیکربندی: %s"
+    IDS_ERR_START_LOG_VIEWER "خطای شروع شدن نمایشگر-گزارش: %ls"
+    IDS_ERR_START_CONF_EDITOR "خطای شروع شدن ویرایشگر-پیکربندی: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI پشتیبانی نمی کند بیشتر از %d پیکربندی. لطفا برای اطلاعات بیشتر با مدیر تماس بگیرید."
     IDS_NFO_NO_CONFIGS "پروفایل اتصال قابل خواندن نیست (فایل پیکربندی) شناخته شد.\n\
-به کار ببرید ""وارد کردن سند"" در منو را یا کپی کنید فایل کانفیگ را در ""%s"" or ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "این اتصال شروع شد (%s) نیاز دارد به عضویت در گروه\
-""%s"" .با مدیر سیستم خود تماس بگیرید\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "این اتصال شروع شد (%s) نیاز دارد به عضویت در گروه\
-""%s"" .\n\n\
+به کار ببرید ""وارد کردن سند"" در منو را یا کپی کنید فایل کانفیگ را در ""%ls"" or ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "این اتصال شروع شد (%ls) نیاز دارد به عضویت در گروه\
+""%ls"" .با مدیر سیستم خود تماس بگیرید\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "این اتصال شروع شد (%ls) نیاز دارد به عضویت در گروه\
+""%ls"" .\n\n\
 می خواهی اضافه کنی خودت به این گروه?\n\
 این فعالیت می تواند نیاز به پسورد یا رضایت مدیر داشته باشد."
-    IDS_NFO_CONFIG_AUTH_PENDING   "این اتصال شروع شد (%s) نیاز مند عضویت در گروه \
-""%s"" .\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "این اتصال شروع شد (%ls) نیاز مند عضویت در گروه \
+""%ls"" .\n\n\
 لطفا احراز هویت قبلی را کامل کنید."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "اضافه کردن کاربر به گروه با خطا مواجه شد ""%s"" ."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "اضافه کردن کاربر به گروه با خطا مواجه شد ""%ls"" ."
     IDS_ERR_ONE_CONN_OLD_VER "تو فقط می توانی یک اتصال را باز نگه داری در یک زمان وقتی به کار می بری ورژن قدیمی از OpenVPN than 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "شما نمیتوانید به کار ببرید OpenVPN GUI را برای شروع یک اتصال وقتی که OpenVPN Service باز است (در OpenVPN 1.5/1.6). اول OpenVPN Service را متوقف کنید اگر میخواهید OpenVPN GUI را استفاده کنید. (GUI -> محیط گرافیکی)"
-    IDS_ERR_CREATE_EVENT "خطای ایجاد رویداد در خروج: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "نمیدانم نام حق تقدم: %s"
-    IDS_ERR_LOG_APPEND_BOOL "ضمیمه نماد در فایل گزارش (داده شده به عنوان '%s') باید باشد '۰' یا '۱'."
+    IDS_ERR_CREATE_EVENT "خطای ایجاد رویداد در خروج: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "نمیدانم نام حق تقدم: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "ضمیمه نماد در فایل گزارش (داده شده به عنوان '%ls') باید باشد '۰' یا '۱'."
     IDS_ERR_GET_MSIE_PROXY "نتوانستم بگیرم MSIE تنظیمات پروکسی را."
     IDS_ERR_INIT_SEC_DESC "مقداردهی اولیه امنیتی انجام نشد."
     IDS_ERR_SET_SEC_DESC_ACL "تنظیم امنیت توصیف Dacl ناموفق بود."
@@ -333,43 +333,43 @@ BEGIN
     IDS_ERR_CREATE_PIPE_INPUT "ساخت Pipe در hInputRead ناموفق بود."
     IDS_ERR_DUP_HANDLE_OUT_READ "تکرار پاسخ دهی در hOutputRead ناموفق بود."
     IDS_ERR_DUP_HANDLE_IN_WRITE "تکرار پاسخ دهی در hInputWrite ناموفق بود."
-    IDS_ERR_CREATE_PROCESS "ساخت پروسه ناموفق بود, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "ساخت پروسه ناموفق بود, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "ایجاد موضوع برای نمایش پنجره وضعیت ناموفق بود."
     IDS_NFO_STATE_WAIT_TERM "وضعیت اخیر: منتظر OpenVPN برای پایان دادن…"
     IDS_NFO_STATE_CONNECTED "وضعیت اخیر: متصل"
-    IDS_NFO_NOW_CONNECTED "%s متصل است."
-    IDS_NFO_ASSIGN_IP "ّIP اختصاص داده شده: %s"
+    IDS_NFO_NOW_CONNECTED "%ls متصل است."
+    IDS_NFO_ASSIGN_IP "ّIP اختصاص داده شده: %ls"
     IDS_ERR_CERT_EXPIRED "اتصال امکان پذیر نیست زیرا گواهی شما منقضی شده است یا زمان سیستم نادرست است."
     IDS_ERR_CERT_NOT_YET_VALID "اتصال امکان پذیر نیست زیرا گواهی شما هنوز معتبر نیست. بررسی کنید که زمان سیستم شما درست است."
     IDS_NFO_STATE_RECONNECTING "وضعیت موجود: اتصال مجدد"
     IDS_NFO_STATE_DISCONNECTED "وضعیت موجود: قطع اتصال"
-    IDS_NFO_CONN_TERMINATED "اتصال به %s پایان داده شد."
+    IDS_NFO_CONN_TERMINATED "اتصال به %ls پایان داده شد."
     IDS_NFO_STATE_FAILED "وضعیت موجود: ناتوان در اتصال"
-    IDS_NFO_CONN_FAILED "اتصال به %s شکست خورد."
+    IDS_NFO_CONN_FAILED "اتصال به %ls شکست خورد."
     IDS_NFO_STATE_FAILED_RECONN "وضعیت موجود : اتصال مجدد ناموفق بود"
-    IDS_NFO_RECONN_FAILED "اتصال مجدد به %s شکست خورد."
+    IDS_NFO_RECONN_FAILED "اتصال مجدد به %ls شکست خورد."
     IDS_NFO_STATE_SUSPENDED "وضعیت موجود: معلق"
     IDS_ERR_READ_STDOUT_PIPE "خطای خواندن از OpenVPN StdOut Pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "ساختن RichEdit LogWindow شکست خورد!!"
     IDS_ERR_SET_SIZE "تنظیم اندازه شکست خورد!"
-    IDS_ERR_AUTOSTART_CONF "پیکربندی درخواستی برای شروع خودکار پیدا نمی شود: %s"
+    IDS_ERR_AUTOSTART_CONF "پیکربندی درخواستی برای شروع خودکار پیدا نمی شود: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ " ساخت Pipe در hInputRead شکست خورد."
     IDS_NFO_STATE_CONNECTING "وضعیت موجود: در حال اتصال"
-    IDS_NFO_CONNECTION_XXX "OpenVPN اتصال (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN اتصال (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "وضعیت موجود: اسکریپت اتصال باز شده"
     IDS_NFO_STATE_DISCONN_SCRIPT "وضعیت موجود : اسکریپت قطع اتصال باز شده"
-    IDS_ERR_RUN_CONN_SCRIPT "خطای باز کردن اسکریپت اتصال: %s"
-    IDS_ERR_GET_EXIT_CODE "شکست در گرفتن ExitCode از اسکریپت اتصال (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "خطای باز کردن اسکریپت اتصال: %ls"
+    IDS_ERR_GET_EXIT_CODE "شکست در گرفتن ExitCode از اسکریپت اتصال (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "اتصال اسکریپت شکست خود. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "اتصال اسکریپت شکست خورد. TimeOut بعد %d ثانیه."
-    IDS_ERR_CONFIG_EXIST "در حال حاضر یک فایل پیکربندی به نام '%s' وجود دارد. تو نمی توانی \
+    IDS_ERR_CONFIG_EXIST "در حال حاضر یک فایل پیکربندی به نام '%ls' وجود دارد. تو نمی توانی \
 چندین فایل پیکربندی با همان نام داشته باشید, حتی اگر \
 آنها در پوشه های مختلفی باشند."
     IDS_NFO_CONN_TIMEOUT "اتصال به رابط مدیریت انجام نشد.\n\
-فایل گزارش را ببینید - لاگ فایل (%s) برای جزئیات بیشتر."
+فایل گزارش را ببینید - لاگ فایل (%ls) برای جزئیات بیشتر."
     /* main – Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "خطای باز کردن فایل dbug (%s) برای خروجی."
-    IDS_ERR_CREATE_PATH "نتوانستم بسازم %s مسیر:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "خطای باز کردن فایل dbug (%ls) برای خروجی."
+    IDS_ERR_CREATE_PATH "نتوانستم بسازم %ls مسیر:\n%ls"
     IDS_ERR_LOAD_RICHED20 "نمی توانم بالا بیاورم RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "shell32.dll شما نسخه اش پایینتر از (0x%lx) است. تو نیاز به نسخه بالا تر داری -نسخه آخر 5.0."
     IDS_NFO_SERVICE_STARTED "خدمت OpenVPN آغاز شد."
@@ -425,26 +425,26 @@ Options to override registry settings:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI Usage"
-    IDS_ERR_BAD_PARAMETER "I'm trying to parse ""%s"" as an --option parameter \
+    IDS_ERR_BAD_PARAMETER "I'm trying to parse ""%ls"" as an --option parameter \
 but I don't see a leading '--'"
-    IDS_ERR_BAD_OPTION "Options error: Unrecognized option or missing parameter(s): --%s\n\
+    IDS_ERR_BAD_OPTION "Options error: Unrecognized option or missing parameter(s): --%ls\n\
 Use openvpn-gui --help for more info."
 
     /* passphrase – Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread to show ChangePassphrase dialog failed."
-    IDS_NFO_CHANGE_PWD "Change Private Key Password (%s)"
+    IDS_NFO_CHANGE_PWD "Change Private Key Password (%ls)"
     IDS_ERR_PWD_DONT_MATCH "The passwords you typed do not match. Try again."
     IDS_ERR_PWD_TO_SHORT "Your new password must be at least %d characters long."
     IDS_NFO_EMPTY_PWD "Are you sure you want to set an EMPTY password?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Unknown keyfile format."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Error opening private key file (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Error opening private key file (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "The old password is incorrect."
-    IDS_ERR_OPEN_WRITE_KEY "Error opening private key file for writing (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Error writing new private key file (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Error opening private key file for writing (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Error writing new private key file (%ls)."
     IDS_NFO_PWD_CHANGED "Your password has been changed."
-    IDS_ERR_READ_PKCS12 "Error reading PKCS #12 file (%s)."
+    IDS_ERR_READ_PKCS12 "Error reading PKCS #12 file (%ls)."
     IDS_ERR_CREATE_PKCS12 "Error creating new PKCS #12 object. Change Password has failed."
-    IDS_ERR_OPEN_CONFIG "Could not open config file for reading: (%s)"
+    IDS_ERR_OPEN_CONFIG "Could not open config file for reading: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "You cannot have more than one ""key"" option in your config."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "You cannot have both ""key"" and ""pkcs12"" options in your config."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "You cannot have more than one ""pkcs12"" option in your config."
@@ -467,7 +467,7 @@ Please choose another one."
     IDS_ERR_SOCKS_PROXY_ADDRESS "You must specify a SOCKS proxy address."
     IDS_ERR_SOCKS_PROXY_PORT "You must specify a SOCKS proxy port."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "You must specify a SOCKS proxy port between 1 and 65535."
-    IDS_ERR_CREATE_REG_HKCU_KEY "Error creating ""HKEY_CURRENT_USER\\%s"" key."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Error creating ""HKEY_CURRENT_USER\\%ls"" key."
     IDS_ERR_GET_TEMP_PATH "Error determining TempPath with GetTempPath(). Using ""C:\\"" instead."
 
     /* service */
@@ -501,24 +501,24 @@ OpenVPN is probably not installed"
     IDS_ERR_CREATE_REG_KEY "Error creating HKLM\\SOFTWARE\\OpenVPN-GUI key."
     IDS_ERR_OPEN_WRITE_REG "Failed to open the registry for writing. You need to run this application \
 once as Administrator to update the registry."
-    IDS_ERR_READ_SET_KEY "Error reading and setting registry key ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Error writing registry value ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Error reading and setting registry key ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Error writing registry value ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n\
-%s\n\nMake sure you have the right permissions."
+%ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "بسیار خوب (OK) را بزن تا رمز عبور ذخیره شده برای پیکر بندی حذف شود ""%s"""
+    IDS_NFO_DELETE_PASS "بسیار خوب (OK) را بزن تا رمز عبور ذخیره شده برای پیکر بندی حذف شود ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – رمز نشان"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "ورودی رمزعبور/رمز برای نشان '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "ورودی رمزعبور/رمز برای نشان '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "مدارک اشتباه است. مجددا تلاش کنید…"
     IDS_NFO_KEY_PASS_RETRY  "پسورد اشتباه است. مجددا تلاش کنید…"
@@ -526,6 +526,6 @@ once as Administrator to update the registry."
     IDS_ERR_INVALID_USERNAME_INPUT "کاراکتر غیر مجاز در نام کاربری"
     IDS_NFO_AUTO_CONNECT    "اتصال خودکار در %u ثانیه آینده…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI قبلا باز شده. کلیک راست کنید بر روی آن در نماد های برنامه ها."
-    IDS_NFO_BYTECOUNT "بایت به: %s  خروج: %s"
+    IDS_NFO_BYTECOUNT "بایت به: %ls  خروج: %ls"
 
 END

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -220,7 +220,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FINNISH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - Graafinen käyttöliittymä OpenVPN:lle\n\
+    LTEXT "OpenVPN GUI v%ls - Graafinen käyttöliittymä OpenVPN:lle\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -276,7 +276,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nYhdistetty kohteeseen: "
     IDS_TIP_CONNECTING "\nYhdistetään kohteeseen: "
     IDS_TIP_CONNECTED_SINCE "\nYhteys luotu: "
-    IDS_TIP_ASSIGNED_IP "\nIP-osoite: %s"
+    IDS_TIP_ASSIGNED_IP "\nIP-osoite: %ls"
     IDS_MENU_SERVICE "OpenVPN-palvelu"
     IDS_MENU_IMPORT "Tuo"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -301,28 +301,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Haluatko katkaista yhteyden ja pysäyttää OpenVPN-palvelun?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Lokitiedoston katselimen käynnistäminen epäonnistui: %s"
-    IDS_ERR_START_CONF_EDITOR "Asetusten muokkaimen käynnistäminen epäonnistui: %s"
+    IDS_ERR_START_LOG_VIEWER "Lokitiedoston katselimen käynnistäminen epäonnistui: %ls"
+    IDS_ERR_START_CONF_EDITOR "Asetusten muokkaimen käynnistäminen epäonnistui: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI:n asetustiedostoja voi olla käytössä korkeintaan %d. Ota yhteys tämän sovelluksen kehittäjään, mikä tarvitset useampia."
     IDS_NFO_NO_CONFIGS "Ei käyttökelpoisia asetustiedostoja.\n\
-Valitse ""Tuo tiedosto.."" valikosta tai kopioi asetustiedosto kansioon ""%s"" tai ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Yhteyden %s käynnistäminen vaatii ryhmään \
-""%s"" kuulumisen. Ota yhteys järjestelmäylläpitäjään.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Yhteyden %s käynnistäminen vaatii ryhmään \
-""%s"" kuulumisen.\n\n\
+Valitse ""Tuo tiedosto.."" valikosta tai kopioi asetustiedosto kansioon ""%ls"" tai ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Yhteyden %ls käynnistäminen vaatii ryhmään \
+""%ls"" kuulumisen. Ota yhteys järjestelmäylläpitäjään.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Yhteyden %ls käynnistäminen vaatii ryhmään \
+""%ls"" kuulumisen.\n\n\
 Haluatko lisätä itsesi tähän ryhmään?\n\
 Toiminto voi vaatia ylläpitäjän salasanan tai vahvistuksen."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Yhteyden %s käynnistäminen vaatii ryhmään \
-""%s"" kuulumisen.\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Yhteyden %ls käynnistäminen vaatii ryhmään \
+""%ls"" kuulumisen.\n\n\
 Ole hyvä ja suorita aiempi varmennus loppuun."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Käyttäjän lisääminen ryhmään ""%s"" epäonnistui."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Käyttäjän lisääminen ryhmään ""%ls"" epäonnistui."
     IDS_ERR_ONE_CONN_OLD_VER "Jos käytössä on OpenVPN 2.0-beta6 tai vanhempi, käytössä voi olla kerrallaan vain yksi yhteys."
     IDS_ERR_STOP_SERV_OLD_VER "OpenVPN GUI -sovelluksella ei voi hallita yhteyksiä, jos OpenVPN (versio 1.5/1.6) on käynnistetty palveluna. Pysäytä OpenVPN-palvelu ja yritä uudelleen."
-    IDS_ERR_CREATE_EVENT "CreateEvent epäonnistui: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Tunnistamaton prioriteetti: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Lokitiedostoon lisäämisasetuksen ('%s') on oltava '0' tai '1'"
+    IDS_ERR_CREATE_EVENT "CreateEvent epäonnistui: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Tunnistamaton prioriteetti: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Lokitiedostoon lisäämisasetuksen ('%ls') on oltava '0' tai '1'"
     IDS_ERR_GET_MSIE_PROXY "Internet Explorerin välipalvelinasetusten nouto epäonnistui."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor failed."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl failed."
@@ -330,43 +330,43 @@ Ole hyvä ja suorita aiempi varmennus loppuun."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe on hInputRead failed."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead failed."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite failed."
-    IDS_ERR_CREATE_PROCESS "CreateProcess failed, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess failed, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread to show Status window Failed."
     IDS_NFO_STATE_WAIT_TERM "Tila: odotetaan OpenVPN:n sammumista…"
     IDS_NFO_STATE_CONNECTED "Tila: yhdistetty"
-    IDS_NFO_NOW_CONNECTED "%s on nyt yhdistetty."
-    IDS_NFO_ASSIGN_IP "IP-osoite: %s"
+    IDS_NFO_NOW_CONNECTED "%ls on nyt yhdistetty."
+    IDS_NFO_ASSIGN_IP "IP-osoite: %ls"
     IDS_ERR_CERT_EXPIRED "Yhdistäminen epäonnistui, koska varmenne on vanhentunut tai tietokoneen kello on väärässä ajassa."
     IDS_ERR_CERT_NOT_YET_VALID "Yhdistäminen epäonnistui, koska varmenne ei ole vielä voimassa. Tarkista, että tietokoneesi kello on oikeassa ajassa."
     IDS_NFO_STATE_RECONNECTING "Tila: yhdistetään uudelleen"
     IDS_NFO_STATE_DISCONNECTED "Tila: yhteys katkaistu"
-    IDS_NFO_CONN_TERMINATED "Yhteys kohteeseen %s katkaistiin."
+    IDS_NFO_CONN_TERMINATED "Yhteys kohteeseen %ls katkaistiin."
     IDS_NFO_STATE_FAILED "Tila: yhdistäminen epäonnistui"
-    IDS_NFO_CONN_FAILED "Yhdistäminen kohteeseen %s epäonnistui."
+    IDS_NFO_CONN_FAILED "Yhdistäminen kohteeseen %ls epäonnistui."
     IDS_NFO_STATE_FAILED_RECONN "Tila: yhdistäminen uudelleen epäonnistui"
-    IDS_NFO_RECONN_FAILED "Yhdistäminen uudelleen kohteeseen %s epäonnistui."
+    IDS_NFO_RECONN_FAILED "Yhdistäminen uudelleen kohteeseen %ls epäonnistui."
     IDS_NFO_STATE_SUSPENDED "Tila: keskeytetty"
     IDS_ERR_READ_STDOUT_PIPE "Lukeminen oletustulosteesta epäonnistui."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Creating RichEdit LogWindow Failed!!"
     IDS_ERR_SET_SIZE "Koon määrittäminen epäonnistui!"
-    IDS_ERR_AUTOSTART_CONF "Ei löydetty automaattisesti käynnistettävää asetustiedostoa %s"
+    IDS_ERR_AUTOSTART_CONF "Ei löydetty automaattisesti käynnistettävää asetustiedostoa %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead failed."
     IDS_NFO_STATE_CONNECTING "Tila: yhdistetään"
-    IDS_NFO_CONNECTION_XXX "OpenVPN-yhteys (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN-yhteys (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Tila: Suoritetaan yhteydenmuodostuskomentosarjaa"
     IDS_NFO_STATE_DISCONN_SCRIPT "Tila: Suoritetaan yhteydenkatkaisukomentosarjaa"
-    IDS_ERR_RUN_CONN_SCRIPT "Virhe suoritettaessa yhteydenmuodostoskomentosarjaa: %s"
-    IDS_ERR_GET_EXIT_CODE "Yhteydenmuodostuskomentosarjan %s paluuarvoa ei saatu"
+    IDS_ERR_RUN_CONN_SCRIPT "Virhe suoritettaessa yhteydenmuodostoskomentosarjaa: %ls"
+    IDS_ERR_GET_EXIT_CODE "Yhteydenmuodostuskomentosarjan %ls paluuarvoa ei saatu"
     IDS_ERR_CONN_SCRIPT_FAILED "Yhteydenmuodostuskomentosarjan suorittaminen epäonnistui. (paluuarvo=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Yhteydenmuodostamiskomentosarja aikakatkaistiin %d sekunnin jälkeen."
-    IDS_ERR_CONFIG_EXIST "Samanniminen asetustiedosto '%s' on jo olemassa. \
+    IDS_ERR_CONFIG_EXIST "Samanniminen asetustiedosto '%ls' on jo olemassa. \
 Myös eri kansioissa olevilla asetustiedostoilla \
 on oltava eri nimi."
     IDS_NFO_CONN_TIMEOUT "Yhdistäminen hallintaliittymään epäonnistui.\n\
-Lisätietoja lokitiedostossa (%s)."
+Lisätietoja lokitiedostossa (%ls)."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Vianjäljitystiedostoon (%s) kirjoittaminen epäonnistui"
-    IDS_ERR_CREATE_PATH "Ei voitu luoda %s polkua:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Vianjäljitystiedostoon (%ls) kirjoittaminen epäonnistui"
+    IDS_ERR_CREATE_PATH "Ei voitu luoda %ls polkua:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Kirjaston RICHED20.DLL lataaminen epäonnistui."
     IDS_ERR_SHELL_DLL_VERSION "Kirjasto shell32.dll on liian vanha (0x%lx), tarvitaan vähintään versio 5.0."
     IDS_NFO_SERVICE_STARTED "OpenVPN-palvelu käynnistetty."
@@ -423,26 +423,26 @@ Rekisterin asetukset kumoavat valinnat:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI:n käyttö"
-    IDS_ERR_BAD_PARAMETER "Syötteen ""%s"" käsittely --option-valitsimen \
+    IDS_ERR_BAD_PARAMETER "Syötteen ""%ls"" käsittely --option-valitsimen \
 parametrina epäonnistui, koska sen alusta puuttui '--'"
-    IDS_ERR_BAD_OPTION "Tuntematon valinta tai parametreja puuttuu: --%s\n\
+    IDS_ERR_BAD_OPTION "Tuntematon valinta tai parametreja puuttuu: --%ls\n\
 Lisätietoja saa komennolla openvpn-gui --help"
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread to show ChangePassphrase dialog failed."
-    IDS_NFO_CHANGE_PWD "Vaihda yksityisen avaimen salasana (%s)"
+    IDS_NFO_CHANGE_PWD "Vaihda yksityisen avaimen salasana (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Salasanat eivät täsmää. Yritä uudelleen."
     IDS_ERR_PWD_TO_SHORT "Salasanan on oltava vähintään %d merkkiä pitkä."
     IDS_NFO_EMPTY_PWD "Haluatko varmasti määrittää TYHJÄN salasanan?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Tuntematon avaintiedoston muoto."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Virhe avattaessa yksityistä avaintiedostoa (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Virhe avattaessa yksityistä avaintiedostoa (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Vanha salasana on virheellinen."
-    IDS_ERR_OPEN_WRITE_KEY "Kirjoittaminen yksityiseen avaintiedostoon (%s) epäonnistui."
-    IDS_ERR_WRITE_NEW_KEY "Uuden yksityisen avaintiedoston (%s) luonti epäonnistui."
+    IDS_ERR_OPEN_WRITE_KEY "Kirjoittaminen yksityiseen avaintiedostoon (%ls) epäonnistui."
+    IDS_ERR_WRITE_NEW_KEY "Uuden yksityisen avaintiedoston (%ls) luonti epäonnistui."
     IDS_NFO_PWD_CHANGED "Salasana vaihdettu."
-    IDS_ERR_READ_PKCS12 "PKCS #12 -tiedoston (%s) lukeminen epäonnistui."
+    IDS_ERR_READ_PKCS12 "PKCS #12 -tiedoston (%ls) lukeminen epäonnistui."
     IDS_ERR_CREATE_PKCS12 "PKCS #12 -tiedoston luonti ja salasanan vaihto epäonnistuivat."
-    IDS_ERR_OPEN_CONFIG "Asetustiedoston luku epäonnistui: (%s)"
+    IDS_ERR_OPEN_CONFIG "Asetustiedoston luku epäonnistui: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "Asetustiedostossa voi olla korkeintaan yksi ""key""-valinta."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Asetustiedostossa ei voi olla yhtäaikaisesti määritettynä sekä ""key"" että ""pkcs12""."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Asetustiedostossa voi olla korkeintaan yksi ""pkcs12""-valinta."
@@ -465,7 +465,7 @@ sitä on muutettava."
     IDS_ERR_SOCKS_PROXY_ADDRESS "SOCKS-välipalvelimen osoite on määritettävä."
     IDS_ERR_SOCKS_PROXY_PORT "SOCKS-välipalvelimen portti on määritettävä."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "SOCKS-välipalvelimen portti on oltava väliltä 1-65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "Virhe luotaessa avainta ""HKEY_CURRENT_USER\\%s""."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Virhe luotaessa avainta ""HKEY_CURRENT_USER\\%ls""."
     IDS_ERR_GET_TEMP_PATH "Virhe määritettäessä muuttujaa TempPath funktiolla GetTempPath(). Käytetään polkua ""C:\\""."
 
     /* service */
@@ -499,24 +499,24 @@ OpenVPN:ää ei todennäköisesti ole asennettu."
     IDS_ERR_CREATE_REG_KEY "Virhe luotaessa rekisteriavainta HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Virhe kirjoitettaessa rekisteriin. Tämä sovellus pitää ensimmäisellä kerralla \
 ajaa ylläpitäjän oikeuksin, jotta se saa lisättyä rekisteriin tietoja."
-    IDS_ERR_READ_SET_KEY "Virhe luettaessa ja määritettäessä rekisteriavainta ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Virhe kirjoitettaessa rekisterin arvoa ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Virhe luettaessa ja määritettäessä rekisteriavainta ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Virhe kirjoitettaessa rekisterin arvoa ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Samanniminen (""%s"") asetustiedosto on jo olemassa."
+    IDS_ERR_IMPORT_EXISTS "Samanniminen (""%ls"") asetustiedosto on jo olemassa."
     IDS_ERR_IMPORT_FAILED "Asetustiedoston tuonti epäonnistui. Polkua ei voitu luoda:\n\n\
-%s\n\nVarmista, että sinulla on tarvittavat tiedosto-oikeudet."
+%ls\n\nVarmista, että sinulla on tarvittavat tiedosto-oikeudet."
     IDS_NFO_IMPORT_SUCCESS "Asetustiedoston tuonti onnistui."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Napsauta OK poistaaksesi asetustiedostoon ""%s"" liitetyt salasanat."
+    IDS_NFO_DELETE_PASS "Napsauta OK poistaaksesi asetustiedostoon ""%ls"" liitetyt salasanat."
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Tokenin salasana"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Anna Salasana/PIN tokenille '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Anna Salasana/PIN tokenille '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
@@ -524,6 +524,6 @@ ajaa ylläpitäjän oikeuksin, jotta se saa lisättyä rekisteriin tietoja."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -220,7 +220,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_FRENCH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - A Windows GUI for OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - A Windows GUI for OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -276,7 +276,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nConnecté à: "
     IDS_TIP_CONNECTING "\nConnexion à: "
     IDS_TIP_CONNECTED_SINCE "\nConnecté depuis: "
-    IDS_TIP_ASSIGNED_IP "\nAdresse IP assignée: %s"
+    IDS_TIP_ASSIGNED_IP "\nAdresse IP assignée: %ls"
     IDS_MENU_SERVICE "OpenVPN Service"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -301,28 +301,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Voulez-vous vous déconnecter (arrêter le service OpenVPN) ?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Erreur au démarrage de l'afficheur de log: %s"
-    IDS_ERR_START_CONF_EDITOR "Erreur au démarrage de l'éditeur de la configuration: %s"
+    IDS_ERR_START_LOG_VIEWER "Erreur au démarrage de l'afficheur de log: %ls"
+    IDS_ERR_START_CONF_EDITOR "Erreur au démarrage de l'éditeur de la configuration: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI ne permet pas plus de %d configurations. Contacter l'auteur si vous en avez besoin de plus."
     IDS_NFO_NO_CONFIGS "Aucun profil de connexion lisible trouvé (fichiers de configuration).\n\
-Utilisez le menu ""Importer fichier.."" ou copiez vos fichiers de configuration vers ""%s"" ou ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "À partir de cette connexion (%s) une adhésion est nécessaire au groupe \
-""%s"". Contactez votre administrateur système.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "À partir de cette connexion (%s) une adhésion est nécessaire au groupe \
-""%s"".\n\n\
+Utilisez le menu ""Importer fichier.."" ou copiez vos fichiers de configuration vers ""%ls"" ou ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "À partir de cette connexion (%ls) une adhésion est nécessaire au groupe \
+""%ls"". Contactez votre administrateur système.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "À partir de cette connexion (%ls) une adhésion est nécessaire au groupe \
+""%ls"".\n\n\
 Voulez-vous vous ajouter à ce groupe?\n\
 Cette action peut demander un mot de passe administratif ou un consentement."
-    IDS_NFO_CONFIG_AUTH_PENDING   "À partir de cette connexion (%s) une adhésion est nécessaire au groupe \
-""%s"".\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "À partir de cette connexion (%ls) une adhésion est nécessaire au groupe \
+""%ls"".\n\n\
 Veuillez compléter la boîte de dialogue d'autorisation précédente."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Ajout de l'utilisateur au groupe ""%s"" échoué."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Ajout de l'utilisateur au groupe ""%ls"" échoué."
     IDS_ERR_ONE_CONN_OLD_VER "Vous ne pouvez avoir qu'une connexion en même temps si vous utilisez une version d'OpenVPN plus ancienne que la 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Vous ne pouvez utiliser OpenVPN GUI pour ouvrir une connexion lorsque que le service OpenVPN est actif (avec OpenVPN 1.5/1.6). Arrêtez le service OpenVPN si vous voulez utiliser OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "CreateEvent échoué à la terminaison. Code d'événnement: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Nom de priorité inconnu: %s"
-    IDS_ERR_LOG_APPEND_BOOL "L'indicateur de log incrémenté (donné par '%s') doit être '0' ou '1'"
+    IDS_ERR_CREATE_EVENT "CreateEvent échoué à la terminaison. Code d'événnement: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Nom de priorité inconnu: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "L'indicateur de log incrémenté (donné par '%ls') doit être '0' ou '1'"
     IDS_ERR_GET_MSIE_PROXY "Impossible d'obtenir la configuration Proxy d'IE parce que."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor échoué."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl échoué."
@@ -330,43 +330,43 @@ Veuillez compléter la boîte de dialogue d'autorisation précédente."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe sur hInputRead échoué."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle sur hOutputRead échoué."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle sur hInputWrite échoué."
-    IDS_ERR_CREATE_PROCESS "CreateProcess échoué, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess échoué, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread échoué pour afficher la fenêtre de statut."
     IDS_NFO_STATE_WAIT_TERM "Etat actuel: Attente que OpenVPN se termine…"
     IDS_NFO_STATE_CONNECTED "Etat actuel: Connecté"
-    IDS_NFO_NOW_CONNECTED "%s est désormais connecté."
-    IDS_NFO_ASSIGN_IP "Adresse IP assignée: %s"
+    IDS_NFO_NOW_CONNECTED "%ls est désormais connecté."
+    IDS_NFO_ASSIGN_IP "Adresse IP assignée: %ls"
     IDS_ERR_CERT_EXPIRED "Connexion impossible car votre certificat a expiré ou la date de votre système est incorrecte."
     IDS_ERR_CERT_NOT_YET_VALID "Connexion impossible car votre certificat n'est plus valide. Véfifiez que la date de votre système est correcte."
     IDS_NFO_STATE_RECONNECTING "Etat actuel: Reconnexion"
     IDS_NFO_STATE_DISCONNECTED "Etat actuel: Deconnecté"
-    IDS_NFO_CONN_TERMINATED "La Connexion à %s était terminée."
+    IDS_NFO_CONN_TERMINATED "La Connexion à %ls était terminée."
     IDS_NFO_STATE_FAILED "Etat actuel: connexion échouée"
-    IDS_NFO_CONN_FAILED "La Connexion à %s a échouée."
+    IDS_NFO_CONN_FAILED "La Connexion à %ls a échouée."
     IDS_NFO_STATE_FAILED_RECONN "Etat actuel: Reconnexion échouée"
-    IDS_NFO_RECONN_FAILED "La Reconnexion à %s a échouée."
+    IDS_NFO_RECONN_FAILED "La Reconnexion à %ls a échouée."
     IDS_NFO_STATE_SUSPENDED "Etat actuel: Suspendu"
     IDS_ERR_READ_STDOUT_PIPE "Erreur lors de la lecture d'OpenVPN StdOut Pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Creating RichEdit LogWindow échoué !"
     IDS_ERR_SET_SIZE "Set Size échoué !"
-    IDS_ERR_AUTOSTART_CONF "Impossible de trouver la configuration pour démarrer automatiquement: %s"
+    IDS_ERR_AUTOSTART_CONF "Impossible de trouver la configuration pour démarrer automatiquement: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe sur hInputRead échoué."
     IDS_NFO_STATE_CONNECTING "Etat actuel: En cours de connexion"
-    IDS_NFO_CONNECTION_XXX "Connexion OpenVPN (%s)"
+    IDS_NFO_CONNECTION_XXX "Connexion OpenVPN (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Etat actuel: Exécution du script de connexion"
     IDS_NFO_STATE_DISCONN_SCRIPT "Etat actuel: Exécution du script de déconnexion"
-    IDS_ERR_RUN_CONN_SCRIPT "Erreur d'exécution du script de connexion: %s"
-    IDS_ERR_GET_EXIT_CODE "Impossible d'obtenir l'ExitCode du script de connexion (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Erreur d'exécution du script de connexion: %ls"
+    IDS_ERR_GET_EXIT_CODE "Impossible d'obtenir l'ExitCode du script de connexion (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Le script de connexion à échoué. (code de sortie=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Le script de connexion à échoué. TimeOut après %d sec."
-    IDS_ERR_CONFIG_EXIST "Il éxiste déjà un fichier de configuration nommé '%s'. Vous ne pouvez \
+    IDS_ERR_CONFIG_EXIST "Il éxiste déjà un fichier de configuration nommé '%ls'. Vous ne pouvez \
 pas avoir différentes configurations avec le même nom même s'ils \
 ont placés dans un répertoire différent."
     IDS_NFO_CONN_TIMEOUT "La connexion à l'interface de gestion a échoué.\n\
-Afficher le fichier journal (%s) pour plus de détails."
+Afficher le fichier journal (%ls) pour plus de détails."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Erreur d'ouverture du fichier de debug (%s) pour output."
-    IDS_ERR_CREATE_PATH "Impossible de créer le chemin vers %s:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Erreur d'ouverture du fichier de debug (%ls) pour output."
+    IDS_ERR_CREATE_PATH "Impossible de créer le chemin vers %ls:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Impossible de charger RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "La version de votre shell32.dll est trop basse (0x%lx). Vous devez avoir au moins la version 5.0."
     IDS_NFO_SERVICE_STARTED "Service OpenVPN démarré."
@@ -422,26 +422,26 @@ Options pour corriger la configuration de registre:\n\
 
 
     IDS_NFO_USAGECAPTION "Usage OpenVPN GUI"
-    IDS_ERR_BAD_PARAMETER "J'essaie de décoder ""%s"" comme un --option parameter \
+    IDS_ERR_BAD_PARAMETER "J'essaie de décoder ""%ls"" comme un --option parameter \
 mais je ne vois pas de correspondance '--'"
-    IDS_ERR_BAD_OPTION "Erreur d'Options: Option(s) ou paramettre(s) manquant(s): --%s\n\
+    IDS_ERR_BAD_OPTION "Erreur d'Options: Option(s) ou paramettre(s) manquant(s): --%ls\n\
 Utiliser openvpn-gui --help pour plus d'informations."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread pour afficher la dialogue ChangePassphrase échoué."
-    IDS_NFO_CHANGE_PWD "Modification du Mot de passe (%s)"
+    IDS_NFO_CHANGE_PWD "Modification du Mot de passe (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Les Mots de passe que vous avez tappé ne correspondent pas, essayez encore."
     IDS_ERR_PWD_TO_SHORT "Le Mot de passe que vous avez tappé doit avoir au moins %d caractères."
     IDS_NFO_EMPTY_PWD "Vous êtes sûr de définir un Mot de passe VIDE ?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Format du fichier de clé inconnu."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Erreur à l'ouverture de la clé privée (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Erreur à l'ouverture de la clé privée (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "L'ancien Mot de passe est incorrect."
-    IDS_ERR_OPEN_WRITE_KEY "Erreur d'ouverture du fichier de clé privé pour écriture (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Erreur d'écriture du fichier de clé privé (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Erreur d'ouverture du fichier de clé privé pour écriture (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Erreur d'écriture du fichier de clé privé (%ls)."
     IDS_NFO_PWD_CHANGED "Votre Mot de passe a été modifié."
-    IDS_ERR_READ_PKCS12 "Erreur de lecture du fichier PKCS #12 X509 (%s)."
+    IDS_ERR_READ_PKCS12 "Erreur de lecture du fichier PKCS #12 X509 (%ls)."
     IDS_ERR_CREATE_PKCS12 "Erreur de création du nouveau fichier PKCS #12 X509. La modification du Mot de passe a échouée."
-    IDS_ERR_OPEN_CONFIG "Impossible d'ouvrir le fichier de la configuration en mode de lecture: (%s)"
+    IDS_ERR_OPEN_CONFIG "Impossible d'ouvrir le fichier de la configuration en mode de lecture: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "Vous ne pouvez pas avoir plus d'une option ""key"" dans votre fichier de configuration."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Vous ne pouvez pas avoir à la fois les options ""key"" et ""pkcs12"" dans votre configuration."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Vous ne pouvez pas avoir plus d'une option ""pkcs12"" dans votre configuration."
@@ -464,7 +464,7 @@ Merci de choisir un autre."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Vous devez spécifier une adresse Proxy SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT "Vous devez spécifier un port Proxy SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Vous devez spécifier un port SOCKS entre 1-65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "Erreur de création de la clé ""HKEY_CURRENT_USER\\%s""."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Erreur de création de la clé ""HKEY_CURRENT_USER\\%ls""."
     IDS_ERR_GET_TEMP_PATH "Erreur de détermination TempPath avec GetTempPath(). Utiliser ""C:\\"" à la place."
 
     /* service */
@@ -498,24 +498,24 @@ OpenVPN n'est probablement pas installé."
     IDS_ERR_CREATE_REG_KEY "Erreur de création de la clé HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Impossible d'ouvrir le registre en mode écriture. Vous devez lancer cette application \
 en tant qu'Administrator pour mettre à jour la base de registre."
-    IDS_ERR_READ_SET_KEY "Impossible de lire et modifier la clé de registre ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Impossible d'écrire la valeur de registre ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Impossible de lire et modifier la clé de registre ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Impossible d'écrire la valeur de registre ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Une configuration nommée ""%s"" existe déjà."
+    IDS_ERR_IMPORT_EXISTS "Une configuration nommée ""%ls"" existe déjà."
     IDS_ERR_IMPORT_FAILED "Impossible d'importer un fichier. Le chemin suivant n'a pas pu être créé.\n\n\
-%s\n\nAssurez-vous d'avoir les bonnes autorisations."
+%ls\n\nAssurez-vous d'avoir les bonnes autorisations."
     IDS_NFO_IMPORT_SUCCESS "Fichier importé avec succès."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Appuyez sur OK pour supprimer les mots de passe enregistrés pour config ""%s"""
+    IDS_NFO_DELETE_PASS "Appuyez sur OK pour supprimer les mots de passe enregistrés pour config ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Mot de passe Token"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Entrer le mot de passe/PIN pour Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Entrer le mot de passe/PIN pour Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Nom d'utilisateur ou mot de passe incorrect. Réessayer..."
     IDS_NFO_KEY_PASS_RETRY  "Mauvais mot de passe. Réessayer..."
@@ -523,6 +523,6 @@ en tant qu'Administrator pour mettre à jour la base de registre."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -220,7 +220,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_ITALIAN, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - Interfaccia per Windows di OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - Interfaccia per Windows di OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -276,7 +276,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nConnesso a: "
     IDS_TIP_CONNECTING "\nConnessione in corso a: "
     IDS_TIP_CONNECTED_SINCE "\nConnesso da: "
-    IDS_TIP_ASSIGNED_IP "\nIP assegnato: %s"
+    IDS_TIP_ASSIGNED_IP "\nIP assegnato: %ls"
     IDS_MENU_SERVICE "Servizio OpenVPN"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -301,28 +301,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Vuoi disconnetterti? (arrestando il servizio OpenVPN)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Errore nell'apertura del visualizzatore di log: %s"
-    IDS_ERR_START_CONF_EDITOR "Errore nell'apertura dell'editor di configurazione: %s"
+    IDS_ERR_START_LOG_VIEWER "Errore nell'apertura del visualizzatore di log: %ls"
+    IDS_ERR_START_CONF_EDITOR "Errore nell'apertura dell'editor di configurazione: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI non supporta più di %d configurazioni. Contatta l'autore se hai bisogno che ne supporti di più."
     IDS_NFO_NO_CONFIGS "Nessun file di configurazione trovato.\n\
-Usa il menu ""Importa file.."" o copia i tuoi file in ""%s"" oppure ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "L'avvio di questa connessione (%s) richiede di essere membro del \
-gruppo ""%s"". Contatta il tuo amministratore di sistema.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "L'avvio di questa connessione (%s) richiede di essere membro del \
-gruppo ""%s"".\n\n\
+Usa il menu ""Importa file.."" o copia i tuoi file in ""%ls"" oppure ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "L'avvio di questa connessione (%ls) richiede di essere membro del \
+gruppo ""%ls"". Contatta il tuo amministratore di sistema.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "L'avvio di questa connessione (%ls) richiede di essere membro del \
+gruppo ""%ls"".\n\n\
 Vuoi aggiungerti al gruppo?\n\
 Quest'azione può richiedere privilegi amministrativi."
-    IDS_NFO_CONFIG_AUTH_PENDING   "L'avvio di questa connessione (%s) richiede di essere membro del \
-gruppo ""%s"".\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "L'avvio di questa connessione (%ls) richiede di essere membro del \
+gruppo ""%ls"".\n\n\
 Completa la richiesta di autorizzazione precedente."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Errore nell'aggiunta dell'utente al gruppo ""%s""."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Errore nell'aggiunta dell'utente al gruppo ""%ls""."
     IDS_ERR_ONE_CONN_OLD_VER "Puoi avere una sola connessione attiva alla volta quando usi una versione di OpenVPN più vecchia della 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Non puoi usare OpenVPN GUI per far partire una connessione mentre il servizio di OpenVPN è in funzionamento (con OpenVPN 1.5/1.6). Arresta il servizio di OpenVPN se vuoi usare OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "Il creatore di eventi è fallito all'uscita dell'evento: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Nome di priorità sconosciuto: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Il file di log ha aggiunto un puntatore (dato come '%s') deve essere '0' o '1'"
+    IDS_ERR_CREATE_EVENT "Il creatore di eventi è fallito all'uscita dell'evento: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Nome di priorità sconosciuto: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Il file di log ha aggiunto un puntatore (dato come '%ls') deve essere '0' o '1'"
     IDS_ERR_GET_MSIE_PROXY "Non riesco ad utilizzare la configurazione di MSIE per il proxy."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor fallito."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl fallito."
@@ -330,43 +330,43 @@ Completa la richiesta di autorizzazione precedente."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe on hInputRead fallito."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead fallito."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite fallito."
-    IDS_ERR_CREATE_PROCESS "CreateProcess fallito, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess fallito, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread fallito per visualizzare lo stato."
     IDS_NFO_STATE_WAIT_TERM "Stato corrente: In attesa che OpenVPN termini…"
     IDS_NFO_STATE_CONNECTED "Stato corrente: Connesso"
-    IDS_NFO_NOW_CONNECTED "%s è ora connesso."
-    IDS_NFO_ASSIGN_IP "IP assegnato: %s"
+    IDS_NFO_NOW_CONNECTED "%ls è ora connesso."
+    IDS_NFO_ASSIGN_IP "IP assegnato: %ls"
     IDS_ERR_CERT_EXPIRED "Non riesco a connettermi perché il tuo certificato è scaduto o l'orologio di sistema non è corretto."
     IDS_ERR_CERT_NOT_YET_VALID "Non riesco a connettermi perché il tuo certificato non è ancora valido. Assicurati che l'orologio di sistema sia corretto."
     IDS_NFO_STATE_RECONNECTING "Stato corrente: Riconnessione in corso"
     IDS_NFO_STATE_DISCONNECTED "Stato corrente: Disconnesso"
-    IDS_NFO_CONN_TERMINATED "La connessione a %s è terminata."
+    IDS_NFO_CONN_TERMINATED "La connessione a %ls è terminata."
     IDS_NFO_STATE_FAILED "Stato corrente: Connessione fallita"
-    IDS_NFO_CONN_FAILED "La connessione a %s è fallita."
+    IDS_NFO_CONN_FAILED "La connessione a %ls è fallita."
     IDS_NFO_STATE_FAILED_RECONN "Stato corrente: Riconnessione fallita"
-    IDS_NFO_RECONN_FAILED "La riconnessione a %s è fallita."
+    IDS_NFO_RECONN_FAILED "La riconnessione a %ls è fallita."
     IDS_NFO_STATE_SUSPENDED "Stato corrente: Sospeso"
     IDS_ERR_READ_STDOUT_PIPE "Errore in lettura dalla OpenVPN StdOut Pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Creazione RichEdit LogWindow Fallita!!"
     IDS_ERR_SET_SIZE "Set Size fallita!"
-    IDS_ERR_AUTOSTART_CONF "Non riesco a trovare una configurazione per partire in automatico: %s"
+    IDS_ERR_AUTOSTART_CONF "Non riesco a trovare una configurazione per partire in automatico: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead falito."
     IDS_NFO_STATE_CONNECTING "Stato corrente: Connessione in corso"
-    IDS_NFO_CONNECTION_XXX "Connessione OpenVPN (%s)"
+    IDS_NFO_CONNECTION_XXX "Connessione OpenVPN (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Stato corrente: Avviato lo script di connessione"
     IDS_NFO_STATE_DISCONN_SCRIPT "Stato corrente: Avviato lo script di disconnessione"
-    IDS_ERR_RUN_CONN_SCRIPT "Errore durante il funzionamento dello script di connessione: %s"
-    IDS_ERR_GET_EXIT_CODE "Errore nel ExitCode dello script di connessione (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Errore durante il funzionamento dello script di connessione: %ls"
+    IDS_ERR_GET_EXIT_CODE "Errore nel ExitCode dello script di connessione (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Fallito lo script di connessione. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Fallito lo script di connessione. TimeOut dopo %d sec."
-    IDS_ERR_CONFIG_EXIST "Esiste già un file di configurazione chiamato '%s'. Non puoi \
+    IDS_ERR_CONFIG_EXIST "Esiste già un file di configurazione chiamato '%ls'. Non puoi \
 avere file di configurazioni con lo stesso nome, \
 a meno che non risiedano in cartelle differenti."
     IDS_NFO_CONN_TIMEOUT "Connessione all'interfacia di gestione fallita.\n\
-Consulta il file di log (%s) per maggiori dettagli."
+Consulta il file di log (%ls) per maggiori dettagli."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Errore nell'apertura del file di debug (%s) per l'output."
-    IDS_ERR_CREATE_PATH "Errore nella creazione del percorso %s:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Errore nell'apertura del file di debug (%ls) per l'output."
+    IDS_ERR_CREATE_PATH "Errore nella creazione del percorso %ls:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Non riesco a caricare RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "La versione del tuo shell32.dll è troppo vecchia (0x%lx). Hai bisogno almeno della versione 5.0."
     IDS_NFO_SERVICE_STARTED "Servizio OpenVPN avviato."
@@ -422,26 +422,26 @@ Opzioni per ignorare il registro di sistema:\n\
 
 
     IDS_NFO_USAGECAPTION "Utilizzo dell'interfaccia di OpenVPN"
-    IDS_ERR_BAD_PARAMETER "Sto tentando di analizzare ""%s"" come un parametro --option \
+    IDS_ERR_BAD_PARAMETER "Sto tentando di analizzare ""%ls"" come un parametro --option \
 ma non vedo all'inizio '--'"
-    IDS_ERR_BAD_OPTION "Errore sull'opzione: Opzione sconosciuta o Parametro(i) mancante: --%s\n\
+    IDS_ERR_BAD_OPTION "Errore sull'opzione: Opzione sconosciuta o Parametro(i) mancante: --%ls\n\
 Usa openvpn-gui --help per maggiori informazioni."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread visualizza la finestra ChangePassphrase è fallito."
-    IDS_NFO_CHANGE_PWD "Cambia password (%s)"
+    IDS_NFO_CHANGE_PWD "Cambia password (%ls)"
     IDS_ERR_PWD_DONT_MATCH "La password che hai digitato non corrisponde. Riprova."
     IDS_ERR_PWD_TO_SHORT "La tua nuova password deve essere lunga almeno %d caratteri."
     IDS_NFO_EMPTY_PWD "Sei sicuro di voler lasciare vuota la password?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Formato di chiave sconosciuto."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Errore nell'apertura del file di chiave privata (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Errore nell'apertura del file di chiave privata (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "La vecchia password è errata."
-    IDS_ERR_OPEN_WRITE_KEY "Errore nell'apertura in scrittura del file di chiave privata (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Errore nella scrittura del file della nuova chiave privata (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Errore nell'apertura in scrittura del file di chiave privata (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Errore nella scrittura del file della nuova chiave privata (%ls)."
     IDS_NFO_PWD_CHANGED "La tua password è stata modificata."
-    IDS_ERR_READ_PKCS12 "Errore nella lettura del PKCS #12 file (%s)."
+    IDS_ERR_READ_PKCS12 "Errore nella lettura del PKCS #12 file (%ls)."
     IDS_ERR_CREATE_PKCS12 "Errore nella creazione del nuovo PKCS #12 oggetto. La modifica della password è fallita."
-    IDS_ERR_OPEN_CONFIG "Non posso aprire in lettura il file di configurazione: (%s)"
+    IDS_ERR_OPEN_CONFIG "Non posso aprire in lettura il file di configurazione: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "Non puoi avere più di una opzione ""key"" nella tua configurazione."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Non puoi avere entrambe le opzioni ""key"" e ""pkcs12"" nella tua configurazione."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Non puoi avere più di una opzione ""pkcs12"" nella tua configurazione."
@@ -464,7 +464,7 @@ Per favore scegline un'altra."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Devi specificare un indirizzo per il proxy SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT "Devi specificare una porta per il proxy SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Devi specificare una porta tra 1-65535 per il proxy SOCKS."
-    IDS_ERR_CREATE_REG_HKCU_KEY "Errore nella creazione della chiave ""HKEY_CURRENT_USER\\%s""."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Errore nella creazione della chiave ""HKEY_CURRENT_USER\\%ls""."
     IDS_ERR_GET_TEMP_PATH "Errore nel determinare TempPath con GetTempPath(). Usa ""C:\\"" invece."
 
     /* service */
@@ -498,24 +498,24 @@ OpenVPN probabilmente non è installato"
     IDS_ERR_CREATE_REG_KEY "Errore nella creazione della chiave HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Errore nell'apertura del registro in scrittura. Puoi far partire questa applicazione \
 una volta che l'amministratore ha aggiornato il registro."
-    IDS_ERR_READ_SET_KEY "Errore nella lettura e modifica della chiave di registro ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Errore nella scrittura del valore di registro ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Errore nella lettura e modifica della chiave di registro ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Errore nella scrittura del valore di registro ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Esiste già una configurazione con il nome ""%s""."
+    IDS_ERR_IMPORT_EXISTS "Esiste già una configurazione con il nome ""%ls""."
     IDS_ERR_IMPORT_FAILED "Errore nell'importazione del file. Non ho potuto creare il percorso seguente:\n\n\
-%s\n\nControlla di avere i permessi giusti."
+%ls\n\nControlla di avere i permessi giusti."
     IDS_NFO_IMPORT_SUCCESS "File importato con successo."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Premi OK per cancellare le password salvate per la configurazione ""%s"""
+    IDS_NFO_DELETE_PASS "Premi OK per cancellare le password salvate per la configurazione ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Password Token"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Inserisci la Password/PIN per il token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Inserisci la Password/PIN per il token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Credenziali errate. Riprova..."
     IDS_NFO_KEY_PASS_RETRY  "Password errata. Riprova..."
@@ -523,6 +523,6 @@ una volta che l'amministratore ha aggiornato il registro."
     IDS_ERR_INVALID_USERNAME_INPUT "Carattere non valido nel nome utente"
     IDS_NFO_AUTO_CONNECT    "Connessione automatica tra %u secondi..."
     IDS_NFO_CLICK_HERE_TO_START "L'interfaccia OpenVPN è già in esecuzione. Clicca con il tasto destro sull'icona nell'area di notifica per cominciare."
-    IDS_NFO_BYTECOUNT "Byte in: %s out: %s"
+    IDS_NFO_BYTECOUNT "Byte in: %ls out: %ls"
 
 END

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -221,7 +221,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - A Windows GUI for OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - A Windows GUI for OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -277,7 +277,7 @@ BEGIN
     IDS_TIP_CONNECTED "\n接続済み: "
     IDS_TIP_CONNECTING "\n接続中: "
     IDS_TIP_CONNECTED_SINCE "\n接続時間: "
-    IDS_TIP_ASSIGNED_IP "\n割り当てられたIP: %s"
+    IDS_TIP_ASSIGNED_IP "\n割り当てられたIP: %ls"
     IDS_MENU_SERVICE "OpenVPNサービス"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server..."
@@ -302,28 +302,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "切断しますか？（OpenVPNサービスを停止します）"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "ログビューアの起動に失敗しました: %s"
-    IDS_ERR_START_CONF_EDITOR "設定エディタの起動に失敗しました: %s"
+    IDS_ERR_START_LOG_VIEWER "ログビューアの起動に失敗しました: %ls"
+    IDS_ERR_START_CONF_EDITOR "設定エディタの起動に失敗しました: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUIは %d 以上の設定はサポートしていません。上限以上の設定は無視されます。"
     IDS_NFO_NO_CONFIGS "読み込める接続プロファイル（設定ファイル）がありません。\n\
-""ファイルのインポート.."" メニューを使用するか、設定ファイルを ""%s"" か ""%s"" にコピーしてください。"
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "この接続 (%s) を開始するには \
-""%s"" グループのメンバーである必要があります。システム管理者に連絡してください。\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "この接続 (%s) を開始するには \
-""%s"" グループのメンバーである必要があります。\n\n\
+""ファイルのインポート.."" メニューを使用するか、設定ファイルを ""%ls"" か ""%ls"" にコピーしてください。"
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "この接続 (%ls) を開始するには \
+""%ls"" グループのメンバーである必要があります。システム管理者に連絡してください。\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "この接続 (%ls) を開始するには \
+""%ls"" グループのメンバーである必要があります。\n\n\
 このグループに追加しますか？\n\
 この操作を実行するには、管理用パスワードの入力や確認が必要な場合があります。"
-    IDS_NFO_CONFIG_AUTH_PENDING   "この接続 (%s) を開始するには \
-""%s"" グループのメンバーである必要があります。\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "この接続 (%ls) を開始するには \
+""%ls"" グループのメンバーである必要があります。\n\n\
 認証処理を完了してください。"
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "グループ ""%s"" にユーザーを追加できませんでした。"
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "グループ ""%ls"" にユーザーを追加できませんでした。"
     IDS_ERR_ONE_CONN_OLD_VER "OpenVPN 2.0-beta6 より古いバージョンでは、同時に使用できる接続は1つだけです。"
     IDS_ERR_STOP_SERV_OLD_VER "OpenVPNサービスが実行されているときには、OpenVPN GUI で接続を開始できません（OpenVPN 1.5/1.6）。OpenVPN GUIを使用する場合には先にOpenVPNサービスを停止してください。"
-    IDS_ERR_CREATE_EVENT "CreateEvent failed on exit event: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Unknown priority name: %s"
-    IDS_ERR_LOG_APPEND_BOOL "ログファイルの追加フラグ ('%s' が指定されています) は'0'か'1'である必要があります。"
+    IDS_ERR_CREATE_EVENT "CreateEvent failed on exit event: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Unknown priority name: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "ログファイルの追加フラグ ('%ls' が指定されています) は'0'か'1'である必要があります。"
     IDS_ERR_GET_MSIE_PROXY "MSIEのプロキシ設定が取得できません。"
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor failed."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl failed."
@@ -331,43 +331,43 @@ BEGIN
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe on hInputRead failed."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead failed."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite failed."
-    IDS_ERR_CREATE_PROCESS "CreateProcess failed, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess failed, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread to show Status window Failed."
     IDS_NFO_STATE_WAIT_TERM "現在の状況: OpenVPNの終了を待機中..."
     IDS_NFO_STATE_CONNECTED "現在の状況: 接続済み"
-    IDS_NFO_NOW_CONNECTED "%s に接続しました。"
-    IDS_NFO_ASSIGN_IP "割り当てられたIP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls に接続しました。"
+    IDS_NFO_ASSIGN_IP "割り当てられたIP: %ls"
     IDS_ERR_CERT_EXPIRED "証明書の期限が切れているかシステム時刻が正しくないため、接続できません。"
     IDS_ERR_CERT_NOT_YET_VALID "証明書の有効期間前のため接続できません。システム時刻が正しく設定されているかを確認してください。"
     IDS_NFO_STATE_RECONNECTING "現在の状況: 再接続中"
     IDS_NFO_STATE_DISCONNECTED "現在の状況: 切断"
-    IDS_NFO_CONN_TERMINATED "%s への接続を終了しました。."
+    IDS_NFO_CONN_TERMINATED "%ls への接続を終了しました。."
     IDS_NFO_STATE_FAILED "現在の状況: 接続に失敗しました。"
-    IDS_NFO_CONN_FAILED "%s への接続に失敗しました。"
+    IDS_NFO_CONN_FAILED "%ls への接続に失敗しました。"
     IDS_NFO_STATE_FAILED_RECONN "現在の状況: 再接続に失敗"
-    IDS_NFO_RECONN_FAILED "%s への再接続に失敗しました。"
+    IDS_NFO_RECONN_FAILED "%ls への再接続に失敗しました。"
     IDS_NFO_STATE_SUSPENDED "現在の状況: 保留中"
     IDS_ERR_READ_STDOUT_PIPE "OpenVPN 標準出力パイプからの読み取りでエラーが発生しました。"
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Creating RichEdit LogWindow Failed!!"
     IDS_ERR_SET_SIZE "Set Size failed!"
-    IDS_ERR_AUTOSTART_CONF "自動起動用の設定が見つかりません: %s"
+    IDS_ERR_AUTOSTART_CONF "自動起動用の設定が見つかりません: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead failed."
     IDS_NFO_STATE_CONNECTING "現在の状況: 接続中"
-    IDS_NFO_CONNECTION_XXX "OpenVPN接続 (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN接続 (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "現在の状況: 接続スクリプトを実行中"
     IDS_NFO_STATE_DISCONN_SCRIPT "現在の状況: 切断スクリプトを実行中"
-    IDS_ERR_RUN_CONN_SCRIPT "接続スクリプトの実行に失敗: %s"
-    IDS_ERR_GET_EXIT_CODE "接続スクリプトからの戻り値の取得に失敗 (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "接続スクリプトの実行に失敗: %ls"
+    IDS_ERR_GET_EXIT_CODE "接続スクリプトからの戻り値の取得に失敗 (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "接続スクリプトが実行できませんでした。 (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "接続スクリプトが実行できませんでした。 %d 秒経過してタイムアウトしました。"
-    IDS_ERR_CONFIG_EXIST "既に '%s' という名前の設定ファイルが存在しています。\
+    IDS_ERR_CONFIG_EXIST "既に '%ls' という名前の設定ファイルが存在しています。\
 別フォルダでも同じ名前で複数の設定ファイルを使用することはできません。"
     IDS_NFO_CONN_TIMEOUT "管理インターフェイスに接続できませんでした。\n\
-ログファイル (%s) を確認してください。"
+ログファイル (%ls) を確認してください。"
 
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "デバッグファイル (%s) を出力用に開くときにエラーが発生しました。"
-    IDS_ERR_CREATE_PATH "%s を作成できませんでした。パス:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "デバッグファイル (%ls) を出力用に開くときにエラーが発生しました。"
+    IDS_ERR_CREATE_PATH "%ls を作成できませんでした。パス:\n%ls"
     IDS_ERR_LOAD_RICHED20 "RICHED20.DLL が読み込めません。"
     IDS_ERR_SHELL_DLL_VERSION "shell32.dll のバージョンが古いです (0x%lx). バージョン 5.0 以降に更新してください。"
     IDS_NFO_SERVICE_STARTED "OpenVPNサービスが開始されました。"
@@ -423,26 +423,26 @@ OpenVPN GUIをこのまま終了しますか？"
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUIの使い方"
-    IDS_ERR_BAD_PARAMETER """%s"" を --option パラメータとしてパースしようとしましたが \
+    IDS_ERR_BAD_PARAMETER """%ls"" を --option パラメータとしてパースしようとしましたが \
 先頭の '--'がありません。"
-    IDS_ERR_BAD_OPTION "オプションエラー: 認識できないパラメータか、パラメータが不足しています。--%s\n\
+    IDS_ERR_BAD_OPTION "オプションエラー: 認識できないパラメータか、パラメータが不足しています。--%ls\n\
 openvpn-gui --help を参照してください。"
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "ChangePassphraseダイアログを表示するためのCreateThread似失敗しました。"
-    IDS_NFO_CHANGE_PWD "パスワード変更 (%s)"
+    IDS_NFO_CHANGE_PWD "パスワード変更 (%ls)"
     IDS_ERR_PWD_DONT_MATCH "入力されたパスワードが一致していません。再試行してください。"
     IDS_ERR_PWD_TO_SHORT "新しいパスワードは %d 文字以上で設定してください。"
     IDS_NFO_EMPTY_PWD "空のパスワードのまま設定しますか？"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "鍵ファイルフォーマットが不明です。"
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "秘密鍵ファイル (%s) を開くときにエラーが発生しました。"
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "秘密鍵ファイル (%ls) を開くときにエラーが発生しました。"
     IDS_ERR_OLD_PWD_INCORRECT "古いパスワードが正しくありません。"
-    IDS_ERR_OPEN_WRITE_KEY "秘密鍵ファイル (%s) を書き込み用に開くときにエラーが発生しました。"
-    IDS_ERR_WRITE_NEW_KEY "新しい秘密鍵ファイル (%s) への書き込みでエラーが発生しました。"
+    IDS_ERR_OPEN_WRITE_KEY "秘密鍵ファイル (%ls) を書き込み用に開くときにエラーが発生しました。"
+    IDS_ERR_WRITE_NEW_KEY "新しい秘密鍵ファイル (%ls) への書き込みでエラーが発生しました。"
     IDS_NFO_PWD_CHANGED "パスワードは変更されました。"
-    IDS_ERR_READ_PKCS12 "PKCS #12 ファイル (%s) の読み込みでエラーが発生しました。"
+    IDS_ERR_READ_PKCS12 "PKCS #12 ファイル (%ls) の読み込みでエラーが発生しました。"
     IDS_ERR_CREATE_PKCS12 "新しい PKCS #12 オブジェクトの作成でエラーが発生しました。パスワードの変更に失敗しました。"
-    IDS_ERR_OPEN_CONFIG "設定ファイル (%s) を読み取り用に開くときにエラーが発生しました。"
+    IDS_ERR_OPEN_CONFIG "設定ファイル (%ls) を読み取り用に開くときにエラーが発生しました。"
     IDS_ERR_ONLY_ONE_KEY_OPTION "設定ファイル内に複数の ""key"" オプションを設定することはできません。"
     IDS_ERR_ONLY_KEY_OR_PKCS12 "設定ファイル内で ""key"" と ""pkcs12"" の両方を設定することはできません。"
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "設定ファイル内に複数の ""pkcs12"" オプションを設定することはできません。"
@@ -465,7 +465,7 @@ openvpn-gui --help を参照してください。"
     IDS_ERR_SOCKS_PROXY_ADDRESS "SOCKSプロキシのアドレスを設定する必要があります。"
     IDS_ERR_SOCKS_PROXY_PORT "SOCKSプロキシのポートを設定する必要があります。"
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "SOCKSプロキシのポートとして設定できるのは 1-65535 の範囲内です。"
-    IDS_ERR_CREATE_REG_HKCU_KEY """HKEY_CURRENT_USER\\%s"" キーの作成時にエラーが発生しました。"
+    IDS_ERR_CREATE_REG_HKCU_KEY """HKEY_CURRENT_USER\\%ls"" キーの作成時にエラーが発生しました。"
     IDS_ERR_GET_TEMP_PATH "GetTempPath()で一時フォルダが取得できませんでした。""C:\\"" を使用します。"
 
     /* service */
@@ -498,24 +498,24 @@ OpenVPNがインストールされていない可能性があります。"
     IDS_ERR_PRECONN_SCRIPT_TIMEOUT "レジストリ ""preconnectscript_timeout"" の値は 1-99 の範囲内である必要があります。"
     IDS_ERR_CREATE_REG_KEY "キー HKLM\\SOFTWARE\\OpenVPN-GUI の作成に失敗しました。"
     IDS_ERR_OPEN_WRITE_REG "レジストリの書き込みに失敗しました。レジストリの更新時にはアプリケーションを管理者権限で実行する必要があります。"
-    IDS_ERR_READ_SET_KEY "レジストリ ""%s"" の読み取り/書き込みに失敗しました。"
-    IDS_ERR_WRITE_REGVALUE "レジストリ ""HKEY_CURRENT_USER\\%s\\%s"" への書き込みに失敗しました。"
+    IDS_ERR_READ_SET_KEY "レジストリ ""%ls"" の読み取り/書き込みに失敗しました。"
+    IDS_ERR_WRITE_REGVALUE "レジストリ ""HKEY_CURRENT_USER\\%ls\\%ls"" への書き込みに失敗しました。"
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "設定 ""%s"" は既に存在しています。"
+    IDS_ERR_IMPORT_EXISTS "設定 ""%ls"" は既に存在しています。"
     IDS_ERR_IMPORT_FAILED "ファイルがインポートできません。以下のパスは作成されませんでした。\n\n\
-%s\n\n適切な権限があることを確認してください。"
+%ls\n\n適切な権限があることを確認してください。"
     IDS_NFO_IMPORT_SUCCESS "ファイルが正しくインポートされました。"
-    IDS_NFO_IMPORT_OVERWRITE "設定 ""%s"" は既に存在しています。上書きしますか？"
-    IDS_ERR_IMPORT_SOURCE "<%s> はグローバル/ローカル設定フォルダにあるためインポートできません。"
+    IDS_NFO_IMPORT_OVERWRITE "設定 ""%ls"" は既に存在しています。上書きしますか？"
+    IDS_ERR_IMPORT_SOURCE "<%ls> はグローバル/ローカル設定フォルダにあるためインポートできません。"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "設定 ""%s"" の保存されたパスワードを削除するには OK を押してください。"
+    IDS_NFO_DELETE_PASS "設定 ""%ls"" の保存されたパスワードを削除するには OK を押してください。"
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – トークンパスワード"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "トークン '%S' のパスワード/PINを入力してください。"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "トークン '%hs' のパスワード/PINを入力してください。"
 
     IDS_NFO_AUTH_PASS_RETRY "認証情報が正しくありません。もう一度試行してください..."
     IDS_NFO_KEY_PASS_RETRY  "パスワードが正しくありません。もう一度試行してください..."
@@ -523,6 +523,6 @@ OpenVPNがインストールされていない可能性があります。"
     IDS_ERR_INVALID_USERNAME_INPUT "ユーザー名で使用できない文字です"
     IDS_NFO_AUTO_CONNECT    "%u 秒で自動的に再接続します…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI は既に実行されています。トレイアイコンを右クリックして開始してください。"
-    IDS_NFO_BYTECOUNT "バイト数 受信: %s  送信: %s"
+    IDS_NFO_BYTECOUNT "バイト数 受信: %ls  送信: %ls"
 
 END

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -222,7 +222,7 @@ FONT 9, "맑은 고딕"
 LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - A Windows GUI for OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - A Windows GUI for OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -277,7 +277,7 @@ BEGIN
     IDS_TIP_CONNECTED "\n연결됨: "
     IDS_TIP_CONNECTING "\n연결중: "
     IDS_TIP_CONNECTED_SINCE "\n연결 시간: "
-    IDS_TIP_ASSIGNED_IP "\n할당된 IP: %s"
+    IDS_TIP_ASSIGNED_IP "\n할당된 IP: %ls"
     IDS_MENU_SERVICE "OpenVPN 서비스"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -302,26 +302,26 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "연결을 해제하겠습니까? (OpenVPN 서비스 중지)"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "로그 뷰어 시작 실패: %s"
-    IDS_ERR_START_CONF_EDITOR "설정 편집기 시작 실패: %s"
+    IDS_ERR_START_LOG_VIEWER "로그 뷰어 시작 실패: %ls"
+    IDS_ERR_START_CONF_EDITOR "설정 편집기 시작 실패: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI는 %d config 이상의 설정은 지원하지 않습니다. 더이상 설정이 필요한 경우 개발자에게 연락 하십시오."
     IDS_NFO_NO_CONFIGS "설정 파일이 없습니다.\n\
-""파일 불러오기.."" 메뉴를 이용하거나 설정 파일을 ""%s"" 또는 ""%s""로 복사 하십시오."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "이 연결(%s)을 시작하기 위하여 ""%s"" 그룹 권한이 필요합니다.\
+""파일 불러오기.."" 메뉴를 이용하거나 설정 파일을 ""%ls"" 또는 ""%ls""로 복사 하십시오."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "이 연결(%ls)을 시작하기 위하여 ""%ls"" 그룹 권한이 필요합니다.\
 시스템 관리자에게 문의 하십시오.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "이 연결(%s)을 시작하기 위하여 ""%s"" 그룹 권한이 필요합니다.\n\n\
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "이 연결(%ls)을 시작하기 위하여 ""%ls"" 그룹 권한이 필요합니다.\n\n\
 자신을 이 그룹에 추가하겠습니까?\n\
 이 작업은 관리자 암호 또는 동의를 요구할 수 있습니다."
-    IDS_NFO_CONFIG_AUTH_PENDING   "이 연결(%s)을 시작하기 위하여 ""%s"" 그룹 권한이 필요합니다.\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "이 연결(%ls)을 시작하기 위하여 ""%ls"" 그룹 권한이 필요합니다.\n\n\
 이전의 인증 대화 상자를 완료 하십시오."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP """%s"" group에 사용자 추가를 실패했습니다."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP """%ls"" group에 사용자 추가를 실패했습니다."
     IDS_ERR_ONE_CONN_OLD_VER "OpenVPN 2.0-beta6 이전 버전에서는 2개 이상의 동시 연결을 지원하지 않습니다."
     IDS_ERR_STOP_SERV_OLD_VER "OpenVPN 1.5/1.6을 사용할 경우, OpenVPN 서비스가 구동되고 있으면 OpenVPN GUI을 이용하여 연결을 할 수 없습니다. OpenVPN GUI를 사용하려면, 먼저 OpenVPN 서비스를 중지 시키십시오."
-    IDS_ERR_CREATE_EVENT "CreateEvent failed on exit event: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Unknown priority name: %s"
-    IDS_ERR_LOG_APPEND_BOOL "로그 파일의 '%s'로 지정된 추가 플래그는 '0'또는 '1'이어야합니다."
+    IDS_ERR_CREATE_EVENT "CreateEvent failed on exit event: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Unknown priority name: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "로그 파일의 '%ls'로 지정된 추가 플래그는 '0'또는 '1'이어야합니다."
     IDS_ERR_GET_MSIE_PROXY "MSIE 프락시 설정을 가져올 수 없습니다."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor 실패"
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl 실패"
@@ -329,42 +329,42 @@ BEGIN
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe on hInputRead failed."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead failed."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite failed."
-    IDS_ERR_CREATE_PROCESS "CreateProcess failed, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess failed, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread to show Status window Failed."
     IDS_NFO_STATE_WAIT_TERM "현재 상태: OpenVPN 종료 대기 중…"
     IDS_NFO_STATE_CONNECTED "현재 상태: 연결됨"
-    IDS_NFO_NOW_CONNECTED "%s 접속이 연결 되었습니다."
-    IDS_NFO_ASSIGN_IP "할당된 IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls 접속이 연결 되었습니다."
+    IDS_NFO_ASSIGN_IP "할당된 IP: %ls"
     IDS_ERR_CERT_EXPIRED "인증서가 만료 되었거나, 시스템 시간이 잘못 설정 되어 연결할 수 없습니다."
     IDS_ERR_CERT_NOT_YET_VALID "인증서의 유효기간 이전에 연결할 수 없습니다. 시스템 시간이 정확한지 확인해 보십시오."
     IDS_NFO_STATE_RECONNECTING "현재 상태: 재접속 중"
     IDS_NFO_STATE_DISCONNECTED "현재 상태: 연결 해제"
-    IDS_NFO_CONN_TERMINATED "%s 연결이 종료 되었습니다."
+    IDS_NFO_CONN_TERMINATED "%ls 연결이 종료 되었습니다."
     IDS_NFO_STATE_FAILED "현재 상태: 접속 실패"
-    IDS_NFO_CONN_FAILED "%s 접속에 실패했습니다."
+    IDS_NFO_CONN_FAILED "%ls 접속에 실패했습니다."
     IDS_NFO_STATE_FAILED_RECONN "현재 상태: 재접속 실패"
-    IDS_NFO_RECONN_FAILED "%s 재접속에 실패했습니다."
+    IDS_NFO_RECONN_FAILED "%ls 재접속에 실패했습니다."
     IDS_NFO_STATE_SUSPENDED "현재 상태: 대기 중"
     IDS_ERR_READ_STDOUT_PIPE "OpenVPN 표준 출력 파이프를 읽는 중 오류가 발생했습니다."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Creating RichEdit LogWindow Failed!!"
     IDS_ERR_SET_SIZE "Set Size failed!"
-    IDS_ERR_AUTOSTART_CONF "요청된 자동 시작 설정을 찾을 수 없습니다: %s"
+    IDS_ERR_AUTOSTART_CONF "요청된 자동 시작 설정을 찾을 수 없습니다: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead failed."
     IDS_NFO_STATE_CONNECTING "현재 상태: 접속 중"
-    IDS_NFO_CONNECTION_XXX "OpenVPN 접속 (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN 접속 (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "현재 상태: 연결 스크립트 실행 중"
     IDS_NFO_STATE_DISCONN_SCRIPT "현재 상태: 연결 해제 스크립트 실행 중"
-    IDS_ERR_RUN_CONN_SCRIPT "연결 실행 스크립트 수행 중 오류: %s"
-    IDS_ERR_GET_EXIT_CODE "연결 스크립트(%s)의 종료코드를 받아오지 못함"
+    IDS_ERR_RUN_CONN_SCRIPT "연결 실행 스크립트 수행 중 오류: %ls"
+    IDS_ERR_GET_EXIT_CODE "연결 스크립트(%ls)의 종료코드를 받아오지 못함"
     IDS_ERR_CONN_SCRIPT_FAILED "연결 스크립트 실패. (종료코드=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "연결 스크립트 실패. %d초 경과 되었습니다."
-    IDS_ERR_CONFIG_EXIST "'%s' 설정 파일이 이미 존재 합니다. 비록 경로가 다르더라도 \
+    IDS_ERR_CONFIG_EXIST "'%ls' 설정 파일이 이미 존재 합니다. 비록 경로가 다르더라도 \
 동일한 설정 파일 이름은 사용할 수 없습니다."
     IDS_NFO_CONN_TIMEOUT "관리 인터페이스 연결에 실패했습니다.\n\
-자세한 사항은 로그파일(%s)을 참조 하십시오."
+자세한 사항은 로그파일(%ls)을 참조 하십시오."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "디버그 파일(%s)을 출력할 수 없습니다."
-    IDS_ERR_CREATE_PATH "%s 생성 실패:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "디버그 파일(%ls)을 출력할 수 없습니다."
+    IDS_ERR_CREATE_PATH "%ls 생성 실패:\n%ls"
     IDS_ERR_LOAD_RICHED20 "RICHED20.DLL 로드를 실패 했습니다."
     IDS_ERR_SHELL_DLL_VERSION "shell32.dll version이 오래되었습니다(0x%lx). 5.0 이상이 필요 합니다."
     IDS_NFO_SERVICE_STARTED "OpenVPN Service가 시작 되었습니다."
@@ -420,26 +420,26 @@ OpenVPN GUI를 이대로 종료 하겠습니까?"
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI 사용법"
-    IDS_ERR_BAD_PARAMETER "I'm trying to parse ""%s"" as an --option parameter \
+    IDS_ERR_BAD_PARAMETER "I'm trying to parse ""%ls"" as an --option parameter \
 but I don't see a leading '--'"
-    IDS_ERR_BAD_OPTION "옵션 오류: 잘못된 옵션 또는 옵션값 누락: --%s\n\
+    IDS_ERR_BAD_OPTION "옵션 오류: 잘못된 옵션 또는 옵션값 누락: --%ls\n\
 자세한 사항은 openvpn-gui --help 명령을 참조 하십시오."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread to show ChangePassphrase dialog failed."
-    IDS_NFO_CHANGE_PWD "(%s) 개인키 암호 변경"
+    IDS_NFO_CHANGE_PWD "(%ls) 개인키 암호 변경"
     IDS_ERR_PWD_DONT_MATCH "입력한 암호가 일치하지 않습니다. 다시 입력 하십시오."
     IDS_ERR_PWD_TO_SHORT "새 암호는 %d글자 보다 길어야 합니다."
     IDS_NFO_EMPTY_PWD "암호가 없는 상태로 설정하겠습니까?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "keyfile 형식을 알 수 없습니다."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "개인키 파일(%s)을 열 수 없습니다."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "개인키 파일(%ls)을 열 수 없습니다."
     IDS_ERR_OLD_PWD_INCORRECT "이전 암호가 맞지 않습니다."
-    IDS_ERR_OPEN_WRITE_KEY "개인키 파일(%s)을 저장 할 수 없습니다."
-    IDS_ERR_WRITE_NEW_KEY "새 개인키 파일(%s)를 저장 할 수 없습니다."
+    IDS_ERR_OPEN_WRITE_KEY "개인키 파일(%ls)을 저장 할 수 없습니다."
+    IDS_ERR_WRITE_NEW_KEY "새 개인키 파일(%ls)를 저장 할 수 없습니다."
     IDS_NFO_PWD_CHANGED "암호가 변경 되었습니다."
-    IDS_ERR_READ_PKCS12 "PKCS #12 파일(%s)을 읽을 수 없습니다."
+    IDS_ERR_READ_PKCS12 "PKCS #12 파일(%ls)을 읽을 수 없습니다."
     IDS_ERR_CREATE_PKCS12 "새로운 PKCS #12 개체를 생성할 수 없어, 암호 변경을 할 수 없습니다."
-    IDS_ERR_OPEN_CONFIG "설정 파일 읽기 오류: (%s)"
+    IDS_ERR_OPEN_CONFIG "설정 파일 읽기 오류: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "설정 파일에 ""key"" 옵션을 중복 지정 할 수 없습니다."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "설정파일에 ""key""와 ""pkcs12"" 옵션을 동시에 지정 할 수 없습니다."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "설정 파일에 ""pkcs12"" 옵션을 중복 지정 할 수 없습니다."
@@ -462,7 +462,7 @@ but I don't see a leading '--'"
     IDS_ERR_SOCKS_PROXY_ADDRESS "SOCKS proxy 주소 설정이 필요 합니다."
     IDS_ERR_SOCKS_PROXY_PORT "SOCKS proxy 포트 설정이 필요 합니다."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "SOCKS proxy 포트는 1-65535 범위로 해야 합니다."
-    IDS_ERR_CREATE_REG_HKCU_KEY """HKEY_CURRENT_USER\\%s"" key를 생성하지 못했습니다."
+    IDS_ERR_CREATE_REG_HKCU_KEY """HKEY_CURRENT_USER\\%ls"" key를 생성하지 못했습니다."
     IDS_ERR_GET_TEMP_PATH "GenTempPath()로 TempPath를 결정하는 중 오류가 발생헀습니다. ""C:\\""를 대신 사용합니다."
 
     /* service */
@@ -496,24 +496,24 @@ OpenVPN이 설치 되어 있지 않은 것 같습니다."
     IDS_ERR_CREATE_REG_KEY "HKLM\\SOFTWARE\\OpenVPN-GUI 키를 만들 수 없습니다.."
     IDS_ERR_OPEN_WRITE_REG "레지스트리에 기록할 수 없습니다. 레지스트리를 업데이트 하려면 \
 Administrator 권한으로 이 프로그램을 실행해야 합니다."
-    IDS_ERR_READ_SET_KEY "레지스트리 ""%s""키 읽기/쓰기를 할 수 없습니다."
-    IDS_ERR_WRITE_REGVALUE "레지스트리 ""HKEY_CURRENT_USER\\%s\\%s"" 값을 기록할 수 없습니다."
+    IDS_ERR_READ_SET_KEY "레지스트리 ""%ls""키 읽기/쓰기를 할 수 없습니다."
+    IDS_ERR_WRITE_REGVALUE "레지스트리 ""HKEY_CURRENT_USER\\%ls\\%ls"" 값을 기록할 수 없습니다."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS """%s"" 설정 파일은 이미 존재 합니다."
+    IDS_ERR_IMPORT_EXISTS """%ls"" 설정 파일은 이미 존재 합니다."
     IDS_ERR_IMPORT_FAILED "파일 불러오기 실패. 다음 경로를 생성할 수 없습니다.\n\n\
-%s\n\n올바른 권한을 가지고 있는지 확인 해 보십시오."
+%ls\n\n올바른 권한을 가지고 있는지 확인 해 보십시오."
     IDS_NFO_IMPORT_SUCCESS "파일 불러오기 성공."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS """%s"" 설정의 저장된 암호를 삭제 하려면 확인을 누르십시오."
+    IDS_NFO_DELETE_PASS """%ls"" 설정의 저장된 암호를 삭제 하려면 확인을 누르십시오."
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - 토큰 암호"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "'%S' 토큰에 대한 암호/핀을 입력 하십시오."
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "'%hs' 토큰에 대한 암호/핀을 입력 하십시오."
 
     IDS_NFO_AUTH_PASS_RETRY "사용자 또는 암호 오류. 재시도 하십시오."
     IDS_NFO_KEY_PASS_RETRY  "암호 오류. 재입력 하십시오."
@@ -521,5 +521,5 @@ Administrator 권한으로 이 프로그램을 실행해야 합니다."
     IDS_ERR_INVALID_USERNAME_INPUT "사용자 이름에 잘못된 문자가 있습니다."
     IDS_NFO_AUTO_CONNECT    "%u초 후 자동으로 연결..."
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI 가 이미 실행 중입니다. 시작하려면 작업 표시줄의 아이콘을 마우스 우클릭 하십시오."
-    IDS_NFO_BYTECOUNT "수신 바이트: %s  전송 바이트: %s"
+    IDS_NFO_BYTECOUNT "수신 바이트: %ls  전송 바이트: %ls"
 END

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -221,7 +221,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_DUTCH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - Een Windows GUI voor OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - Een Windows GUI voor OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -277,7 +277,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nVerbonden met: "
     IDS_TIP_CONNECTING "\nVerbinden met: "
     IDS_TIP_CONNECTED_SINCE "\nVerbonden sinds: "
-    IDS_TIP_ASSIGNED_IP "\nToegewezen IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nToegewezen IP: %ls"
     IDS_MENU_SERVICE "OpenVPN Service"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -302,28 +302,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "De verbinding verbreken (Stop de OpenVPN Service)?"
 
     /* Logviewer – Resources */
-    IDS_ERR_START_LOG_VIEWER "Fout tijdens starten logboek: %s"
-    IDS_ERR_START_CONF_EDITOR "Fout tijdens starten configurator: %s"
+    IDS_ERR_START_LOG_VIEWER "Fout tijdens starten logboek: %ls"
+    IDS_ERR_START_CONF_EDITOR "Fout tijdens starten configurator: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI ondersteunt niet meer dan %d configuraties. Neem contact op met de auteur indien u er meer wenst."
     IDS_NFO_NO_CONFIGS "Geen leesbare verbindingsprofielen (config files) gevonden.\n\
-Gebruik het menu ""Bestand importeren…"" of kopieer uw configuratiebestanden naar ""%s"" of ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Het maken van deze verbinding (%s) vereist lidmaatschap van\n\
-de groep ""%s"". Neem contact op met de systeembeheerder.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Het maken van deze verbinding (%s) vereist lidmaatschap van\n\
-de groep ""%s"".\n\n\
+Gebruik het menu ""Bestand importeren…"" of kopieer uw configuratiebestanden naar ""%ls"" of ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Het maken van deze verbinding (%ls) vereist lidmaatschap van\n\
+de groep ""%ls"". Neem contact op met de systeembeheerder.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Het maken van deze verbinding (%ls) vereist lidmaatschap van\n\
+de groep ""%ls"".\n\n\
 Wilt u uzelf toevoegen aan deze groep?\n\
 Tijdens deze actie kan er om het administratorwachtwoord gevraagd worden."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Het maken van deze verbinding (%s) vereist lidmaatschap van\n\
-de groep ""%s"".\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Het maken van deze verbinding (%ls) vereist lidmaatschap van\n\
+de groep ""%ls"".\n\n\
 Vul het voorgaande autorisatiescherm volledig in."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Toevoegen van de gebruiker aan de groep ""%s"" is mislukt."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Toevoegen van de gebruiker aan de groep ""%ls"" is mislukt."
     IDS_ERR_ONE_CONN_OLD_VER "Er kan maar één verbinding per OpenVPN-client gestart worden met versies ouder dan OpenVPN 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "De OpenVPN GUI kan niet gestart worden als de OpenVPN Service actief is. (OpenVPN 1.5/1.6). Stop eerst de OpenVPN Service indien u de OpenVPN GUI wenst te gebruiken."
-    IDS_ERR_CREATE_EVENT "CreateEvent mislukt tijdens exit event: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Onbekende prioriteitsnaam: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Logbestand append flag (opgegeven als '%s') moet '0' of '1' zijn"
+    IDS_ERR_CREATE_EVENT "CreateEvent mislukt tijdens exit event: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Onbekende prioriteitsnaam: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Logbestand append flag (opgegeven als '%ls') moet '0' of '1' zijn"
     IDS_ERR_GET_MSIE_PROXY "Kan MSIE proxyinstellingen niet ophalen."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor mislukt."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl mislukt."
@@ -331,43 +331,43 @@ Vul het voorgaande autorisatiescherm volledig in."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe on hInputRead mislukt."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead mislukt."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite mislukt."
-    IDS_ERR_CREATE_PROCESS "CreateProcess mislukt, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess mislukt, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread om Statusvenster te tonen mislukt."
     IDS_NFO_STATE_WAIT_TERM "Huidige status: Wachten tot OpenVPN gestopt is…"
     IDS_NFO_STATE_CONNECTED "Huidige status: Verbonden"
-    IDS_NFO_NOW_CONNECTED "%s is nu verbonden."
-    IDS_NFO_ASSIGN_IP "Toegewezen IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls is nu verbonden."
+    IDS_NFO_ASSIGN_IP "Toegewezen IP: %ls"
     IDS_ERR_CERT_EXPIRED "Kan geen verbinding maken, het certificaat is vervallen. Controleer eventueel de systeemtijd."
     IDS_ERR_CERT_NOT_YET_VALID "Kan geen verbinding maken, het certificaat is nog niet geldig. Controleer eventueel de systeemtijd."
     IDS_NFO_STATE_RECONNECTING "Huidige status: Opnieuw verbinden"
     IDS_NFO_STATE_DISCONNECTED "Huidige status: Niet verbonden"
-    IDS_NFO_CONN_TERMINATED "Verbinding met %s is verbroken."
+    IDS_NFO_CONN_TERMINATED "Verbinding met %ls is verbroken."
     IDS_NFO_STATE_FAILED "Huidige status: Kan geen verbinding maken"
-    IDS_NFO_CONN_FAILED "Verbinden met %s is mislukt."
+    IDS_NFO_CONN_FAILED "Verbinden met %ls is mislukt."
     IDS_NFO_STATE_FAILED_RECONN "Huidige status: Opnieuw verbinden is mislukt."
-    IDS_NFO_RECONN_FAILED "Opnieuw verbinden met %s is mislukt."
+    IDS_NFO_RECONN_FAILED "Opnieuw verbinden met %ls is mislukt."
     IDS_NFO_STATE_SUSPENDED "Huidige status: Onderbroken"
     IDS_ERR_READ_STDOUT_PIPE "Fout tijdens lezen van OpenVPN StdOut Pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Creatie van RichEdit LogWindow mislukt!"
     IDS_ERR_SET_SIZE "Instellen afmetingen mislukt!"
-    IDS_ERR_AUTOSTART_CONF "Kan opgegeven configuratie voor automatische verbinding niet vinden: %s"
+    IDS_ERR_AUTOSTART_CONF "Kan opgegeven configuratie voor automatische verbinding niet vinden: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe tijdens hInputRead mislukt."
     IDS_NFO_STATE_CONNECTING "Huidige status: Verbinden"
-    IDS_NFO_CONNECTION_XXX "OpenVPN Verbinding (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN Verbinding (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Huidige status: Connect Script Uitvoeren"
     IDS_NFO_STATE_DISCONN_SCRIPT "Huidige status: Disconnect Script Uitvoeren"
-    IDS_ERR_RUN_CONN_SCRIPT "Fout tijdens  uitvoeren Connect Script: %s"
-    IDS_ERR_GET_EXIT_CODE "Kan ExitCode niet uitlezen voor Connect Script (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Fout tijdens  uitvoeren Connect Script: %ls"
+    IDS_ERR_GET_EXIT_CODE "Kan ExitCode niet uitlezen voor Connect Script (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Connect Script mislukt. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Connect Script mislukt. TimeOut na %d sec."
-    IDS_ERR_CONFIG_EXIST "Er bestaat al een configuratie '%s'. Elke configuratie \
+    IDS_ERR_CONFIG_EXIST "Er bestaat al een configuratie '%ls'. Elke configuratie \
 moet een unieke naam hebben, ook als \
 ze in verschillende mappen bewaard worden."
     IDS_NFO_CONN_TIMEOUT "Verbinden met management interface mislukt.\n\
-Bekijk logbestand (%s) voor meer informatie."
+Bekijk logbestand (%ls) voor meer informatie."
     /* main – Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Fout tijdens schrijven naar debug-log (%s)."
-    IDS_ERR_CREATE_PATH "Kan het %s pad niet aanmaken:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Fout tijdens schrijven naar debug-log (%ls)."
+    IDS_ERR_CREATE_PATH "Kan het %ls pad niet aanmaken:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Kan RICHED20.DLL niet laden."
     IDS_ERR_SHELL_DLL_VERSION "De shell32.dll versie is te oud (0x%lx). Minstens versie 5.0 is vereist."
     IDS_NFO_SERVICE_STARTED "OpenVPN Service gestart."
@@ -423,26 +423,26 @@ Instellingen die de registerinstellingen overschrijven:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI Opties"
-    IDS_ERR_BAD_PARAMETER "Ik probeer ""%s"" te interpreteren als een --option parameter \
+    IDS_ERR_BAD_PARAMETER "Ik probeer ""%ls"" te interpreteren als een --option parameter \
 maar kan geen '--'-prefix vinden."
-    IDS_ERR_BAD_OPTION "Fout in Opties: Onbekende optie of ontbrekende parameter: --%s\n\
+    IDS_ERR_BAD_OPTION "Fout in Opties: Onbekende optie of ontbrekende parameter: --%ls\n\
 Gebruik openvpn-gui --help voor meer informatie."
 
     /* passphrase – Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread om ChangePassphrase venster aan te maken is mislukt."
-    IDS_NFO_CHANGE_PWD "Wijzig wachtwoord (%s)"
+    IDS_NFO_CHANGE_PWD "Wijzig wachtwoord (%ls)"
     IDS_ERR_PWD_DONT_MATCH "De wachtwoorden die u heeft ingegeven komen niet overeen. Probeer opnieuw."
     IDS_ERR_PWD_TO_SHORT "Het nieuwe wachtwoord moet minstens %d tekens bevatten."
     IDS_NFO_EMPTY_PWD "Wilt u echt een LEEG wachtwoord instellen?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Onbekend keyfile formaat."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Fout tijdens openen van private key bestand (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Fout tijdens openen van private key bestand (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Het oude wachtwoord is niet correct."
-    IDS_ERR_OPEN_WRITE_KEY "Fout tijdens schrijven naar private key bestand (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Fout tijdens schrijven naar nieuw private key bestand (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Fout tijdens schrijven naar private key bestand (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Fout tijdens schrijven naar nieuw private key bestand (%ls)."
     IDS_NFO_PWD_CHANGED "Het wachtwoord is gewijzigd."
-    IDS_ERR_READ_PKCS12 "Fout tijdens lezen van PKCS #12 bestand (%s)."
+    IDS_ERR_READ_PKCS12 "Fout tijdens lezen van PKCS #12 bestand (%ls)."
     IDS_ERR_CREATE_PKCS12 "Fout tijdens aanmaken van PKCS #12 object. Wijzigen wachtwoord is mislukt."
-    IDS_ERR_OPEN_CONFIG "Kan configuratiebestand niet lezen: (%s)"
+    IDS_ERR_OPEN_CONFIG "Kan configuratiebestand niet lezen: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "Er mag slechts een enkele ""key"" optie voorkomen in een configuratie."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "De opties ""key"" en ""pkcs12"" mogen niet samen voorkomen in een configuratie."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Er mag slechts een enkele ""pkcs12"" optie voorkomen in een configuratie."
@@ -465,7 +465,7 @@ Kies een nieuw wachtwoord."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Er moet een SOCKS proxyadres opgegeven worden."
     IDS_ERR_SOCKS_PROXY_PORT "Er moet een SOCKS proxypoort opgegeven worden."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Er moet een SOCKS proxypoort opgegeven worden tussen 1 en 65535."
-    IDS_ERR_CREATE_REG_HKCU_KEY "Fout tijdens aanmaken ""HKEY_CURRENT_USER\\%s"" sleutel."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Fout tijdens aanmaken ""HKEY_CURRENT_USER\\%ls"" sleutel."
     IDS_ERR_GET_TEMP_PATH "Fout tijdens opvragen TempPath met GetTempPath(). Gebruikt ""C:\\"" als TempPath."
 
     /* service */
@@ -499,24 +499,24 @@ OpenVPN is waarschijnlijk niet geïnstalleerd"
     IDS_ERR_CREATE_REG_KEY "Fout tijdens aanmaken van HKLM\\SOFTWARE\\OpenVPN-GUI sleutel."
     IDS_ERR_OPEN_WRITE_REG "Fout tijdens het schrijven naar het register. Voer deze applicatie één keer uit als Administrator \
 om de registerinstellingen te updaten."
-    IDS_ERR_READ_SET_KEY "Fout tijdens lezen en instellen van registersleutel ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Fout tijdens schrijven van registersleutel ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Fout tijdens lezen en instellen van registersleutel ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Fout tijdens schrijven van registersleutel ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Een configuratie met de naam ""%s"" bestaat al."
+    IDS_ERR_IMPORT_EXISTS "Een configuratie met de naam ""%ls"" bestaat al."
     IDS_ERR_IMPORT_FAILED "Importeren bestand is mislukt. De onderstaande bestandsnaam kon niet gemaakt worden.\n\n\
-%s\n\nControleer of de juiste rechten gebruikt worden."
+%ls\n\nControleer of de juiste rechten gebruikt worden."
     IDS_NFO_IMPORT_SUCCESS "Importeren bestand gelukt."
-    IDS_NFO_IMPORT_OVERWRITE "Een configuratie met de naam ""%s"" bestaat al. Wilt u deze vervangen?"
-    IDS_ERR_IMPORT_SOURCE "Het bestand <%s> kan niet worden geïmporteerd omdat het al in de globale of lokale configuratiemap bestaat"
+    IDS_NFO_IMPORT_OVERWRITE "Een configuratie met de naam ""%ls"" bestaat al. Wilt u deze vervangen?"
+    IDS_ERR_IMPORT_SOURCE "Het bestand <%ls> kan niet worden geïmporteerd omdat het al in de globale of lokale configuratiemap bestaat"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Klik op OK om alle opgeslagen wachtwoorden voor de configuratie ""%s"" te verwijderen"
+    IDS_NFO_DELETE_PASS "Klik op OK om alle opgeslagen wachtwoorden voor de configuratie ""%ls"" te verwijderen"
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Wachtwoord voor Token"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Vul het wachtwoord of de PIN in voor Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Vul het wachtwoord of de PIN in voor Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Onjuiste gebruikersnaam of wachtwoord. Probeer opnieuw..."
     IDS_NFO_KEY_PASS_RETRY  "Onjuist wachtwoord. Probeer opnieuw..."
@@ -524,6 +524,6 @@ om de registerinstellingen te updaten."
     IDS_ERR_INVALID_USERNAME_INPUT "Ongeldig karakter in de gebruikersnaam"
     IDS_NFO_AUTO_CONNECT    "Automatisch verbinden over %u seconden..."
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI draait al. Klik met de rechtermuisknop op het tray icon om te starten."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  uit: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  uit: %ls"
 
 END

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -220,7 +220,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_NORWEGIAN, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - Et Windows-grensesnitt mot OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - Et Windows-grensesnitt mot OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -276,7 +276,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nTilkoblet: "
     IDS_TIP_CONNECTING "\nKobler til: "
     IDS_TIP_CONNECTED_SINCE "\nTilkoblet siden: "
-    IDS_TIP_ASSIGNED_IP "\nTildelt IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nTildelt IP: %ls"
     IDS_MENU_SERVICE "OpenVPN-tjenesten"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -301,26 +301,26 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Vil du koble fra (stoppe OpenVPN-tjenesten)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Feil under oppstart av program for loggvisning: %s"
-    IDS_ERR_START_CONF_EDITOR "Feil under oppstart av konfigurasjons-editor: %s"
+    IDS_ERR_START_LOG_VIEWER "Feil under oppstart av program for loggvisning: %ls"
+    IDS_ERR_START_CONF_EDITOR "Feil under oppstart av konfigurasjons-editor: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "Du kan ikke ha flere enn %d konfigurasjonsfiler. Kontakt utvikleren av OpenVPN GUI om du har behov for å håndtere flere filer."
     IDS_NFO_NO_CONFIGS "Ingen lesbare tilkoblingsprofiler (konfigurasjonsfiler) funnet"
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "For å starte tilkoblingen (%s) kreves medlemskap i gruppen ""%s"". \
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "For å starte tilkoblingen (%ls) kreves medlemskap i gruppen ""%ls"". \
 Kontakt din systemadministrator for hjelp med dette.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "For å starte tilkoblingen (%s) kreves medlemskap i gruppen ""%s"".\n\n\
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "For å starte tilkoblingen (%ls) kreves medlemskap i gruppen ""%ls"".\n\n\
 Vil du gjøre din brukerkonto medlem av denne gruppen?\n\
 Du kan bli spurt om administrator-rettigheter for å utføre denne endringen."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Please complete the previous authorization dialog."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%ls"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Du kan bare bruke én enkelt tilkobling av gangen med eldre versjoner av OpenVPN enn 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Du kan ikke koble til med OpenVPN GUI når OpenVPN-tjenesten kjører. (kun OpenVPN 1.5/1.6). Stopp tjenesten først om du vil benytte OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "CreateEvent feilet med å opprette hendelsen: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Ukjent prioritet: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Flagg for å overskrive eller beholde gammel loggfil ('%s') må være '0' eller '1'."
+    IDS_ERR_CREATE_EVENT "CreateEvent feilet med å opprette hendelsen: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Ukjent prioritet: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Flagg for å overskrive eller beholde gammel loggfil ('%ls') må være '0' eller '1'."
     IDS_ERR_GET_MSIE_PROXY "Kunne ikke hente HTTP proxy-innstillinger fra Internet Explorer."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor feilet."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl feilet."
@@ -328,41 +328,41 @@ Please complete the previous authorization dialog."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe på hInputRead feilet."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle på hOutputRead feilet."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle på hInputWrite feilet."
-    IDS_ERR_CREATE_PROCESS "CreateProcess feilet, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess feilet, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread for å vise statusvindu feilet."
     IDS_NFO_STATE_WAIT_TERM "Status: Venter på at OpenVPN stopper…"
     IDS_NFO_STATE_CONNECTED "Status: Tilkoblet"
-    IDS_NFO_NOW_CONNECTED "%s er tilkoblet."
-    IDS_NFO_ASSIGN_IP "Tildelt IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls er tilkoblet."
+    IDS_NFO_ASSIGN_IP "Tildelt IP: %ls"
     IDS_ERR_CERT_EXPIRED "Kunne ikke koble til. Sertifikatet er ikke lenger gyldig. Eventuelt kan klokken på datamaskinen din gå feil."
     IDS_ERR_CERT_NOT_YET_VALID "Kunne ikke koble til. Sertifikatet er ikke gyldig enda. Eventuelt kan klokken på datamaskinen din gå feil."
     IDS_NFO_STATE_RECONNECTING "Status: Kobler til på nytt"
     IDS_NFO_STATE_DISCONNECTED "Status: Koblet fra"
-    IDS_NFO_CONN_TERMINATED "Du har blitt frakoblet %s."
+    IDS_NFO_CONN_TERMINATED "Du har blitt frakoblet %ls."
     IDS_NFO_STATE_FAILED "Status: Tilkobling feilet."
-    IDS_NFO_CONN_FAILED "Tilkobling til %s feilet."
+    IDS_NFO_CONN_FAILED "Tilkobling til %ls feilet."
     IDS_NFO_STATE_FAILED_RECONN "Status: Kunne ikke koble til på nytt"
-    IDS_NFO_RECONN_FAILED "Tilkobling til %s feilet."
+    IDS_NFO_RECONN_FAILED "Tilkobling til %ls feilet."
     IDS_NFO_STATE_SUSPENDED "Status: Hvilemodus"
     IDS_ERR_READ_STDOUT_PIPE "Feil under behandling av loggdata fra OpenVPN"
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Kunne ikke klargjøre loggvindu"
     IDS_ERR_SET_SIZE "'Set Size' feilet!"
-    IDS_ERR_AUTOSTART_CONF "Følgende konfig kunne ikke starte automatisk: %s"
+    IDS_ERR_AUTOSTART_CONF "Følgende konfig kunne ikke starte automatisk: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe på hInputRead feilet."
     IDS_NFO_STATE_CONNECTING "Status: Kobler til"
-    IDS_NFO_CONNECTION_XXX "OpenVPN Tilkoblet (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN Tilkoblet (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Status: Kjører skript for tilkobling"
     IDS_NFO_STATE_DISCONN_SCRIPT "Status: Kjører skript for frakobling"
-    IDS_ERR_RUN_CONN_SCRIPT "En feil oppsto under kjøring av skript: %s"
-    IDS_ERR_GET_EXIT_CODE "En feil oppsto da avslutningskode fra følgende skript skulle hentes: %s"
+    IDS_ERR_RUN_CONN_SCRIPT "En feil oppsto under kjøring av skript: %ls"
+    IDS_ERR_GET_EXIT_CODE "En feil oppsto da avslutningskode fra følgende skript skulle hentes: %ls"
     IDS_ERR_CONN_SCRIPT_FAILED "Tilkoblingsskriptet feilet. (avslutningskode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Tilkoblingsskriptet fikk tidsavbrudd etter %d sekunder."
-    IDS_ERR_CONFIG_EXIST "Det finnes allerede en konfigurasjonsfil med navnet '%s'. Du kan ikke ha flere \
+    IDS_ERR_CONFIG_EXIST "Det finnes allerede en konfigurasjonsfil med navnet '%ls'. Du kan ikke ha flere \
 konfigurasjonsfiler med samme navn, selv om de ligger i ulike kataloger."
 
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Feil under åpning av feilsøkingsfil. (%s)"
-    IDS_ERR_CREATE_PATH "Kunne ikke opprette filsti for %s:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Feil under åpning av feilsøkingsfil. (%ls)"
+    IDS_ERR_CREATE_PATH "Kunne ikke opprette filsti for %ls:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Kunne ikke laste RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Din versjon av shell32.dll er for lav (0x%lx). Du trenger minst versjon 5.0."
     IDS_NFO_SERVICE_STARTED "OpenVPN-tjenesten startet."
@@ -416,26 +416,26 @@ Parametere som vil overstyre innstillinger gjort i registeret:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI bruk"
-    IDS_ERR_BAD_PARAMETER "Forsøkte å tolke ""%s"" som et --option parameter, \
+    IDS_ERR_BAD_PARAMETER "Forsøkte å tolke ""%ls"" som et --option parameter, \
 men kunne ikke finne innledende '--'"
-    IDS_ERR_BAD_OPTION "Ukjent parameter eller manglende argument: --%s\n\
+    IDS_ERR_BAD_OPTION "Ukjent parameter eller manglende argument: --%ls\n\
 Kjør openvpn-gui --help for hjelp."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "Det oppsto en feil under åpning av dialogboksen for endring av passord."
-    IDS_NFO_CHANGE_PWD "Endre passord (%s)"
+    IDS_NFO_CHANGE_PWD "Endre passord (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Passordene som ble oppgitt samsvarer ikke med hverandre. Prøv igjen."
     IDS_ERR_PWD_TO_SHORT "Passordet må bestå av minst %d tegn."
     IDS_NFO_EMPTY_PWD "Er du sikker på at du vil benytte et BLANKT passord?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Nøkkelfilen har ukjent format."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "En feil oppsto under åpning av nøkkelfilen (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "En feil oppsto under åpning av nøkkelfilen (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Du har oppgitt feil passord."
-    IDS_ERR_OPEN_WRITE_KEY "En feil oppsto under åpning av nøkkelfil for skrivning (%s)."
-    IDS_ERR_WRITE_NEW_KEY "En feil oppsto under opprettelse av ny nøkkelfil (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "En feil oppsto under åpning av nøkkelfil for skrivning (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "En feil oppsto under opprettelse av ny nøkkelfil (%ls)."
     IDS_NFO_PWD_CHANGED "Passordet er endret."
-    IDS_ERR_READ_PKCS12 "Feil under lesning fra PKCS #12 fil (%s)."
+    IDS_ERR_READ_PKCS12 "Feil under lesning fra PKCS #12 fil (%ls)."
     IDS_ERR_CREATE_PKCS12 "En feil oppsto under opprettelse av PKCS #12 objekt."
-    IDS_ERR_OPEN_CONFIG "En feil oppsto under åpningen av en konfigurasjonsfil: %s."
+    IDS_ERR_OPEN_CONFIG "En feil oppsto under åpningen av en konfigurasjonsfil: %ls."
     IDS_ERR_ONLY_ONE_KEY_OPTION "Du kan ikke ha mer enn ett ""key""-parameter i din konfigurasjonsfil."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Du kan ikke ha både ""key""- og ""pkcs12""-parametetre i din konfigurasjonsfil."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Du kan ikke ha mer enn ett ""pkcs12""-parameter i din konfigurasjonsfil."
@@ -457,7 +457,7 @@ Kjør openvpn-gui --help for hjelp."
     IDS_ERR_SOCKS_PROXY_ADDRESS "SOCKS proxy addresse må oppgis."
     IDS_ERR_SOCKS_PROXY_PORT "SOCKS proxy port må oppgis."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "SOCKS proxy port må være ett tall mellom 1 og 65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "En feil oppsto ved opprettelse av registernøkkelen ""HKEY_CURRENT_USER\\%s"""
+    IDS_ERR_CREATE_REG_HKCU_KEY "En feil oppsto ved opprettelse av registernøkkelen ""HKEY_CURRENT_USER\\%ls"""
     IDS_ERR_GET_TEMP_PATH "En feil oppsto da programmet forsøkte å finne stien til mappe for midlertidige filer (%TEMP%). ""C:\\"" vil bli brukt istedet."
 
     /* service */
@@ -489,24 +489,24 @@ Wintun driver will not work."
     IDS_ERR_PRECONN_SCRIPT_TIMEOUT "Registerverdien ""preconnectscript_timeout"" må være et tall mellom 1 og 99."
     IDS_ERR_CREATE_REG_KEY "En feil oppsto under opprettelse av registernøkkelen 'HKLM\\SOFTWARE\\OpenVPN-GUI'."
     IDS_ERR_OPEN_WRITE_REG "Kunne ikke oppdatere registeret. Du må starte programmet med administrator-rettigheter for å kunne gjøre endringer i registeret."
-    IDS_ERR_READ_SET_KEY "Kunne ikke lese eller skrive til registernøkkelen ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Feil ved oppdatering av registerverdien ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Kunne ikke lese eller skrive til registernøkkelen ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Feil ved oppdatering av registerverdien ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "En konfigurasjon med navnet ""%s"" eksisterer allerede."
+    IDS_ERR_IMPORT_EXISTS "En konfigurasjon med navnet ""%ls"" eksisterer allerede."
     IDS_ERR_IMPORT_FAILED "En feil oppsto under importeringen. Kunne ikke opprette filstien:\n\n\
-%s\n\nDet kan hende du trenger administrator-rettigheter for å importere filer."
+%ls\n\nDet kan hende du trenger administrator-rettigheter for å importere filer."
     IDS_NFO_IMPORT_SUCCESS "Importeringen var vellykket."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Klikk OK for å slette lagrede passord for konfigurasjonen ""%s""."
+    IDS_NFO_DELETE_PASS "Klikk OK for å slette lagrede passord for konfigurasjonen ""%ls""."
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
@@ -514,6 +514,6 @@ Wintun driver will not work."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -221,7 +221,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - Windows GUI dla OpenVPN-a\n\
+    LTEXT "OpenVPN GUI v%ls - Windows GUI dla OpenVPN-a\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -277,7 +277,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nPołączony z: "
     IDS_TIP_CONNECTING "\nŁączenie z: "
     IDS_TIP_CONNECTED_SINCE "\nPołączony od: "
-    IDS_TIP_ASSIGNED_IP "\nPrzyznany IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nPrzyznany IP: %ls"
     IDS_MENU_SERVICE "Usługa OpenVPN"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -302,28 +302,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Czy chcesz się rozłączyć (zatrzymać usługę OpenVPN)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Błąd podczas uruchamiania przeglądarki dziennika: %s"
-    IDS_ERR_START_CONF_EDITOR "Błąd podczas uruchamiania edytora konfiguracji: %s"
+    IDS_ERR_START_LOG_VIEWER "Błąd podczas uruchamiania przeglądarki dziennika: %ls"
+    IDS_ERR_START_CONF_EDITOR "Błąd podczas uruchamiania edytora konfiguracji: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI nie obsługuje więcej niż %d plików konfiguracyjnych. Proszę skontaktować się z autorem w przypadku takiej potrzeby."
     IDS_NFO_NO_CONFIGS "Brak profili połączeń (plików konfiguracyjnych) możliwych do użycia.\n\
-Użyj opcji ""Importuj plik…"" z menu lub skopiuj plik konfiguracyjny do ""%s"" lub ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Uruchomienie tego połączenia (%s) wymaga przynależności do \
-grupy ""%s"". Skontaktuj się z administratorem.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Uruchomienie tego połączenia (%s) wymaga przynależności do \
-grupy ""%s"".\n\n\
+Użyj opcji ""Importuj plik…"" z menu lub skopiuj plik konfiguracyjny do ""%ls"" lub ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Uruchomienie tego połączenia (%ls) wymaga przynależności do \
+grupy ""%ls"". Skontaktuj się z administratorem.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Uruchomienie tego połączenia (%ls) wymaga przynależności do \
+grupy ""%ls"".\n\n\
 Czy chcesz dodać siebie do tej grupy?\n\
 Ta czynność może wymagać hasła administratora lub jego zgody."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Uruchomienie tego połączenia (%s) wymaga przynależności do \
-grupy ""%s"".\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Uruchomienie tego połączenia (%ls) wymaga przynależności do \
+grupy ""%ls"".\n\n\
 Proszę uzupełnić poprzednie okno autoryzacji."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Dodawanie użytkownika do grupy ""%s"" zakończone niepowodzeniem."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Dodawanie użytkownika do grupy ""%ls"" zakończone niepowodzeniem."
     IDS_ERR_ONE_CONN_OLD_VER "Możesz mieć jednocześnie tylko jedno aktywne połączenie kiedy używasz OpenVPN-a w wersji starszej niż 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Nie możesz nawiązać połączenia za pomocą OpenVPN GUI gdy uruchomiona jest usługa OpenVPN (dla OpenVPN-a 1.5/1.6). Zatrzymaj usługę OpenVPN jeśli chcesz użyć OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "Błąd podczas tworzenia zdarzenia wyjścia: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Nieznana nazwa priorytetu: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Flaga dopisywania zdarzeń do pliku dziennika (podana jako '%s') musi mieć postać '0' lub '1'"
+    IDS_ERR_CREATE_EVENT "Błąd podczas tworzenia zdarzenia wyjścia: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Nieznana nazwa priorytetu: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Flaga dopisywania zdarzeń do pliku dziennika (podana jako '%ls') musi mieć postać '0' lub '1'"
     IDS_ERR_GET_MSIE_PROXY "Błąd podczas pobierania ustawień systemowych proxy."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor zakończone niepowodzeniem."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl zakończone niepowodzeniem."
@@ -331,41 +331,41 @@ Proszę uzupełnić poprzednie okno autoryzacji."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe dla hInputRead zakończone niepowodzeniem."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle dla hOutputRead zakończone niepowodzeniem."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle dla hInputWrite zakończone niepowodzeniem."
-    IDS_ERR_CREATE_PROCESS "Utworzenie procesu zakończone niepowodzeniem, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "Utworzenie procesu zakończone niepowodzeniem, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "Utworzenie wątku dla okna statusu zakończone niepowodzeniem."
     IDS_NFO_STATE_WAIT_TERM "Stan obecny: Oczekiwanie na zakończenie OpenVPN-a…"
     IDS_NFO_STATE_CONNECTED "Stan obecny: Połączony"
-    IDS_NFO_NOW_CONNECTED "%s jest teraz połączony."
-    IDS_NFO_ASSIGN_IP "Przyznany IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls jest teraz połączony."
+    IDS_NFO_ASSIGN_IP "Przyznany IP: %ls"
     IDS_ERR_CERT_EXPIRED "Połączenie nie jest możliwe z powodu wygaśnięcia certyfikatu lub błędnie ustawionego czasu systemowego."
     IDS_ERR_CERT_NOT_YET_VALID "Połączenie nie jest możliwe ponieważ certyfikat jest jeszcze nieważny. Sprawdź poprawność ustawienia czasu systemowego."
     IDS_NFO_STATE_RECONNECTING "Stan obecny: Ponowne łączenie"
     IDS_NFO_STATE_DISCONNECTED "Stan obecny: Rozłączony"
-    IDS_NFO_CONN_TERMINATED "Połączenie z %s zostało zakończone."
+    IDS_NFO_CONN_TERMINATED "Połączenie z %ls zostało zakończone."
     IDS_NFO_STATE_FAILED "Stan obecny: Połączenie nie powiodło się"
-    IDS_NFO_CONN_FAILED "Połączenie z %s nie powiodło się."
+    IDS_NFO_CONN_FAILED "Połączenie z %ls nie powiodło się."
     IDS_NFO_STATE_FAILED_RECONN "Stan obecny: Ponowne połączenie nie powiodło się"
-    IDS_NFO_RECONN_FAILED "Ponowne połączenie z %s nie powiodło się."
+    IDS_NFO_RECONN_FAILED "Ponowne połączenie z %ls nie powiodło się."
     IDS_NFO_STATE_SUSPENDED "Stan obecny: Zawieszone"
     IDS_ERR_READ_STDOUT_PIPE "Błąd podczas czytania z OpenVPN StdOut Pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Błąd podczas tworzenia okna dziennika!!"
     IDS_ERR_SET_SIZE "Ustawienie rozmiaru nie powiodło się!"
-    IDS_ERR_AUTOSTART_CONF "Brak pliku konfiguracyjnego dla żądanego połączenia automatycznego: %s"
+    IDS_ERR_AUTOSTART_CONF "Brak pliku konfiguracyjnego dla żądanego połączenia automatycznego: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe dla hInputRead zakończone niepowodzeniem."
     IDS_NFO_STATE_CONNECTING "Stan obecny: Łączenie"
-    IDS_NFO_CONNECTION_XXX "Połączenie OpenVPN (%s)"
+    IDS_NFO_CONNECTION_XXX "Połączenie OpenVPN (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Stan obecny: Uruchomiono skrypt połączenia"
     IDS_NFO_STATE_DISCONN_SCRIPT "Stan obecny: Uruchomiono skrypt rozłączenia"
-    IDS_ERR_RUN_CONN_SCRIPT "Błąd podczas wykonywania skryptu połączenia: %s"
-    IDS_ERR_GET_EXIT_CODE "Błąd podczas pobierania kodu wyjścia skryptu połączenia (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Błąd podczas wykonywania skryptu połączenia: %ls"
+    IDS_ERR_GET_EXIT_CODE "Błąd podczas pobierania kodu wyjścia skryptu połączenia (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Błąd skryptu połączenia. (kod wyjścia=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Błąd skryptu połączenia. Brak odpowiedzi przez %d sek."
-    IDS_ERR_CONFIG_EXIST "Plik konfiguracyjny o nazwie '%s' już istnieje. Nie można \
+    IDS_ERR_CONFIG_EXIST "Plik konfiguracyjny o nazwie '%ls' już istnieje. Nie można \
 mieć kilku plików konfiguracyjnych o tej samej nazwie, nawet jeśli \
 umieszczone są w innych katalogach."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Błąd otwarcia pliku debugowania (%s)."
-    IDS_ERR_CREATE_PATH "Błąd utworzenia ścieżki %s :\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Błąd otwarcia pliku debugowania (%ls)."
+    IDS_ERR_CREATE_PATH "Błąd utworzenia ścieżki %ls :\n%ls"
     IDS_ERR_LOAD_RICHED20 "Błąd ładowania biblioteki RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Twoja wersja biblioteki shell32.dll jest za stara (0x%lx). Wymagana co najmniej wersja 5.0."
     IDS_NFO_SERVICE_STARTED "Usługa OpenVPN uruchomiona."
@@ -421,26 +421,26 @@ Opcje oddalające ustawienia rejestru:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI składnia"
-    IDS_ERR_BAD_PARAMETER "Próbuję traktować ""%s"" jako opcję \
+    IDS_ERR_BAD_PARAMETER "Próbuję traktować ""%ls"" jako opcję \
 ale brak poprzedzającego '--'"
-    IDS_ERR_BAD_OPTION "Błąd składni: Nieznana opcja lub brak parametru(ów): --%s\n\
+    IDS_ERR_BAD_OPTION "Błąd składni: Nieznana opcja lub brak parametru(ów): --%ls\n\
 Użyj openvpn-gui --help aby uzyskać więcej informacji."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "Utworzenie wątku w celu wyświetlenia okna dialogowego zmiany hasła nie powiodło się."
-    IDS_NFO_CHANGE_PWD "Zmiana hasła (%s)"
+    IDS_NFO_CHANGE_PWD "Zmiana hasła (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Podane hasła nie pasują. Spróbuj ponownie."
     IDS_ERR_PWD_TO_SHORT "Hasło musi składać się przynajmniej z %d znaków."
     IDS_NFO_EMPTY_PWD "Czy na pewno ustawić puste hasło?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Nieznany format pliku klucza."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Błąd podczas otwierania pliku klucza prywatnego (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Błąd podczas otwierania pliku klucza prywatnego (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Stare hasło jest niepoprawne."
-    IDS_ERR_OPEN_WRITE_KEY "Błąd podczas otwierania pliku klucza prywatnego w trybie do zapisu (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Błąd podczas zapisu nowego pliku klucza prywatnego (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Błąd podczas otwierania pliku klucza prywatnego w trybie do zapisu (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Błąd podczas zapisu nowego pliku klucza prywatnego (%ls)."
     IDS_NFO_PWD_CHANGED "Twoje hasło zostało zmienione."
-    IDS_ERR_READ_PKCS12 "Błąd odczytu pliku PKCS #12(%s)."
+    IDS_ERR_READ_PKCS12 "Błąd odczytu pliku PKCS #12(%ls)."
     IDS_ERR_CREATE_PKCS12 "Błąd podczas tworzenia nowego obiektu PKCS #12. Zmiana hasła nie powiodła się."
-    IDS_ERR_OPEN_CONFIG "Nie można odczytać pliku konfiguracyjnego: (%s)"
+    IDS_ERR_OPEN_CONFIG "Nie można odczytać pliku konfiguracyjnego: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "Opcja ""key"" w pliku konfiguracyjnym może być zdefiniowana najwyżej jeden raz."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Opcje ""key"" i ""pkcs12"" nie mogą być zdefiniowane jednocześnie."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Opcja ""pkcs12"" może być zdefiniowana najwyżej jeden raz."
@@ -463,7 +463,7 @@ Proszę podać inne hasło."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Musisz zdefiniować adres serwera proxy protokołu SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT "Musisz zdefiniować port dla usługi proxy protokołu SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Port dla usługi proxy protokołu SOCKS musi zawierać się w przedziale 1-65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "Błąd podczas tworzenia klucza rejestru ""HKEY_CURRENT_USER\\%s""."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Błąd podczas tworzenia klucza rejestru ""HKEY_CURRENT_USER\\%ls""."
     IDS_ERR_GET_TEMP_PATH "Błąd przy ustalaniu katalogu tymczasowego przy pomocy funkcji GetTempPath(). Użyty zostanie katalog ""C:\\""."
 
     /* service */
@@ -497,24 +497,24 @@ Prawdopodobnie OpenVPN nie jest zainstalowany."
     IDS_ERR_CREATE_REG_KEY "Błąd podczas tworzenia klucza rejestru HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Błąd podczas otwierania rejestru w trybie do zapisu. Musisz chociaż raz uruchomić program \
 z prawami administratora aby uaktualnić rejestr."
-    IDS_ERR_READ_SET_KEY "Błąd odczytu/zmiany klucza rejestru ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Błąd zapisu rejestru ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Błąd odczytu/zmiany klucza rejestru ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Błąd zapisu rejestru ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Konfiguracja o nazwie ""%s"" już istnieje."
+    IDS_ERR_IMPORT_EXISTS "Konfiguracja o nazwie ""%ls"" już istnieje."
     IDS_ERR_IMPORT_FAILED "Nie udało się zaimportować pliku. Nie można utworzyć następującej ścieżki.\n\n\
-%s\n\nUpewnij się, że posiadasz właściwe uprawnienia."
+%ls\n\nUpewnij się, że posiadasz właściwe uprawnienia."
     IDS_NFO_IMPORT_SUCCESS "Plik został zaimportowany."
-    IDS_NFO_IMPORT_OVERWRITE "Konfiguracja o nazwie ""%s"" już istnieje. Czy chcesz ją zamienić?"
-    IDS_ERR_IMPORT_SOURCE "Nie można zaimportować pliku <%s> ponieważistnieje on już w globalnym lub lokalnym katalogu konfiguracji"
+    IDS_NFO_IMPORT_OVERWRITE "Konfiguracja o nazwie ""%ls"" już istnieje. Czy chcesz ją zamienić?"
+    IDS_ERR_IMPORT_SOURCE "Nie można zaimportować pliku <%ls> ponieważistnieje on już w globalnym lub lokalnym katalogu konfiguracji"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Naciśnij OK aby usunąć zapisane hasła dla konfiguracji ""%s"""
+    IDS_NFO_DELETE_PASS "Naciśnij OK aby usunąć zapisane hasła dla konfiguracji ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Hasło tokena"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Wprowadź hasło/PIN dla tokena '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Wprowadź hasło/PIN dla tokena '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Nieprawidłowe dane uwierzytelniające. Spróbuj ponownie…"
     IDS_NFO_KEY_PASS_RETRY  "Nieprawidłowe hasło. Spróbuj ponownie…"
@@ -522,7 +522,7 @@ z prawami administratora aby uaktualnić rejestr."
     IDS_ERR_INVALID_USERNAME_INPUT "Nieprawidłowy znak w nazwie użytkownika"
     IDS_NFO_AUTO_CONNECT    "Automatycznie połączenie za %u sek…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI jest już uruchomiony. Kliknij prawym przyciskiem myszy na ikonę w pasku zadań aby rozpocząć."
-    IDS_NFO_BYTECOUNT "Bajtów pobranych: %s  wysłanych: %s"
+    IDS_NFO_BYTECOUNT "Bajtów pobranych: %ls  wysłanych: %ls"
 
 END
 

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -219,7 +219,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_PORTUGUESE, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - Interface Windows para o OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - Interface Windows para o OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 Colaboradores do OpenVPN GUI\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -275,7 +275,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nConectado a: "
     IDS_TIP_CONNECTING "\nConectando a: "
     IDS_TIP_CONNECTED_SINCE "\nConectado desde: "
-    IDS_TIP_ASSIGNED_IP "\nIP atribuído: %s"
+    IDS_TIP_ASSIGNED_IP "\nIP atribuído: %ls"
     IDS_MENU_SERVICE "Serviço OpenVPN"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -300,28 +300,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Você deseja desconectar (Parar o serviço OpenVPN)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Erro iniciando o visualizador de log: %s"
-    IDS_ERR_START_CONF_EDITOR "Erro iniciando o editor de configuração: %s"
+    IDS_ERR_START_LOG_VIEWER "Erro iniciando o visualizador de log: %ls"
+    IDS_ERR_START_CONF_EDITOR "Erro iniciando o editor de configuração: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI não suporta mais do que %d configurações. Contate o autor se você necessita de mais."
     IDS_NFO_NO_CONFIGS "Nenhum perfil de conexão (arquivo de configuração) foi localizado.\n\
-Use o menu ""Importar Arquivo.."" ou copie os seus arquivos de configuração para ""%s"" ou ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Para iniciar esta conexão (%s), é necessário ser membro no \
-grupo ""%s"". Contate o administrador do sistema.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Para iniciar esta conexão (%s), é necessário ser membro no \
-grupo ""%s"".\n\n\
+Use o menu ""Importar Arquivo.."" ou copie os seus arquivos de configuração para ""%ls"" ou ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Para iniciar esta conexão (%ls), é necessário ser membro no \
+grupo ""%ls"". Contate o administrador do sistema.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Para iniciar esta conexão (%ls), é necessário ser membro no \
+grupo ""%ls"".\n\n\
 Você deseja se adicionar a este grupo?\n\
 Esta ação pode solicitar a senha do administrador ou consentimento."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Para iniciar esta conexão (%s), é necessário ser membro no \
-grupo ""%s"".\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Para iniciar esta conexão (%ls), é necessário ser membro no \
+grupo ""%ls"".\n\n\
 Por favor, complete o diálogo de autorização anterior."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Falha ao adicionar o usuário ao grupo ""%s""."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Falha ao adicionar o usuário ao grupo ""%ls""."
     IDS_ERR_ONE_CONN_OLD_VER "Você pode ter apenas uma conexão ativa enquanto estiver usando uma versão anterior a OpenVPN 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Você não pode usar o OpenVPN GUI para iniciar uma conexão enquanto o serviço OpenVPN estiver em execução (com OpenVPN 1.5/1.6). Pare o serviço OpenVPN primeiro se você quiser utilizar o OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "CreateEvent falhou no evento de saída: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Nome de prioridade desconhecida: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Parâmetro ""adicionar ao arquivo de log"" (informado como '%s') deve ser '0' ou '1'"
+    IDS_ERR_CREATE_EVENT "CreateEvent falhou no evento de saída: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Nome de prioridade desconhecida: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Parâmetro ""adicionar ao arquivo de log"" (informado como '%ls') deve ser '0' ou '1'"
     IDS_ERR_GET_MSIE_PROXY "Impossível carregar configurações de proxy do MSIE."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor falhou."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl falhou."
@@ -329,43 +329,43 @@ Por favor, complete o diálogo de autorização anterior."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe em hInputRead falhou."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle em hOutputRead falhou."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle em hInputWrite falhou."
-    IDS_ERR_CREATE_PROCESS "CreateProcess falhou, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess falhou, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread falhou ao mostrar janela de status."
     IDS_NFO_STATE_WAIT_TERM "Estado atual: Aguardando OpenVPN terminar…"
     IDS_NFO_STATE_CONNECTED "Estado atual: Conectado"
-    IDS_NFO_NOW_CONNECTED "%s está conectado."
-    IDS_NFO_ASSIGN_IP "IP atribuído: %s"
+    IDS_NFO_NOW_CONNECTED "%ls está conectado."
+    IDS_NFO_ASSIGN_IP "IP atribuído: %ls"
     IDS_ERR_CERT_EXPIRED "Impossível conectar porque seu certificado expirou ou a data do sistema está incorreta."
     IDS_ERR_CERT_NOT_YET_VALID "Impossível conectar porque seu certificado não é mais válido. Verifique a data/hora de seu sistema."
     IDS_NFO_STATE_RECONNECTING "Estado atual: Reconectando"
     IDS_NFO_STATE_DISCONNECTED "Estado atual: Desconectado"
-    IDS_NFO_CONN_TERMINATED "Conexão para %s foi terminada."
+    IDS_NFO_CONN_TERMINATED "Conexão para %ls foi terminada."
     IDS_NFO_STATE_FAILED "Estado atual: Falha ao conectar"
-    IDS_NFO_CONN_FAILED "Conectando a %s falhou."
+    IDS_NFO_CONN_FAILED "Conectando a %ls falhou."
     IDS_NFO_STATE_FAILED_RECONN "Estado atual: Falha ao reconectar"
-    IDS_NFO_RECONN_FAILED "Reconexão a %s falhou."
+    IDS_NFO_RECONN_FAILED "Reconexão a %ls falhou."
     IDS_NFO_STATE_SUSPENDED "Estado atual: Suspenso"
     IDS_ERR_READ_STDOUT_PIPE "Erro lendo o pipe de stdout do OpenVPN."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Creating RichEdit LogWindow falhou!!"
     IDS_ERR_SET_SIZE "Set Size falhou!"
-    IDS_ERR_AUTOSTART_CONF "Impossível encontrar configurações para início automático: %s"
+    IDS_ERR_AUTOSTART_CONF "Impossível encontrar configurações para início automático: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe em hInputRead falhou."
     IDS_NFO_STATE_CONNECTING "Estado atual: Conectando"
-    IDS_NFO_CONNECTION_XXX "Conexão OpenVPN (%s)"
+    IDS_NFO_CONNECTION_XXX "Conexão OpenVPN (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Estado atual: Executando script de conexão"
     IDS_NFO_STATE_DISCONN_SCRIPT "Estado atual: Executando script de desconexão"
-    IDS_ERR_RUN_CONN_SCRIPT "Erro ao executar o script de conexão: %s"
-    IDS_ERR_GET_EXIT_CODE "Falha ao obter o código de saída do script de conexão (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Erro ao executar o script de conexão: %ls"
+    IDS_ERR_GET_EXIT_CODE "Falha ao obter o código de saída do script de conexão (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Script de conexão falhou. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Script de conexão falhou. Tempo limite depois de %d seg."
-    IDS_ERR_CONFIG_EXIST "O arquivo de configuração '%s' já existe. Você não pode \
+    IDS_ERR_CONFIG_EXIST "O arquivo de configuração '%ls' já existe. Você não pode \
 ter vários arquivos de configuração com o mesmo nome, mesmo que \
 em pastas diferentes."
     IDS_NFO_CONN_TIMEOUT "A conexão com a interface de gerenciamento falhou.\n\
-Consulte o arquivo de log (%s) para mais detalhes."
+Consulte o arquivo de log (%ls) para mais detalhes."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Erro ao abrir arquivo de depuração (%s) para saída."
-    IDS_ERR_CREATE_PATH "Não foi possível criar o caminho %s:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Erro ao abrir arquivo de depuração (%ls) para saída."
+    IDS_ERR_CREATE_PATH "Não foi possível criar o caminho %ls:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Erro ao carregar RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Sua versão do shell32.dll é antiga (0x%lx). Você precisa de no mínimo da versão 5.0."
     IDS_NFO_SERVICE_STARTED "Serviço OpenVPN iniciado."
@@ -421,26 +421,26 @@ Opções para sobrescrever opções do registro:\n\
 
 
     IDS_NFO_USAGECAPTION "Uso do OpenVPN GUI"
-    IDS_ERR_BAD_PARAMETER "Tentando analisar ""%s"" como um parâmetro --option \
+    IDS_ERR_BAD_PARAMETER "Tentando analisar ""%ls"" como um parâmetro --option \
 mas não foi encontrado '--' antes do parâmetro"
-    IDS_ERR_BAD_OPTION "Erro: Parâmetro desconhecido ou parâmetro(s) faltando: --%s\n\
+    IDS_ERR_BAD_OPTION "Erro: Parâmetro desconhecido ou parâmetro(s) faltando: --%ls\n\
 Use openvpn-gui --help para maiores informações."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread para mostrar ChangePassphrase dialog falhou."
-    IDS_NFO_CHANGE_PWD "Alterar senha (%s)"
+    IDS_NFO_CHANGE_PWD "Alterar senha (%ls)"
     IDS_ERR_PWD_DONT_MATCH "As senhas digitadas não conferem. Tente novamente."
     IDS_ERR_PWD_TO_SHORT "A nova senha deve ter no mínimo %d caracteres."
     IDS_NFO_EMPTY_PWD "Você tem certeza de que deseja deixar a senha em branco?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Formato do keyfile inválido."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Erro abrindo arquivo private key (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Erro abrindo arquivo private key (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "A senha antiga está incorreta."
-    IDS_ERR_OPEN_WRITE_KEY "Erro abrindo arquivo private key para gravação (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Erro gravando novo arquivo private key (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Erro abrindo arquivo private key para gravação (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Erro gravando novo arquivo private key (%ls)."
     IDS_NFO_PWD_CHANGED "Sua senha foi alterada."
-    IDS_ERR_READ_PKCS12 "Erro lendo arquivo PKCS #12 (%s)."
+    IDS_ERR_READ_PKCS12 "Erro lendo arquivo PKCS #12 (%ls)."
     IDS_ERR_CREATE_PKCS12 "Erro criando novo objeto PKCS #12. Troca da senha falhou."
-    IDS_ERR_OPEN_CONFIG "Impossível abrir arquivo de configuração para leitura: (%s)"
+    IDS_ERR_OPEN_CONFIG "Impossível abrir arquivo de configuração para leitura: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "Você não pode ter mais do que uma opção ""key"" na sua configuração."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Você não pode ter as duas opções ""key"" e ""pkcs12"" na sua configuração."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Você não pode ter mais do que uma opção ""pkcs12"" na sua configuração."
@@ -463,7 +463,7 @@ Por favor, escolha outra."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Você precisa especificar o endereço de proxy SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT "Você precisa especificar a porta para proxy SOCKS."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Você precisa especificar uma porta entre 1-65535 para o proxy SOCKS"
-    IDS_ERR_CREATE_REG_HKCU_KEY "Erro criando chave ""HKEY_CURRENT_USER\\%s""."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Erro criando chave ""HKEY_CURRENT_USER\\%ls""."
     IDS_ERR_GET_TEMP_PATH "Erro ao determinar TempPath com GetTempPath(). Usando ""C:\\"" no lugar."
 
     /* service */
@@ -497,24 +497,24 @@ OpenVPN provavelmente não está instalado"
     IDS_ERR_CREATE_REG_KEY "Erro criando chave HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Erro ao abrir o registro para gravação. Você deve executar esta aplicação \
 uma vez como Administrador para alterar o registro."
-    IDS_ERR_READ_SET_KEY "Erro ao ler e ajustar chave de registro ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Erro ao gravar valor da chave de registro ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Erro ao ler e ajustar chave de registro ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Erro ao gravar valor da chave de registro ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Já existe uma configuração com o nome ""%s""."
+    IDS_ERR_IMPORT_EXISTS "Já existe uma configuração com o nome ""%ls""."
     IDS_ERR_IMPORT_FAILED "Falha ao importar o arquivo. O seguinte caminho não pôde ser criado.\n\n\
-%s\n\nCertifique-se de que você possui as permissões necessárias."
+%ls\n\nCertifique-se de que você possui as permissões necessárias."
     IDS_NFO_IMPORT_SUCCESS "Arquivo importado com sucesso."
-    IDS_NFO_IMPORT_OVERWRITE "Uma configuração nomeada ""%s"" já existe. Você deseja substituí-la?"
-    IDS_ERR_IMPORT_SOURCE "Não é possível importar o arquivo <%s>, pois ele já está na pasta de configurações global ou local"
+    IDS_NFO_IMPORT_OVERWRITE "Uma configuração nomeada ""%ls"" já existe. Você deseja substituí-la?"
+    IDS_ERR_IMPORT_SOURCE "Não é possível importar o arquivo <%ls>, pois ele já está na pasta de configurações global ou local"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Pressione OK para excluir as senhas salvas para a configuração ""%s"""
+    IDS_NFO_DELETE_PASS "Pressione OK para excluir as senhas salvas para a configuração ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Senha de Token"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Entre a Senha/PIN para o Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Entre a Senha/PIN para o Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Credenciais incorretas. Tente novamente…"
     IDS_NFO_KEY_PASS_RETRY  "Senha incorreta. Tente novamente…"
@@ -522,6 +522,6 @@ uma vez como Administrador para alterar o registro."
     IDS_ERR_INVALID_USERNAME_INPUT "Caractere inválido no nome de usuário"
     IDS_NFO_AUTO_CONNECT    "Conectando automaticamente em %u segundos…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI já está em execução. Clique direito no ícone da área de notificação para iniciar."
-    IDS_NFO_BYTECOUNT "Bytes recebidos: %s  enviados: %s"
+    IDS_NFO_BYTECOUNT "Bytes recebidos: %ls  enviados: %ls"
 
 END

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -222,7 +222,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - графический интерфейс OpenVPN для Windows\n\
+    LTEXT "OpenVPN GUI v%ls - графический интерфейс OpenVPN для Windows\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -278,7 +278,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nПодключен к: "
     IDS_TIP_CONNECTING "\nПодключение к: "
     IDS_TIP_CONNECTED_SINCE "\nПодключен с: "
-    IDS_TIP_ASSIGNED_IP "\nНазначенный IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nНазначенный IP: %ls"
     IDS_MENU_SERVICE "Служба OpenVPN"
     IDS_MENU_IMPORT "Импорт"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -303,28 +303,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Вы хотите отключиться (остановить службу OpenVPN)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Ошибка запуска просмотрщика журнала: %s"
-    IDS_ERR_START_CONF_EDITOR "Ошибка запуска редактора конфигурации: %s"
+    IDS_ERR_START_LOG_VIEWER "Ошибка запуска просмотрщика журнала: %ls"
+    IDS_ERR_START_CONF_EDITOR "Ошибка запуска редактора конфигурации: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI не поддерживает более %d конфигураций. Пожалуйста, свяжитесь с автором, если вам нужно больше."
     IDS_NFO_NO_CONFIGS "Файлы конфигурации не найдены.\n\
-Воспользуйтесь пунктом «Импорт конфигурации…» или скопируйте файлы в ""%s"" или ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Для запуска данного подключения (%s) требуется членство в группе\n\
-""%s"". Свяжитесь с вашим системным администратором.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Для запуска данного подключения (%s) требуется членство в группе\n\
-""%s"".\n\n\
+Воспользуйтесь пунктом «Импорт конфигурации…» или скопируйте файлы в ""%ls"" или ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Для запуска данного подключения (%ls) требуется членство в группе\n\
+""%ls"". Свяжитесь с вашим системным администратором.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Для запуска данного подключения (%ls) требуется членство в группе\n\
+""%ls"".\n\n\
 Хотите добавить вашу учетную запись в эту группу?\n\
 Данное действие может потребовать ввод пароля администратора."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Для запуска данного подключения (%s) требуется членство в группе\n\
-""%s"".\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Для запуска данного подключения (%ls) требуется членство в группе\n\
+""%ls"".\n\n\
 Пожалуйста, сначала закройте предыдущий диалог авторизации."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Ошибка добавления учетной записи в группу ""%s""."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Ошибка добавления учетной записи в группу ""%ls""."
     IDS_ERR_ONE_CONN_OLD_VER "Одновременно вы можете использовать только одно соединение, если вы используете OpenVPN версии старее 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Вы не можете использовать OpenVPN GUI для запуска подключения, пока запущена служба OpenVPN (с OpenVPN 1.5/1.6). Сначала остановите службу OpenVPN, если хотите использовать OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "Ошибка выполнения CreateEvent при выходе: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Неизвестное название приоритета: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Флаг добавления к файлу журнала (данный как'%s') должен быть '0' или '1'"
+    IDS_ERR_CREATE_EVENT "Ошибка выполнения CreateEvent при выходе: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Неизвестное название приоритета: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Флаг добавления к файлу журнала (данный как'%ls') должен быть '0' или '1'"
     IDS_ERR_GET_MSIE_PROXY "Не удалось получить настройки прокси Internet Explorer."
     IDS_ERR_INIT_SEC_DESC "Ошибка выполнения InitializeSecurityDescriptor."
     IDS_ERR_SET_SEC_DESC_ACL "Ошибка выполнения SetSecurityDescriptorDacl."
@@ -332,41 +332,41 @@ BEGIN
     IDS_ERR_CREATE_PIPE_INPUT "Ошибка выполнения CreatePipe при hInputRead."
     IDS_ERR_DUP_HANDLE_OUT_READ "Ошибка выполнения DuplicateHandle при hOutputRead."
     IDS_ERR_DUP_HANDLE_IN_WRITE "Ошибка выполнения DuplicateHandle при hInputWrite."
-    IDS_ERR_CREATE_PROCESS "Ошибка выполнения CreateProcess, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "Ошибка выполнения CreateProcess, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "Ошибка выполнения CreateThread при отображении окна состояния."
     IDS_NFO_STATE_WAIT_TERM "Текущее состояние: ожидание завершения работы OpenVPN…"
     IDS_NFO_STATE_CONNECTED "Текущее состояние: подключено"
-    IDS_NFO_NOW_CONNECTED "%s сейчас подключено."
-    IDS_NFO_ASSIGN_IP "Назначенный IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls сейчас подключено."
+    IDS_NFO_ASSIGN_IP "Назначенный IP: %ls"
     IDS_ERR_CERT_EXPIRED "Невозможно подключиться, так как срок действия вашего сертификата истёк или системное время некорректно."
     IDS_ERR_CERT_NOT_YET_VALID "Невозможно подключиться, так как ваш сертификат ещё не действителен. Проверьте правильность установки системного времени."
     IDS_NFO_STATE_RECONNECTING "Текущее состояние: переподключение"
     IDS_NFO_STATE_DISCONNECTED "Текущее состояние: отключено"
-    IDS_NFO_CONN_TERMINATED "Соединение с %s было прервано."
+    IDS_NFO_CONN_TERMINATED "Соединение с %ls было прервано."
     IDS_NFO_STATE_FAILED "Текущее состояние: ошибка подключения"
-    IDS_NFO_CONN_FAILED "Не удалось подключиться к %s."
+    IDS_NFO_CONN_FAILED "Не удалось подключиться к %ls."
     IDS_NFO_STATE_FAILED_RECONN "Текущее состояние: ошибка переподключения"
-    IDS_NFO_RECONN_FAILED "Не удалось переподключиться к %s."
+    IDS_NFO_RECONN_FAILED "Не удалось переподключиться к %ls."
     IDS_NFO_STATE_SUSPENDED "Текущее состояние: приостановлено"
     IDS_ERR_READ_STDOUT_PIPE "Ошибка чтения из стандартного ввода OpenVPN."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Не удалось создать RichEdit LogWindow!"
     IDS_ERR_SET_SIZE "Не удалось установить размер!"
-    IDS_ERR_AUTOSTART_CONF "Не удалось найти запрошенный файл конфигурации для автозапуска: %s"
+    IDS_ERR_AUTOSTART_CONF "Не удалось найти запрошенный файл конфигурации для автозапуска: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "Не удалось выполнить CreatePipe при hInputRead."
     IDS_NFO_STATE_CONNECTING "Текущее состояние: подключение"
-    IDS_NFO_CONNECTION_XXX "Соединение OpenVPN (%s)"
+    IDS_NFO_CONNECTION_XXX "Соединение OpenVPN (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Текущее состояние: запуск скрипта подключения"
     IDS_NFO_STATE_DISCONN_SCRIPT "Текущее состояние: запуск скрипта отключения"
-    IDS_ERR_RUN_CONN_SCRIPT "Ошибка запуска скрипта подключения: %s"
-    IDS_ERR_GET_EXIT_CODE "Ошибка получения кода выхода (ExitCode) скрипта подключения (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Ошибка запуска скрипта подключения: %ls"
+    IDS_ERR_GET_EXIT_CODE "Ошибка получения кода выхода (ExitCode) скрипта подключения (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Ошибка выполнения скрипта подключения. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Ошибка выполнения скрипта подключения. Истекло время ожидания после %d сек."
-    IDS_ERR_CONFIG_EXIST "Уже существует файл конфигурации с названием '%s'. Вы не можете \
+    IDS_ERR_CONFIG_EXIST "Уже существует файл конфигурации с названием '%ls'. Вы не можете \
 иметь несколько файлов конфигурации с одним именем, даже если \
 они находятся в разных папках."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Ошибка открытия файла отладки (%s) для вывода."
-    IDS_ERR_CREATE_PATH "Невозможно создать %s путь:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Ошибка открытия файла отладки (%ls) для вывода."
+    IDS_ERR_CREATE_PATH "Невозможно создать %ls путь:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Не удалось загрузить RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Ваша версия shell32.dll слишком старая (0x%lx). Вам необходима как минимум версия 5.0."
     IDS_NFO_SERVICE_STARTED "Служба OpenVPN запущена."
@@ -422,26 +422,26 @@ Supported commands:\n\
 
 
     IDS_NFO_USAGECAPTION "Использование OpenVPN GUI"
-    IDS_ERR_BAD_PARAMETER "Не удалось обработать строку ""%s"", которая была интерпретирована как опция вида ""--опция параметр"". \
+    IDS_ERR_BAD_PARAMETER "Не удалось обработать строку ""%ls"", которая была интерпретирована как опция вида ""--опция параметр"". \
 Если это не опция, поставьте '--' перед этой строкой."
-    IDS_ERR_BAD_OPTION "Ошибка опций: нераспознанная опция или отсутствующий параметр(ы): --%s\n\
+    IDS_ERR_BAD_OPTION "Ошибка опций: нераспознанная опция или отсутствующий параметр(ы): --%ls\n\
 Используйте openvpn-gui --help для доп. информации."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "Не удалось выполнить CreateThread для отображения диалога ChangePassphrase."
-    IDS_NFO_CHANGE_PWD "Смена пароля (%s)"
+    IDS_NFO_CHANGE_PWD "Смена пароля (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Введённые вами пароли не совпадают. Попробуйте снова."
     IDS_ERR_PWD_TO_SHORT "Ваш новый пароль должен быть длиной как минимум %d символов."
     IDS_NFO_EMPTY_PWD "Вы уверены, что хотите установить ПУСТОЙ пароль?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Неизвестный формат файла ключа."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Ошибка открытия файла личного ключа (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Ошибка открытия файла личного ключа (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Старый пароль неверен."
-    IDS_ERR_OPEN_WRITE_KEY "Ошибка открытия файла личного ключа для записи (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Ошибка записи файла нового личного ключа (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Ошибка открытия файла личного ключа для записи (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Ошибка записи файла нового личного ключа (%ls)."
     IDS_NFO_PWD_CHANGED "Ваш пароль был изменён."
-    IDS_ERR_READ_PKCS12 "Ошибка чтения файла PKCS #12 (%s)."
+    IDS_ERR_READ_PKCS12 "Ошибка чтения файла PKCS #12 (%ls)."
     IDS_ERR_CREATE_PKCS12 "Ошибка создания нового объекта PKCS #12. Пароль сменить не удалось."
-    IDS_ERR_OPEN_CONFIG "Не удалось открыть файл конфигурации для чтения: (%s)"
+    IDS_ERR_OPEN_CONFIG "Не удалось открыть файл конфигурации для чтения: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "В вашей конфигурации не может быть более одной опции ""key""."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "В вашей конфигурации не могут одновременно находиться опции ""key"" и ""pkcs12""."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "В вашей конфигурации не может быть более одной опции ""pkcs12""."
@@ -464,7 +464,7 @@ Supported commands:\n\
     IDS_ERR_SOCKS_PROXY_ADDRESS "Вы должны указать адрес SOCKS-прокси."
     IDS_ERR_SOCKS_PROXY_PORT "Вы должны указать порт SOCKS-прокси."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Вы должны указать порт SOCKS-прокси в диапазоне 1-65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "Ошибка создания ключа ""HKEY_CURRENT_USER\\%s""."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Ошибка создания ключа ""HKEY_CURRENT_USER\\%ls""."
     IDS_ERR_GET_TEMP_PATH "Ошибка определения TempPath с помощью GetTempPath(). Вместо этого использую ""C:\\""."
 
     /* service */
@@ -498,24 +498,24 @@ OpenVPN, возможно, не установлен."
     IDS_ERR_CREATE_REG_KEY "Ошибка создания ключа HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Не удалось открыть реестр для записи. Вам необходимо запустить это приложение \
 однократно с правами администратора, чтобы обновить реестр."
-    IDS_ERR_READ_SET_KEY "Ошибка чтения и установки значения ключа ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Ошибка записи значения реестра ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Ошибка чтения и установки значения ключа ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Ошибка записи значения реестра ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Файл конфигурации ""%s"" уже существует."
-    IDS_ERR_IMPORT_FAILED "Ошибка импорта файла. Путь %s не может быть создан.\n\n\
+    IDS_ERR_IMPORT_EXISTS "Файл конфигурации ""%ls"" уже существует."
+    IDS_ERR_IMPORT_FAILED "Ошибка импорта файла. Путь %ls не может быть создан.\n\n\
 Убедитесь, что у вас есть необходимые привилегии для данного действия."
     IDS_NFO_IMPORT_SUCCESS "Импорт файла успешно завершен."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Подтвердите удаление сохраненных паролей для ""%s"""
+    IDS_NFO_DELETE_PASS "Подтвердите удаление сохраненных паролей для ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Неправильное имя пользователя или пароль"
     IDS_NFO_KEY_PASS_RETRY  "Неправильный пароль"
@@ -523,6 +523,6 @@ OpenVPN, возможно, не установлен."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Автоматическое подключение через %u сек..."
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -219,7 +219,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_SWEDISH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - Ett Windows GUI för OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - Ett Windows GUI för OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -275,7 +275,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nAnsluten till: "
     IDS_TIP_CONNECTING "\nAnsluter till: "
     IDS_TIP_CONNECTED_SINCE "\nAnsluten sedan: "
-    IDS_TIP_ASSIGNED_IP "\nTilldelad IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nTilldelad IP: %ls"
     IDS_MENU_SERVICE "OpenVPN Service"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -300,28 +300,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Vill du koppla ner? (Stoppa OpenVPN tjänsten)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Fel vid start av logg viewer: %s"
-    IDS_ERR_START_CONF_EDITOR "Fel vid start av konfig editor: %s"
+    IDS_ERR_START_LOG_VIEWER "Fel vid start av logg viewer: %ls"
+    IDS_ERR_START_CONF_EDITOR "Fel vid start av konfig editor: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "Du kan inte ha fler än %d konfig-filer. Kontakta utvecklaren av OpenVPN GUI om du har behov av att hantera fler."
     IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n\
-Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in \
-""%s"" group. Contact your system administrator.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+Use the ""Import File.."" menu or copy your config files to ""%ls"" or ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%ls) requires membership in \
+""%ls"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Do you want to add yourself to this group?\n\
 This action may prompt for administrative password or consent."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Please complete the previous authorization dialog."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%ls"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "Du kan bara ha en uppkoppling igång samtidigt med äldre versioner av OpenVPN än 2.0-beta6."
     IDS_ERR_STOP_SERV_OLD_VER "Du kan inte ansluta med OpenVPN GUI medan OpenVPN Service är igång. (med OpenVPN 1.5/1.6). Stoppa tjänsten först om du vill använda OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "CreateEvent misslyckades med att skapa event: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Okänt prioritets namn: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Log file append flag (given as '%s') must be '0' or '1'"
+    IDS_ERR_CREATE_EVENT "CreateEvent misslyckades med att skapa event: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Okänt prioritets namn: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Log file append flag (given as '%ls') must be '0' or '1'"
     IDS_ERR_GET_MSIE_PROXY "Kunde inte hämta inställning för HTTP Proxy från Internet Explorer."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor misslyckades."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl misslyckades."
@@ -329,41 +329,41 @@ Please complete the previous authorization dialog."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe på hInputRead misslyckades."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle på hOutputRead misslyckades."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle på hInputWrite misslyckades."
-    IDS_ERR_CREATE_PROCESS "CreateProcess misslyckades, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess misslyckades, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread för att visa status fönstret misslyckades."
     IDS_NFO_STATE_WAIT_TERM "Status: Väntar på att OpenVPN skall avslutas…"
     IDS_NFO_STATE_CONNECTED "Status: Ansluten"
-    IDS_NFO_NOW_CONNECTED "%s är nu ansluten."
-    IDS_NFO_ASSIGN_IP "Tilldelad IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls är nu ansluten."
+    IDS_NFO_ASSIGN_IP "Tilldelad IP: %ls"
     IDS_ERR_CERT_EXPIRED "Kunde inte ansluta för att ditt certifikat är för gammalt, eller för att klockan i din dator går fel."
     IDS_ERR_CERT_NOT_YET_VALID "Kunde inte ansluta för att ditt certifikat ännu inte börjat gälla, eller för att klockan i din dator går fel."
     IDS_NFO_STATE_RECONNECTING "Status: ÅterAnsluter"
     IDS_NFO_STATE_DISCONNECTED "Status: Frånkopplad"
-    IDS_NFO_CONN_TERMINATED "Du har kopplats ner från %s."
+    IDS_NFO_CONN_TERMINATED "Du har kopplats ner från %ls."
     IDS_NFO_STATE_FAILED "Status: Anslutningen misslyckades"
-    IDS_NFO_CONN_FAILED "Anslutningen till %s misslyckades."
+    IDS_NFO_CONN_FAILED "Anslutningen till %ls misslyckades."
     IDS_NFO_STATE_FAILED_RECONN "Status: Misslyckades att återansluta"
-    IDS_NFO_RECONN_FAILED "Återanslutning till %s misslyckades."
+    IDS_NFO_RECONN_FAILED "Återanslutning till %ls misslyckades."
     IDS_NFO_STATE_SUSPENDED "Status: Viloläge"
     IDS_ERR_READ_STDOUT_PIPE "Fel vid läsning från OpenVPN StdOut pipe."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Skapande av RichEdit LogWindow misslyckades!!"
     IDS_ERR_SET_SIZE "Set Size misslyckades!"
-    IDS_ERR_AUTOSTART_CONF "Följande konfig gick inte att automatiskt starta: %s"
+    IDS_ERR_AUTOSTART_CONF "Följande konfig gick inte att automatiskt starta: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe på hInputRead misslyckades."
     IDS_NFO_STATE_CONNECTING "Status: Ansluter"
-    IDS_NFO_CONNECTION_XXX "OpenVPN Anslutning (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN Anslutning (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Status: Kör anslutnings-skript"
     IDS_NFO_STATE_DISCONN_SCRIPT "Status: Kör frånkopplings-skript"
-    IDS_ERR_RUN_CONN_SCRIPT "Ett fel uppstod vid körning av följande skript: %s"
-    IDS_ERR_GET_EXIT_CODE "Ett fel uppstod när exitcode från följande skript skulle erhållas: %s"
+    IDS_ERR_RUN_CONN_SCRIPT "Ett fel uppstod vid körning av följande skript: %ls"
+    IDS_ERR_GET_EXIT_CODE "Ett fel uppstod när exitcode från följande skript skulle erhållas: %ls"
     IDS_ERR_CONN_SCRIPT_FAILED "Uppkopplingsskriptet misslyckades. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Uppkopplingsskriptet gjorde TimeOut efter %d sek."
-    IDS_ERR_CONFIG_EXIST "Det finns redan en konfig fil vid namn '%s'. Du kan inte ha flera \
+    IDS_ERR_CONFIG_EXIST "Det finns redan en konfig fil vid namn '%ls'. Du kan inte ha flera \
 konfigurations filer med samma namn, även om de ligger i olika kataloger."
 
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Fel vid öppnande av debug fil. (%s)"
-    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Fel vid öppnande av debug fil. (%ls)"
+    IDS_ERR_CREATE_PATH "Could not create %ls path:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Kunde inte ladda RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Din shell32.dll version är för låg (0x%lx). Du böhöver minst version 5.0."
     IDS_NFO_SERVICE_STARTED "OpenVPN Service startad."
@@ -418,26 +418,26 @@ Parametrar som ersätter inställningar gjorda i registret:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI Användning"
-    IDS_ERR_BAD_PARAMETER "Försöker tolka ""%s"" som en --option parameter \
+    IDS_ERR_BAD_PARAMETER "Försöker tolka ""%ls"" som en --option parameter \
 men kan inte hitta några inledande '--'"
-    IDS_ERR_BAD_OPTION "Parameter fel: Okänd parameter eller saknat argument: --%s\n\
+    IDS_ERR_BAD_OPTION "Parameter fel: Okänd parameter eller saknat argument: --%ls\n\
 Kör openvpn-gui --help för mer hjälp."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread för att visa ChangePassphrase dialogen misslyckades."
-    IDS_NFO_CHANGE_PWD "Ändra Lösenord (%s)"
+    IDS_NFO_CHANGE_PWD "Ändra Lösenord (%ls)"
     IDS_ERR_PWD_DONT_MATCH "De angivna lösenorden matchar inte. Försök igen"
     IDS_ERR_PWD_TO_SHORT "Ditt nya lösenord måste vara minst %d tecken långt."
     IDS_NFO_EMPTY_PWD "Är du säker på att du vill använda ett BLANKT lösenord??"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Okänt format på nyckelfilen."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Ett fel uppstod vid öppnande av nyckel fil (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Ett fel uppstod vid öppnande av nyckel fil (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Du har angivit ett felaktigt nuvarande lösenord."
-    IDS_ERR_OPEN_WRITE_KEY "Ett fel uppstod vid öppnande av nyckel fil för skrivning (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Ett fel uppstod vid skapande av ny nyckel fil (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Ett fel uppstod vid öppnande av nyckel fil för skrivning (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Ett fel uppstod vid skapande av ny nyckel fil (%ls)."
     IDS_NFO_PWD_CHANGED "Ditt lösenord har ändrats."
-    IDS_ERR_READ_PKCS12 "Fel vid läsning från pkcs #12 fil (%s)."
+    IDS_ERR_READ_PKCS12 "Fel vid läsning från pkcs #12 fil (%ls)."
     IDS_ERR_CREATE_PKCS12 "Ett fel uppstod vid skapande av pkcs12 object."
-    IDS_ERR_OPEN_CONFIG "Ett fel uppstod vid öppnande av följande konfigurations fil: %s."
+    IDS_ERR_OPEN_CONFIG "Ett fel uppstod vid öppnande av följande konfigurations fil: %ls."
     IDS_ERR_ONLY_ONE_KEY_OPTION "Du kan inte ha mer än en ""key"" parameter i din konfigurations fil."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Du kan inte ha både ""key"" och ""pkcs12"" parametetrar i din konfigurations fil."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Du kan inte ha mer än en ""pkcs12"" parameter i din konfigurations fil."
@@ -460,7 +460,7 @@ Välj ett nytt."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Du måste ange en SOCKS proxy adress."
     IDS_ERR_SOCKS_PROXY_PORT "Du måste ange en SOCKS proxy port."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Du måste ange en SOCKS proxy port mellan 1-65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "Ett fel uppstod vid skapande av register nyckel ""HKEY_CURRENT_USER\\%s"""
+    IDS_ERR_CREATE_REG_HKCU_KEY "Ett fel uppstod vid skapande av register nyckel ""HKEY_CURRENT_USER\\%ls"""
     IDS_ERR_GET_TEMP_PATH "Ett fel uppstod när GetTempPath() anropades. Använder ""C:\\"" istället."
 
     /* service */
@@ -492,24 +492,24 @@ Wintun driver ska inte fungera."
     IDS_ERR_PRECONN_SCRIPT_TIMEOUT "Register värdet ""preconnectscript_timeout"" måste vara ett tal mellan 1 och 99."
     IDS_ERR_CREATE_REG_KEY "Fel vid skapande av register nyckeln HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Fel vid öppnande av registret för skrivning. Du måste starta programmet en gång som administratör för att uppdatera registret."
-    IDS_ERR_READ_SET_KEY "Fel vid läsning och skrivning av register värde ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Fel vid skrivning av register värdet ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Fel vid läsning och skrivning av register värde ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Fel vid skrivning av register värdet ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n\
-%s\n\nMake sure you have the right permissions."
+%ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
@@ -517,6 +517,6 @@ Wintun driver ska inte fungera."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -221,7 +221,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - OpenVPN için Windows Arayüzü\n\
+    LTEXT "OpenVPN GUI v%ls - OpenVPN için Windows Arayüzü\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -277,7 +277,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nBağlanıldı: "
     IDS_TIP_CONNECTING "\nBağlanılıyor: "
     IDS_TIP_CONNECTED_SINCE "\nBağlanıldı: "
-    IDS_TIP_ASSIGNED_IP "\nBağlanılan IP: %s"
+    IDS_TIP_ASSIGNED_IP "\nBağlanılan IP: %ls"
     IDS_MENU_SERVICE "OpenVPN Servisi"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -302,28 +302,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Bağlantıyı koparmak istediğinize emin misiniz ? (OpenVPN Servisini Durdurur)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Olay görüntüleyici başlarken hata oluştu: %s"
-    IDS_ERR_START_CONF_EDITOR "Ayar editörü başlarken hata oluştu: %s"
+    IDS_ERR_START_LOG_VIEWER "Olay görüntüleyici başlarken hata oluştu: %ls"
+    IDS_ERR_START_CONF_EDITOR "Ayar editörü başlarken hata oluştu: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI %d den fazla konfigürasyonu desteklemiyor. Eğer daha fazlasına ihtiyacınız varsa lütfen hak sahibi ile görüşün."
     IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n\
-Use the ""Import File.."" menu or copy your config files to ""%s"" or ""%s""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%s) requires membership in \
-""%s"" group. Contact your system administrator.\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+Use the ""Import File.."" menu or copy your config files to ""%ls"" or ""%ls""."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%ls) requires membership in \
+""%ls"" group. Contact your system administrator.\n"
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Do you want to add yourself to this group?\n\
 This action may prompt for administrative password or consent."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%s) requires membership in \
-""%s"" group.\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Starting this connection (%ls) requires membership in \
+""%ls"" group.\n\n\
 Please complete the previous authorization dialog."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%s"" group failed."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Adding the user to ""%ls"" group failed."
     IDS_ERR_ONE_CONN_OLD_VER "OpenVPN 2.0-beta6 sürümünden daha eski bir versiyon açıkken, aynı anda sadece bir bağlantı açabilirsiniz!"
     IDS_ERR_STOP_SERV_OLD_VER "OpenVPN servisi çalışırken (OpenVPN ver.1.5/1.6) OpenVPN GUI ile bağlantı yapamazsınız. OpenVPN GUI yi kullanacaksanız, öncelikle OpenVPN servisini durdurmanız gerekmektedir."
-    IDS_ERR_CREATE_EVENT "Çıkılırken hata oluştu: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Bilinmeyen öncelik ismi: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Günlük dosyası ekleme değeri('%s') olarak verilmiş.'0' veya '1' olmalıdır."
+    IDS_ERR_CREATE_EVENT "Çıkılırken hata oluştu: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Bilinmeyen öncelik ismi: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Günlük dosyası ekleme değeri('%ls') olarak verilmiş.'0' veya '1' olmalıdır."
     IDS_ERR_GET_MSIE_PROXY "MSIE (Internet Explorer) proxy ayarlarına erişilemiyor."
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor hatası."
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl hatası."
@@ -331,41 +331,41 @@ Please complete the previous authorization dialog."
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe on hInputRead hatası."
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead hatası."
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite hatası."
-    IDS_ERR_CREATE_PROCESS "CreateProcess hatası, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "CreateProcess hatası, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread anında durum penceresi gösterilemedi hatası."
     IDS_NFO_STATE_WAIT_TERM "Geçerli Durum: OpenVPN' in kapanması bekleniyor…"
     IDS_NFO_STATE_CONNECTED "Geçerli Durum: Bağlandı"
-    IDS_NFO_NOW_CONNECTED "%s şu an bağlı."
-    IDS_NFO_ASSIGN_IP "Atanan IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls şu an bağlı."
+    IDS_NFO_ASSIGN_IP "Atanan IP: %ls"
     IDS_ERR_CERT_EXPIRED "Sertifikanız veya sistem tarih/zaman ayarlarınız geçersiz olduğundan bağlantı sağlanamadı."
     IDS_ERR_CERT_NOT_YET_VALID "Sertifikanız geçersiz olduğundan bağlantı sağlanamadı. Sistem zamanınızın doğruluğunu kontrol edin."
     IDS_NFO_STATE_RECONNECTING "Geçerli Durum: Yeniden Bağlanılıyor"
     IDS_NFO_STATE_DISCONNECTED "Geçerli Durum: Bağlantı Kesildi"
-    IDS_NFO_CONN_TERMINATED "%s ile olan bağlantı kesildi. "
+    IDS_NFO_CONN_TERMINATED "%ls ile olan bağlantı kesildi. "
     IDS_NFO_STATE_FAILED "Geçerli Durum: Bağlantı sağlanamadı."
-    IDS_NFO_CONN_FAILED "%s ile bağlantı kurulamadı"
+    IDS_NFO_CONN_FAILED "%ls ile bağlantı kurulamadı"
     IDS_NFO_STATE_FAILED_RECONN "Geçerli Durum: Bağlantı sağlanamadı"
-    IDS_NFO_RECONN_FAILED "%s ile yeniden bağlantı sağlanırken hata oluştu."
+    IDS_NFO_RECONN_FAILED "%ls ile yeniden bağlantı sağlanırken hata oluştu."
     IDS_NFO_STATE_SUSPENDED "Geçerli Durum: Beklemede"
     IDS_ERR_READ_STDOUT_PIPE "OpenVPN StdOut Pipe okunurken hata oluştu."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Günlük dosyası oluşturulurken hata oluştu!!"
     IDS_ERR_SET_SIZE "Boyut ayarlanırken hata oluştu!"
-    IDS_ERR_AUTOSTART_CONF "İstenilen konfigürasyon dosyası yeniden başlatılırken hata oluştu.: %s"
+    IDS_ERR_AUTOSTART_CONF "İstenilen konfigürasyon dosyası yeniden başlatılırken hata oluştu.: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead başarısız oldu!."
     IDS_NFO_STATE_CONNECTING "Geçerli Durum: Bağlanıyor!"
-    IDS_NFO_CONNECTION_XXX "OpenVPN Bağlantısı (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN Bağlantısı (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Geçerli Durum: Bağlantı betiği çalıştırılıyor"
     IDS_NFO_STATE_DISCONN_SCRIPT "Geçerli Durum: Bağlantıyı koparmak için betik çalıştırılıyor"
-    IDS_ERR_RUN_CONN_SCRIPT "Bağlantı betiği çalıştırma hatası: %s"
-    IDS_ERR_GET_EXIT_CODE "Bağlantı betiğinde ExitCode çalıştırılamadı: (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Bağlantı betiği çalıştırma hatası: %ls"
+    IDS_ERR_GET_EXIT_CODE "Bağlantı betiğinde ExitCode çalıştırılamadı: (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Bağlantı betiği başarısız oldu. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Bağlantı betiği başarısız oldu. %d saniyede timeout oldu."
-    IDS_ERR_CONFIG_EXIST "Zaten '%s' ismi ile kayıtlı bir ayar dosyası mevcut. \
+    IDS_ERR_CONFIG_EXIST "Zaten '%ls' ismi ile kayıtlı bir ayar dosyası mevcut. \
 Ayrı klasörlerde olmadığı sürece, aynı isimle ayar dosyası \
 kayıt edemezsiniz."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Debug dosyası açılırken hata oluştu (%s)"
-    IDS_ERR_CREATE_PATH "Could not create %s path:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Debug dosyası açılırken hata oluştu (%ls)"
+    IDS_ERR_CREATE_PATH "Could not create %ls path:\n%ls"
     IDS_ERR_LOAD_RICHED20 "RICHED20.DLL yüklenemedi."
     IDS_ERR_SHELL_DLL_VERSION "Sistemde bulunan shell32.dll verdsiyonu eski. (0x%lx). En az 5.0 versiyonuna sahip olmalısınız."
     IDS_NFO_SERVICE_STARTED "OpenVPN Servisi başlatıldı."
@@ -421,26 +421,26 @@ Registry ayarları için:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI Kullanımı"
-    IDS_ERR_BAD_PARAMETER " ""%s"" ifadesini --seçenek parametre olarak ayırmaya çalışıyorum \
+    IDS_ERR_BAD_PARAMETER " ""%ls"" ifadesini --seçenek parametre olarak ayırmaya çalışıyorum \
 fakat şu ifadeleri göremedim '--'"
-    IDS_ERR_BAD_OPTION "Seçenek hatası: Bilinmeyen bir parametre girişi yaptınız: --%s\n\
+    IDS_ERR_BAD_OPTION "Seçenek hatası: Bilinmeyen bir parametre girişi yaptınız: --%ls\n\
 Daha fazla bilgi için komut satırında openvpn-gui --help ifadesini kullanın."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "Şifre değiştirme diyaloğunu başlatma olayı başarısız oldu."
-    IDS_NFO_CHANGE_PWD "Şifre Değiştir (%s)"
+    IDS_NFO_CHANGE_PWD "Şifre Değiştir (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Girdiğiniz şifreler eşleşmiyor."
     IDS_ERR_PWD_TO_SHORT "yeni şifreniz en az %d karakter uzunluğunda olmalıdır."
     IDS_NFO_EMPTY_PWD "Boş bir şifreyi kullanmak istediğinize gerçekten emin misiniz?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Bilinmeyen anahtar dosyası biçimi."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "private key açılırken hata oluştu(%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "private key açılırken hata oluştu(%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Yanlış şifre girdiniz."
-    IDS_ERR_OPEN_WRITE_KEY "private key dosyası yazılırken hata oluştu (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Yeni private key dosyası yazılırken hata oluştu (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "private key dosyası yazılırken hata oluştu (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Yeni private key dosyası yazılırken hata oluştu (%ls)."
     IDS_NFO_PWD_CHANGED "Şifreniz değiştirildi."
-    IDS_ERR_READ_PKCS12 "PKCS #12 dosyası okunurken hata oluştu (%s)."
+    IDS_ERR_READ_PKCS12 "PKCS #12 dosyası okunurken hata oluştu (%ls)."
     IDS_ERR_CREATE_PKCS12 "Yeni PKCS #12 oluşturulurken hata oluştu. Yeni şifre dosyası oluşturulamadı."
-    IDS_ERR_OPEN_CONFIG "Ayar dosyası okuma için açılamadı: (%s)"
+    IDS_ERR_OPEN_CONFIG "Ayar dosyası okuma için açılamadı: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "Ayar dosyasında birden fazla anahtar ""key"" belirtemezsiniz."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "Ayarlarınızda aynı anda anahtar ""key"" ve pkcs12 ""pkcs12"" seçimlerini kullanamazsınız."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "Ayar dosyanızda birden fazla pkcs12 ""pkcs12"" seçimi bulunduramazsınız."
@@ -463,7 +463,7 @@ Lütfen yeni bir tane seçiniz."
     IDS_ERR_SOCKS_PROXY_ADDRESS "Bir SOCKS proxy adresi girmelisiniz."
     IDS_ERR_SOCKS_PROXY_PORT "Bir SOCKS proxy port u girmelisiniz."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "1 ila 65535 arasında bir SOCKS proxy port numarası girmelisiniz."
-    IDS_ERR_CREATE_REG_HKCU_KEY """HKEY_CURRENT_USER\\%s"" anahtarı oluşturulurken hata oluştu."
+    IDS_ERR_CREATE_REG_HKCU_KEY """HKEY_CURRENT_USER\\%ls"" anahtarı oluşturulurken hata oluştu."
     IDS_ERR_GET_TEMP_PATH "GetTempPath() ile TempPath aranırken hata oluştu. ""C:\\"" kullanılacak."
 
     /* service */
@@ -497,24 +497,24 @@ Muhtemelen OpenVPN yüklü değil."
     IDS_ERR_CREATE_REG_KEY "HKLM\\SOFTWARE\\OpenVPN-GUI anahtarı oluşturulamadı."
     IDS_ERR_OPEN_WRITE_REG "Windows Registry açılmadı. Registry' i açabilmek için \
 sistem yönetici haklarına sahip olmanız gerekmektedir.."
-    IDS_ERR_READ_SET_KEY """%s"" anahtarı ayarlanırken hata oluştu."
-    IDS_ERR_WRITE_REGVALUE """HKEY_CURRENT_USER\\%s\\%s"" anahtarı yazılırken hata oluştu."
+    IDS_ERR_READ_SET_KEY """%ls"" anahtarı ayarlanırken hata oluştu."
+    IDS_ERR_WRITE_REGVALUE """HKEY_CURRENT_USER\\%ls\\%ls"" anahtarı yazılırken hata oluştu."
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "A config named ""%s"" already exists."
+    IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."
     IDS_ERR_IMPORT_FAILED "Failed to import file. The following path could not be created.\n\n\
-%s\n\nMake sure you have the right permissions."
+%ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%s"""
+    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%hs'"
 
     IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
@@ -522,6 +522,6 @@ sistem yönetici haklarına sahip olmanız gerekmektedir.."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -220,7 +220,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_UKRAINIAN, SUBLANG_DEFAULT
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - графічний інтерфейс Windows для OpenVPN\n\
+    LTEXT "OpenVPN GUI v%ls - графічний інтерфейс Windows для OpenVPN\n\
 Copyright (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 Copyright (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 Copyright (C) 2012-2021 OpenVPN GUI contributors\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -277,7 +277,7 @@ BEGIN
     IDS_TIP_CONNECTED "\nЗ'єднано з узлом: "
     IDS_TIP_CONNECTING "\nЗ'єднання з: "
     IDS_TIP_CONNECTED_SINCE "\nЗ'єднано з такого часу: "
-    IDS_TIP_ASSIGNED_IP "\n IP: %s"
+    IDS_TIP_ASSIGNED_IP "\n IP: %ls"
     IDS_MENU_SERVICE "Служба OpenVPN"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -302,28 +302,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "Ви бажаєте відключитися (зупинити сервіс OpenVPN)?"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "Помилка старту переглядача лог файлу: %s"
-    IDS_ERR_START_CONF_EDITOR "Помилка старту редактора лог файлу: %s"
+    IDS_ERR_START_LOG_VIEWER "Помилка старту переглядача лог файлу: %ls"
+    IDS_ERR_START_CONF_EDITOR "Помилка старту редактора лог файлу: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI не підтримує більш ніж %d конфігурацій. Будь ласка, з'єднайтеся із автором, якщо вам потрібна більша кількість конфігурацій."
     IDS_NFO_NO_CONFIGS "Профілів для підключення (файлів конфігурації) не знайдено.\n\
-Скористайтеся меню ""Імпортувати файл"" або скопіюйте свої конфігураційні файли в ""%s"" або в ""%s""."
+Скористайтеся меню ""Імпортувати файл"" або скопіюйте свої конфігураційні файли в ""%ls"" або в ""%ls""."
     IDS_ERR_CONFIG_NOT_AUTHORIZED "Запуск цього з’єднання (% s) вимагає членства в групі \
-""%s"". Зверніться до системного адміністратора.\n"
+""%ls"". Зверніться до системного адміністратора.\n"
     IDS_ERR_CONFIG_TRY_AUTHORIZE  "Запуск цього з’єднання (% s) вимагає членства в групі \
-""%s""\n\n\
+""%ls""\n\n\
 Ви хочете додати себе до цієї групи?\n\
 Ця дія може вимагати пароля адміністратора системи або його згоди (підтвердження)."
-    IDS_NFO_CONFIG_AUTH_PENDING   "Запуск цього з’єднання (%s) вимагає членства в групі \
-""%s"".\n\n\
+    IDS_NFO_CONFIG_AUTH_PENDING   "Запуск цього з’єднання (%ls) вимагає членства в групі \
+""%ls"".\n\n\
 Будь ласка, заповніть попереднє діалогове вікно авторизації."
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Неможливо додати користувача до групи ""%s""."
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "Неможливо додати користувача до групи ""%ls""."
     IDS_ERR_ONE_CONN_OLD_VER "Одночасно ви маєте можливість використовувати тільки одне з'єднання, у версіях OpenVPN 2.0-beta6, або найновіших"
     IDS_ERR_STOP_SERV_OLD_VER "Ви не маєте можливості використовувати OpenVPN GUI, щоб стартувати з'єднання, поки запущений процес OpenVPN (с OpenVPN 1.5/1.6). Спочатку зупиніть процес OpenVPN, у випадку, якщо ви бажаєте використати OpenVPN GUI."
-    IDS_ERR_CREATE_EVENT "Робоча помилка CreateEvent під час завершення %s"
-    IDS_ERR_UNKNOWN_PRIORITY "Не задане найменування пріорітету: %s"
-    IDS_ERR_LOG_APPEND_BOOL "Опція додання до файлу журналу (заданий як'%s') має бути '0' або '1'"
+    IDS_ERR_CREATE_EVENT "Робоча помилка CreateEvent під час завершення %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "Не задане найменування пріорітету: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "Опція додання до файлу журналу (заданий як'%ls') має бути '0' або '1'"
     IDS_ERR_GET_MSIE_PROXY "Не вдалось отримати конфігурацію проксі із Microsoft Internet Explorer та конфігурацію проксі з Microsoft Windows."
     IDS_ERR_INIT_SEC_DESC "Робоча помилка InitializeSecurityDescriptor."
     IDS_ERR_SET_SEC_DESC_ACL "Робоча помилка SetSecurityDescriptorDacl."
@@ -331,41 +331,41 @@ BEGIN
     IDS_ERR_CREATE_PIPE_INPUT "Робоча помилка CreatePipe, а саме у час hInputRead."
     IDS_ERR_DUP_HANDLE_OUT_READ "Робоча помилка DuplicateHandle, а саме у час hOutputRead."
     IDS_ERR_DUP_HANDLE_IN_WRITE "Робоча помилка DuplicateHandle, а саме у час hInputWrite."
-    IDS_ERR_CREATE_PROCESS "Робоча помилка CreateProcess, exe='%s' cmdline='%s' dir='%s'"
+    IDS_ERR_CREATE_PROCESS "Робоча помилка CreateProcess, exe='%ls' cmdline='%ls' dir='%ls'"
     IDS_ERR_CREATE_THREAD_STATUS "Робоча помилка CreateThread, а саме у час відображення вікна статусу."
     IDS_NFO_STATE_WAIT_TERM "У цей час статус: очікування зупинки роботи OpenVPN…"
     IDS_NFO_STATE_CONNECTED "У цей час статус: підключено."
-    IDS_NFO_NOW_CONNECTED "%s зараз підключено."
-    IDS_NFO_ASSIGN_IP "Отримано IP: %s"
+    IDS_NFO_NOW_CONNECTED "%ls зараз підключено."
+    IDS_NFO_ASSIGN_IP "Отримано IP: %ls"
     IDS_ERR_CERT_EXPIRED "Неможливо з'єднатися, бо час дії вашого сертифікату минув або системний час некорректний."
     IDS_ERR_CERT_NOT_YET_VALID "Неможливо з'єднатися, бо ваш сертифікат ще не вступив у дію. Перевірте корректність налаштувань системного часу."
     IDS_NFO_STATE_RECONNECTING "Поточний статус: перепідключення"
     IDS_NFO_STATE_DISCONNECTED "Поточний статус: відключено"
-    IDS_NFO_CONN_TERMINATED "З'єднання з %s було втрачено."
+    IDS_NFO_CONN_TERMINATED "З'єднання з %ls було втрачено."
     IDS_NFO_STATE_FAILED "Поточний статус: помилка підключення"
-    IDS_NFO_CONN_FAILED "Не вдалось з'єднатися з %s."
+    IDS_NFO_CONN_FAILED "Не вдалось з'єднатися з %ls."
     IDS_NFO_STATE_FAILED_RECONN "У цей час статус: помилка у час з'єднання знову"
-    IDS_NFO_RECONN_FAILED "Не вдалося з'єднатися з %s."
+    IDS_NFO_RECONN_FAILED "Не вдалося з'єднатися з %ls."
     IDS_NFO_STATE_SUSPENDED "Поточний статус: призупинено"
     IDS_ERR_READ_STDOUT_PIPE "Помилка отримання із стандартного вводу OpenVPN."
     IDS_ERR_CREATE_EDIT_LOGWINDOW "Не вдалося зробити RichEdit LogWindow!"
     IDS_ERR_SET_SIZE "Не вдалося зберегти налаштування розміру (файла)!"
-    IDS_ERR_AUTOSTART_CONF "Не вдалося знайти файл конфігурації для автозапуску, що був заданий: %s"
+    IDS_ERR_AUTOSTART_CONF "Не вдалося знайти файл конфігурації для автозапуску, що був заданий: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "Не вдалося виконати CreatePipe, а саме у час hInputRead."
     IDS_NFO_STATE_CONNECTING "У цей час: підключення"
-    IDS_NFO_CONNECTION_XXX "З'єднання OpenVPN (%s)"
+    IDS_NFO_CONNECTION_XXX "З'єднання OpenVPN (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "Поточний статус: старт скрипта підключення"
     IDS_NFO_STATE_DISCONN_SCRIPT "Поточний статус: старт скрипта відключення"
-    IDS_ERR_RUN_CONN_SCRIPT "Помилка старту скрипта підключення: %s"
-    IDS_ERR_GET_EXIT_CODE "Помилка отримання коду виходу (ExitCode) скрипта підключення (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "Помилка старту скрипта підключення: %ls"
+    IDS_ERR_GET_EXIT_CODE "Помилка отримання коду виходу (ExitCode) скрипта підключення (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "Помилку роботи скрипта підключення. (exitcode=%ld)"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "Помилка роботи скрипта підключення. Закінчився час очікування після %d сек."
-    IDS_ERR_CONFIG_EXIST "Вже знайдено файл конфігурації із назвою '%s'. Ви не маєте можливості \
+    IDS_ERR_CONFIG_EXIST "Вже знайдено файл конфігурації із назвою '%ls'. Ви не маєте можливості \
 використувати кілька файлів конфігурації із однією назвою, навіть якщо \
 вони знаходяться у різних папках одночасно."
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "Помилка відкриття файлу відладки (%s) для ."
-    IDS_ERR_CREATE_PATH "Неможливо зробити новий %s шлях:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "Помилка відкриття файлу відладки (%ls) для ."
+    IDS_ERR_CREATE_PATH "Неможливо зробити новий %ls шлях:\n%ls"
     IDS_ERR_LOAD_RICHED20 "Не вдалося завантижити RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Ваша версія shell32.dll занадто стара (0x%lx). Вам необхідно використовувати, як мінімум, версію файлів 5.0."
     IDS_NFO_SERVICE_STARTED "Служба OpenVPN стартувала."
@@ -421,26 +421,26 @@ BEGIN
 
 
     IDS_NFO_USAGECAPTION "Спроба OpenVPN GUI"
-    IDS_ERR_BAD_PARAMETER "Спроба запуску з ""%s"" як --опція параметр, \
+    IDS_ERR_BAD_PARAMETER "Спроба запуску з ""%ls"" як --опція параметр, \
 але немає зпочатку '--'"
-    IDS_ERR_BAD_OPTION "Помилка опцій: нерозпізнано опції або відсутні параметри: --%s\n\
+    IDS_ERR_BAD_OPTION "Помилка опцій: нерозпізнано опції або відсутні параметри: --%ls\n\
 Використувуйте openvpn-gui --help у пошуках дод. інформації."
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "Не вдалося виконати CreateThread для відображення діалогу ChangePassphrase."
-    IDS_NFO_CHANGE_PWD "Змена паролю (%s)"
+    IDS_NFO_CHANGE_PWD "Змена паролю (%ls)"
     IDS_ERR_PWD_DONT_MATCH "Введені вами паролі не співпадають. Спробуйте знову."
     IDS_ERR_PWD_TO_SHORT "Ваш новий пароль має бути довжиною не менш ніж %d символів."
     IDS_NFO_EMPTY_PWD "Ви впевнені, що бажаєте встановити ПУСТИЙ пароль?"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "Нерозпізнано формат у файлі із ключем."
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Помилка відкриття файлу із приватним ключем (%s)."
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "Помилка відкриття файлу із приватним ключем (%ls)."
     IDS_ERR_OLD_PWD_INCORRECT "Старий пароль не вірний."
-    IDS_ERR_OPEN_WRITE_KEY "Помилка відкриття файла із приватним ключем для запису (%s)."
-    IDS_ERR_WRITE_NEW_KEY "Помилка запису файла, що містить новий приватний ключ (%s)."
+    IDS_ERR_OPEN_WRITE_KEY "Помилка відкриття файла із приватним ключем для запису (%ls)."
+    IDS_ERR_WRITE_NEW_KEY "Помилка запису файла, що містить новий приватний ключ (%ls)."
     IDS_NFO_PWD_CHANGED "Ваш пароль було змінено."
-    IDS_ERR_READ_PKCS12 "Помилка доступу до файла PKCS #12 (%s)."
+    IDS_ERR_READ_PKCS12 "Помилка доступу до файла PKCS #12 (%ls)."
     IDS_ERR_CREATE_PKCS12 "Помилка створення нового об'єкта PKCS #12. Пароль змінити не вдалося."
-    IDS_ERR_OPEN_CONFIG "Не вдалося відкрити файл конфигурації для читання: (%s)"
+    IDS_ERR_OPEN_CONFIG "Не вдалося відкрити файл конфигурації для читання: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "У вашій конфігурації не має бути більше одної опції ""key""."
     IDS_ERR_ONLY_KEY_OR_PKCS12 "У вашій конфігурації не має бути одночасно знайдено опції ""key"" и ""pkcs12""."
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "У вашій конфігурації не може бути більше однієї опції ""pkcs12""."
@@ -463,7 +463,7 @@ BEGIN
     IDS_ERR_SOCKS_PROXY_ADDRESS "Ви повинні задати адресу SOCKS-проксі."
     IDS_ERR_SOCKS_PROXY_PORT "Ви повинні задати порт SOCKS-проксі."
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "Ви повинні задати порт SOCKS-прокси із діапозону 1-65535"
-    IDS_ERR_CREATE_REG_HKCU_KEY "Помилка створення ключів ""HKEY_CURRENT_USER\\%s""."
+    IDS_ERR_CREATE_REG_HKCU_KEY "Помилка створення ключів ""HKEY_CURRENT_USER\\%ls""."
     IDS_ERR_GET_TEMP_PATH "Помилка пошуку TempPath із використанням GetTempPath(). Замість цього программа використувує ""C:\\""."
 
     /* service */
@@ -497,25 +497,25 @@ OpenVPN, можливо, не встановлений."
     IDS_ERR_CREATE_REG_KEY "Помилка створення ключів HKLM\\SOFTWARE\\OpenVPN-GUI."
     IDS_ERR_OPEN_WRITE_REG "Не вдалося відкрити реєстр під запис. Вам необхідно стартувати цей сервіс \
  із правами адміністратора, щоб відновити реєстр."
-    IDS_ERR_READ_SET_KEY "Помилка читання і встановлення перемінної ""%s""."
-    IDS_ERR_WRITE_REGVALUE "Помилка запису перемінної реєстру до ""HKEY_CURRENT_USER\\%s\\%s""."
+    IDS_ERR_READ_SET_KEY "Помилка читання і встановлення перемінної ""%ls""."
+    IDS_ERR_WRITE_REGVALUE "Помилка запису перемінної реєстру до ""HKEY_CURRENT_USER\\%ls\\%ls""."
 
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "Файл конфігурації ""%s"" вже існує."
-    IDS_ERR_IMPORT_FAILED "Помилка імпорту файла. Шлях %s не може бути створений.\n\n\
+    IDS_ERR_IMPORT_EXISTS "Файл конфігурації ""%ls"" вже існує."
+    IDS_ERR_IMPORT_FAILED "Помилка імпорту файла. Шлях %ls не може бути створений.\n\n\
 Перевірте, що в вас є необхідні права для цієї операції."
     IDS_NFO_IMPORT_SUCCESS "Імпорт файла успішно завершено."
-    IDS_NFO_IMPORT_OVERWRITE "Конфігурація з назвою ""%s"" вже існує. Замінити?"
-    IDS_ERR_IMPORT_SOURCE "Не вдається імпортувати файл <%s>, оскільки він уже є в глобальному або локальному каталозі конфігурації"
+    IDS_NFO_IMPORT_OVERWRITE "Конфігурація з назвою ""%ls"" вже існує. Замінити?"
+    IDS_ERR_IMPORT_SOURCE "Не вдається імпортувати файл <%ls>, оскільки він уже є в глобальному або локальному каталозі конфігурації"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Підтвердіть видалення збережених паролів для ""%s"""
+    IDS_NFO_DELETE_PASS "Підтвердіть видалення збережених паролів для ""%ls"""
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Пароль токену"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Введіть пароль/PIN-код токену '%S'"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "Введіть пароль/PIN-код токену '%hs'"
     IDS_NFO_AUTH_PASS_RETRY "Невірне ім'я користувача або пароль"
     IDS_NFO_KEY_PASS_RETRY "Невірний пароль"
 
@@ -523,6 +523,6 @@ OpenVPN, можливо, не встановлений."
     IDS_ERR_INVALID_USERNAME_INPUT "Невірний символ в імені користувача"
     IDS_NFO_AUTO_CONNECT    "Автоматичне підключення через %u секунд…"
     IDS_NFO_CLICK_HERE_TO_START "Графічний інтерфейс OpenVPN вже запущений. Клацніть правою кнопкою мишки на піктограмі OpenVPN в лотку, щоб його запустити."
-    IDS_NFO_BYTECOUNT "Завантажено байт: %s Передано байт: %s"
+    IDS_NFO_BYTECOUNT "Завантажено байт: %ls Передано байт: %ls"
 
 END

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -223,7 +223,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - OpenVPN 的 Windows 图形化界面\n\
+    LTEXT "OpenVPN GUI v%ls - OpenVPN 的 Windows 图形化界面\n\
 版权所有 (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 版权所有 (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 版权所有 (C) 2012-2021 OpenVPN GUI 贡献者\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -279,7 +279,7 @@ BEGIN
     IDS_TIP_CONNECTED "\n已连接至: "
     IDS_TIP_CONNECTING "\n正在连接至: "
     IDS_TIP_CONNECTED_SINCE "\n连接自: "
-    IDS_TIP_ASSIGNED_IP "\n分配 IP: %s"
+    IDS_TIP_ASSIGNED_IP "\n分配 IP: %ls"
     IDS_MENU_SERVICE "OpenVPN 服务"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -304,28 +304,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "您想要断开连接（停止 OpenVPN 服务）吗？"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "日志文件查看器启动失败: %s"
-    IDS_ERR_START_CONF_EDITOR "配置文件编辑器启动失败: %s"
+    IDS_ERR_START_LOG_VIEWER "日志文件查看器启动失败: %ls"
+    IDS_ERR_START_CONF_EDITOR "配置文件编辑器启动失败: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI 不支持超过 %d 组连接配置文件。若您有需要，请联系作者。"
     IDS_NFO_NO_CONFIGS "没有找到可读取的连接配置文件。\n\
-请使用「导入配置文件…」菜单，或将配置文件复制到「%s」或「%s」。"
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "启动此连接 (%s) 必须要有「%s」群组的成员资格。\
+请使用「导入配置文件…」菜单，或将配置文件复制到「%ls」或「%ls」。"
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "启动此连接 (%ls) 必须要有「%ls」群组的成员资格。\
 请联系您的系统管理员。\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "启动此连接 (%s) 必须要有「%s」群组的成员资格。\
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "启动此连接 (%ls) 必须要有「%ls」群组的成员资格。\
 \n\n\
 您想要把自己加入到此群组吗？\n\
 可能需要输入管理者密码或由管理员同意才能进行此行为。"
-    IDS_NFO_CONFIG_AUTH_PENDING   "启动此连接 (%s) 必须要有「%s」群组的成员资格。\
+    IDS_NFO_CONFIG_AUTH_PENDING   "启动此连接 (%ls) 必须要有「%ls」群组的成员资格。\
 \n\n\
 请完成先前的授权对话框。"
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "将用户加入至「%s」群组失败。"
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "将用户加入至「%ls」群组失败。"
     IDS_ERR_ONE_CONN_OLD_VER "若您使用 OpenVPN 2.0-beta6 以前的旧版本，同时仅能有一个连接。"
     IDS_ERR_STOP_SERV_OLD_VER "OpenVPN 1.5/1.6 的服务启动时，将无法使用 OpenVPN GUI 进行连接。若您想使用 OpenVPN GUI，请先停止 OpenVPN 服务。"
-    IDS_ERR_CREATE_EVENT "CreateEvent在发生退出事件时失败: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "未知的优先权名称: %s"
-    IDS_ERR_LOG_APPEND_BOOL "追加日志文件的标志（例如「%s」）必须为「0」或「1」"
+    IDS_ERR_CREATE_EVENT "CreateEvent在发生退出事件时失败: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "未知的优先权名称: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "追加日志文件的标志（例如「%ls」）必须为「0」或「1」"
     IDS_ERR_GET_MSIE_PROXY "无法获取 MSIE 的代理设置。"
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor 失败。"
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl 失败。"
@@ -333,42 +333,42 @@ BEGIN
     IDS_ERR_CREATE_PIPE_INPUT "CreatePipe hInputRead 失败。"
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead 失败。"
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite 失败。"
-    IDS_ERR_CREATE_PROCESS "CreateProcess 失败，exe=「%s」 cmdline=「%s」 dir=「%s」"
+    IDS_ERR_CREATE_PROCESS "CreateProcess 失败，exe=「%ls」 cmdline=「%ls」 dir=「%ls」"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread 显示状态窗口时失败。"
     IDS_NFO_STATE_WAIT_TERM "当前状态: 等待中止 OpenVPN…"
     IDS_NFO_STATE_CONNECTED "当前状态: 已连接"
-    IDS_NFO_NOW_CONNECTED "已连接至 %s。"
-    IDS_NFO_ASSIGN_IP "分配 IP: %s"
+    IDS_NFO_NOW_CONNECTED "已连接至 %ls。"
+    IDS_NFO_ASSIGN_IP "分配 IP: %ls"
     IDS_ERR_CERT_EXPIRED "您的证书已过期，或是系统时间不正确，无法连接。"
     IDS_ERR_CERT_NOT_YET_VALID "您的证书尚未生效，无法连接。请检查您的系统时间是否正确。"
     IDS_NFO_STATE_RECONNECTING "当前状态: 重新连接中"
     IDS_NFO_STATE_DISCONNECTED "当前状态: 已断开连接"
-    IDS_NFO_CONN_TERMINATED "%s 连接已中断。"
+    IDS_NFO_CONN_TERMINATED "%ls 连接已中断。"
     IDS_NFO_STATE_FAILED "当前状态: 连接失败"
-    IDS_NFO_CONN_FAILED "%s 连接失败。"
+    IDS_NFO_CONN_FAILED "%ls 连接失败。"
     IDS_NFO_STATE_FAILED_RECONN "当前状态: 重新连接失败"
-    IDS_NFO_RECONN_FAILED "%s 重新连接失败。"
+    IDS_NFO_RECONN_FAILED "%ls 重新连接失败。"
     IDS_NFO_STATE_SUSPENDED "目前状态: 已暂停"
     IDS_ERR_READ_STDOUT_PIPE "无法从 OpenVPN StdOut 管道读取。"
     IDS_ERR_CREATE_EDIT_LOGWINDOW "建立 RichEdit 日志窗口失败！"
     IDS_ERR_SET_SIZE "设定大小失败！"
-    IDS_ERR_AUTOSTART_CONF "无法找到指定的自动连接配置文件: %s"
+    IDS_ERR_AUTOSTART_CONF "无法找到指定的自动连接配置文件: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead 失败。"
     IDS_NFO_STATE_CONNECTING "当前状态: 连接中"
-    IDS_NFO_CONNECTION_XXX "OpenVPN 连接 (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN 连接 (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "当前状态: 正在执行连接脚本"
     IDS_NFO_STATE_DISCONN_SCRIPT "当前状态: 正在执行断开连接脚本"
-    IDS_ERR_RUN_CONN_SCRIPT "执行连接脚本时发生错误: %s"
-    IDS_ERR_GET_EXIT_CODE "无法取得连接脚本的退出码 (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "执行连接脚本时发生错误: %ls"
+    IDS_ERR_GET_EXIT_CODE "无法取得连接脚本的退出码 (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "连接脚本执行失败。（退出码为 %ld）"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "连接脚本执行失败，执行超过 %d 已超时。"
-    IDS_ERR_CONFIG_EXIST "已有名为「%s」的连接配置文件。即使连接配置文件存在不同文件夹，\
+    IDS_ERR_CONFIG_EXIST "已有名为「%ls」的连接配置文件。即使连接配置文件存在不同文件夹，\
 您也不得设置相同名称。"
     IDS_NFO_CONN_TIMEOUT "连接至管理接口失败。\n\
-请检查日志文件 (%s) 获得更多详细信息。"
+请检查日志文件 (%ls) 获得更多详细信息。"
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "打开调试文件 (%s) 时失败。"
-    IDS_ERR_CREATE_PATH "无法建立 %s 路径:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "打开调试文件 (%ls) 时失败。"
+    IDS_ERR_CREATE_PATH "无法建立 %ls 路径:\n%ls"
     IDS_ERR_LOAD_RICHED20 "无法加载 RICHED20.DLL。"
     IDS_ERR_SHELL_DLL_VERSION "您的 shell32.dll 版本太旧 (0x%lx)，需要至少 5.0 版本或更新版。"
     IDS_NFO_SERVICE_STARTED "已启动 OpenVPN 服务。"
@@ -424,26 +424,26 @@ BEGIN
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI 使用方式"
-    IDS_ERR_BAD_PARAMETER "尝试将「%s」解析成 --option 的参数，\
+    IDS_ERR_BAD_PARAMETER "尝试将「%ls」解析成 --option 的参数，\
 但没看到参数前面的「--」"
-    IDS_ERR_BAD_OPTION "选项错误: 无法识别选项，或缺少参数: --%s\n\
+    IDS_ERR_BAD_OPTION "选项错误: 无法识别选项，或缺少参数: --%ls\n\
 使用 openvpn-gui --help 获得更多信息。"
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread 显示变更密码对话框失败。"
-    IDS_NFO_CHANGE_PWD "变更私钥密码 (%s)"
+    IDS_NFO_CHANGE_PWD "变更私钥密码 (%ls)"
     IDS_ERR_PWD_DONT_MATCH "您输入的密码不相符，请再试一次。"
     IDS_ERR_PWD_TO_SHORT "您的新密码必须要有至少 %d 字符长。"
     IDS_NFO_EMPTY_PWD "您确定要使用空白密码吗？"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "未知格式的密钥文件。"
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "打开私钥文件 (%s) 时发生错误。"
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "打开私钥文件 (%ls) 时发生错误。"
     IDS_ERR_OLD_PWD_INCORRECT "旧密码不正确。"
-    IDS_ERR_OPEN_WRITE_KEY "无法打开私钥文件进行写入 (%s)。"
-    IDS_ERR_WRITE_NEW_KEY "写入新私钥文件时发生错误 (%s)。"
+    IDS_ERR_OPEN_WRITE_KEY "无法打开私钥文件进行写入 (%ls)。"
+    IDS_ERR_WRITE_NEW_KEY "写入新私钥文件时发生错误 (%ls)。"
     IDS_NFO_PWD_CHANGED "您的密码已经变更。"
-    IDS_ERR_READ_PKCS12 "读取 PKCS #12 文件时发生错误 (%s)。"
+    IDS_ERR_READ_PKCS12 "读取 PKCS #12 文件时发生错误 (%ls)。"
     IDS_ERR_CREATE_PKCS12 "无法建立新的 PKCS #12 对象，密码变更失败。"
-    IDS_ERR_OPEN_CONFIG "无法读取连接配置文件: (%s)"
+    IDS_ERR_OPEN_CONFIG "无法读取连接配置文件: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "您的连接配置文件中不能包含超过一个「key」选项。"
     IDS_ERR_ONLY_KEY_OR_PKCS12 "您的连接配置文件中不能同时包含「key」和「pkcs12」选项。"
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "您的连接配置文件中不能包含超过一个「pkcs12」选项。"
@@ -466,7 +466,7 @@ BEGIN
     IDS_ERR_SOCKS_PROXY_ADDRESS "您必须指定 SOCKS代理 地址。"
     IDS_ERR_SOCKS_PROXY_PORT "您必须指定 SOCKS代理 端口。"
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "您必须指定在 1-65535 之间的 SOCKS代理 端口"
-    IDS_ERR_CREATE_REG_HKCU_KEY "「HKEY_CURRENT_USER\\%s」建立注册表项失败。"
+    IDS_ERR_CREATE_REG_HKCU_KEY "「HKEY_CURRENT_USER\\%ls」建立注册表项失败。"
     IDS_ERR_GET_TEMP_PATH "使用 GetTempPath() 决定 TempPath 时发生错误。改用「C:\\」。"
 
     /* service */
@@ -499,24 +499,24 @@ Wintun driver will not work."
     IDS_ERR_PRECONN_SCRIPT_TIMEOUT "系统注册表值「preconnectscript_timeout」必须为 1 到 99 之间的数字。"
     IDS_ERR_CREATE_REG_KEY "建立 HKLM\\SOFTWARE\\OpenVPN-GUI 注册表项时发生错误。"
     IDS_ERR_OPEN_WRITE_REG "无法打开系统注册表进行写入，您必须以管理员身分执行此应用程序更新注册表。"
-    IDS_ERR_READ_SET_KEY "读取并设定系统注册表项「%s」时发生错误。"
-    IDS_ERR_WRITE_REGVALUE "读取系统注册表值「HKEY_CURRENT_USER\\%s\\%s」时发生错误。"
+    IDS_ERR_READ_SET_KEY "读取并设定系统注册表项「%ls」时发生错误。"
+    IDS_ERR_WRITE_REGVALUE "读取系统注册表值「HKEY_CURRENT_USER\\%ls\\%ls」时发生错误。"
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "已有名为「%s」的连接配置文件。"
+    IDS_ERR_IMPORT_EXISTS "已有名为「%ls」的连接配置文件。"
     IDS_ERR_IMPORT_FAILED "文件导入失败。无法建立下列路径。\n\n\
-%s\n\n请确定您有正确的系统权限。"
+%ls\n\n请确定您有正确的系统权限。"
     IDS_NFO_IMPORT_SUCCESS "已成功导入文件。"
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "请按「确定」删除「%s」连接配置文件的已存密码。"
+    IDS_NFO_DELETE_PASS "请按「确定」删除「%ls」连接配置文件的已存密码。"
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - 令牌密码"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "请输入令牌「%S」的密码或 PIN"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "请输入令牌「%hs」的密码或 PIN"
 
     IDS_NFO_AUTH_PASS_RETRY "错误的凭据。请重试..."
     IDS_NFO_KEY_PASS_RETRY  "密码错误。请重试..."
@@ -524,6 +524,6 @@ Wintun driver will not work."
     IDS_ERR_INVALID_USERNAME_INPUT "用户名称中有无效字符"
     IDS_NFO_AUTO_CONNECT    "在 %u 秒后自动连接..."
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI 已经运行. 右击任务栏图标启动."
-    IDS_NFO_BYTECOUNT "接收字节: %s  发送字节: %s"
+    IDS_NFO_BYTECOUNT "接收字节: %ls  发送字节: %ls"
 
 END

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -223,7 +223,7 @@ FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL
 BEGIN
     ICON ID_ICO_APP, ID_ICON_ABOUT, 8, 16, 21, 20
-    LTEXT "OpenVPN GUI v%s - OpenVPN 的 Windows 圖形化介面\n\
+    LTEXT "OpenVPN GUI v%ls - OpenVPN 的 Windows 圖形化介面\n\
 版權所有 (C) 2004-2005 Mathias Sundman <info@openvpn.se>\n\
 版權所有 (C) 2008-2014 Heiko Hund <heikoh@users.sf.net>\n\
 版權所有 (C) 2012-2021 OpenVPN GUI 貢獻者\n", ID_TXT_VERSION, 36, 15, 206, 50
@@ -279,7 +279,7 @@ BEGIN
     IDS_TIP_CONNECTED "\n已連線至: "
     IDS_TIP_CONNECTING "\n正在連線至: "
     IDS_TIP_CONNECTED_SINCE "\n連線自: "
-    IDS_TIP_ASSIGNED_IP "\n配發 IP: %s"
+    IDS_TIP_ASSIGNED_IP "\n配發 IP: %ls"
     IDS_MENU_SERVICE "OpenVPN 服務"
     IDS_MENU_IMPORT "Import"
     IDS_MENU_IMPORT_AS "Import from Access Server…"
@@ -304,28 +304,28 @@ BEGIN
     IDS_MENU_ASK_STOP_SERVICE "您想要斷線（停止 OpenVPN 服務）嗎？"
 
     /* Logviewer - Resources */
-    IDS_ERR_START_LOG_VIEWER "記錄檔檢視器啟動失敗: %s"
-    IDS_ERR_START_CONF_EDITOR "設定檔編輯器啟動失敗: %s"
+    IDS_ERR_START_LOG_VIEWER "記錄檔檢視器啟動失敗: %ls"
+    IDS_ERR_START_CONF_EDITOR "設定檔編輯器啟動失敗: %ls"
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI 不支援超過 %d 組連線設定檔。若您有需要，請聯繫作者。"
     IDS_NFO_NO_CONFIGS "沒有找到可讀取的連線設定檔。\n\
-請使用選單的「匯入設定檔…」，或將設定檔複製到「%s」或「%s」。"
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "啟動此連線 (%s) 必須要有「%s」群組的成員資格。\
+請使用選單的「匯入設定檔…」，或將設定檔複製到「%ls」或「%ls」。"
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "啟動此連線 (%ls) 必須要有「%ls」群組的成員資格。\
 請連絡您的系統管理員。\n"
-    IDS_ERR_CONFIG_TRY_AUTHORIZE  "啟動此連線 (%s) 必須要有「%s」群組的成員資格。\
+    IDS_ERR_CONFIG_TRY_AUTHORIZE  "啟動此連線 (%ls) 必須要有「%ls」群組的成員資格。\
 \n\n\
 您想要把自己加入到此群組嗎？\n\
 可能需要輸入管理密碼或管理員同意才能進行此行為。"
-    IDS_NFO_CONFIG_AUTH_PENDING   "啟動此連線 (%s) 必須要有「%s」群組的成員資格。\
+    IDS_NFO_CONFIG_AUTH_PENDING   "啟動此連線 (%ls) 必須要有「%ls」群組的成員資格。\
 \n\n\
 請完成先前的授權對話窗。"
-    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "將使用者加入至「%s」群組失敗。"
+    IDS_ERR_ADD_USER_TO_ADMIN_GROUP "將使用者加入至「%ls」群組失敗。"
     IDS_ERR_ONE_CONN_OLD_VER "若您使用 OpenVPN 2.0-beta6 以前的舊版本，同時僅能有一個連線。"
     IDS_ERR_STOP_SERV_OLD_VER "OpenVPN 1.5/1.6 的服務執行中時，將無法使用 OpenVPN GUI 進行連線。若您想使用 OpenVPN GUI，請先停止 OpenVPN 服務。"
-    IDS_ERR_CREATE_EVENT "發生結束事件時 CreateEvent 失敗: %s"
-    IDS_ERR_UNKNOWN_PRIORITY "未知的優先權名稱: %s"
-    IDS_ERR_LOG_APPEND_BOOL "附加記錄檔的旗標（例如「%s」）必須為「0」或「1」"
+    IDS_ERR_CREATE_EVENT "發生結束事件時 CreateEvent 失敗: %ls"
+    IDS_ERR_UNKNOWN_PRIORITY "未知的優先權名稱: %ls"
+    IDS_ERR_LOG_APPEND_BOOL "附加記錄檔的旗標（例如「%ls」）必須為「0」或「1」"
     IDS_ERR_GET_MSIE_PROXY "無法取得 MSIE 的 Proxy 設定。"
     IDS_ERR_INIT_SEC_DESC "InitializeSecurityDescriptor 失敗。"
     IDS_ERR_SET_SEC_DESC_ACL "SetSecurityDescriptorDacl 失敗。"
@@ -333,42 +333,42 @@ BEGIN
     IDS_ERR_CREATE_PIPE_INPUT "建立 hInputRead 管道失敗。"
     IDS_ERR_DUP_HANDLE_OUT_READ "DuplicateHandle on hOutputRead 失敗。"
     IDS_ERR_DUP_HANDLE_IN_WRITE "DuplicateHandle on hInputWrite 失敗。"
-    IDS_ERR_CREATE_PROCESS "CreateProcess 失敗，exe=「%s」 cmdline=「%s」 dir=「%s」"
+    IDS_ERR_CREATE_PROCESS "CreateProcess 失敗，exe=「%ls」 cmdline=「%ls」 dir=「%ls」"
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread 以顯示狀態視窗時失敗。"
     IDS_NFO_STATE_WAIT_TERM "目前狀態: 等待中止 OpenVPN…"
     IDS_NFO_STATE_CONNECTED "目前狀態: 已連線"
-    IDS_NFO_NOW_CONNECTED "已連線至 %s。"
-    IDS_NFO_ASSIGN_IP "配發 IP: %s"
+    IDS_NFO_NOW_CONNECTED "已連線至 %ls。"
+    IDS_NFO_ASSIGN_IP "配發 IP: %ls"
     IDS_ERR_CERT_EXPIRED "您的憑證已過期，或是系統時間不正確，無法連線。"
     IDS_ERR_CERT_NOT_YET_VALID "您的憑證尚未生效，無法連線。請檢查您的系統時間是否正確。"
     IDS_NFO_STATE_RECONNECTING "目前狀態: 重新連線中"
     IDS_NFO_STATE_DISCONNECTED "目前狀態: 已斷線"
-    IDS_NFO_CONN_TERMINATED "%s 連線已中斷。"
+    IDS_NFO_CONN_TERMINATED "%ls 連線已中斷。"
     IDS_NFO_STATE_FAILED "目前狀態: 連線失敗"
-    IDS_NFO_CONN_FAILED "%s 連線失敗。"
+    IDS_NFO_CONN_FAILED "%ls 連線失敗。"
     IDS_NFO_STATE_FAILED_RECONN "目前狀態: 重新連線失敗"
-    IDS_NFO_RECONN_FAILED "%s 重新連線失敗。"
+    IDS_NFO_RECONN_FAILED "%ls 重新連線失敗。"
     IDS_NFO_STATE_SUSPENDED "目前狀態: 已暫停"
     IDS_ERR_READ_STDOUT_PIPE "無法從 OpenVPN StdOut 管道讀取。"
     IDS_ERR_CREATE_EDIT_LOGWINDOW "建立 RichEdit 紀錄視窗失敗！"
     IDS_ERR_SET_SIZE "設定大小失敗！"
-    IDS_ERR_AUTOSTART_CONF "無法找到指定的自動連線設定檔: %s"
+    IDS_ERR_AUTOSTART_CONF "無法找到指定的自動連線設定檔: %ls"
     IDS_ERR_CREATE_PIPE_IN_READ "CreatePipe on hInputRead 失敗。"
     IDS_NFO_STATE_CONNECTING "目前狀態: 連線中"
-    IDS_NFO_CONNECTION_XXX "OpenVPN 連線 (%s)"
+    IDS_NFO_CONNECTION_XXX "OpenVPN 連線 (%ls)"
     IDS_NFO_STATE_CONN_SCRIPT "目前狀態: 正在執行連線指令碼"
     IDS_NFO_STATE_DISCONN_SCRIPT "目前狀態: 正在執行斷線指令碼"
-    IDS_ERR_RUN_CONN_SCRIPT "執行連線指令碼時發生錯誤: %s"
-    IDS_ERR_GET_EXIT_CODE "無法取得連線指令碼的 ExitCode (%s)"
+    IDS_ERR_RUN_CONN_SCRIPT "執行連線指令碼時發生錯誤: %ls"
+    IDS_ERR_GET_EXIT_CODE "無法取得連線指令碼的 ExitCode (%ls)"
     IDS_ERR_CONN_SCRIPT_FAILED "連線指令碼執行失敗。（退出碼為 %ld）"
     IDS_ERR_RUN_CONN_SCRIPT_TIMEOUT "連線指令碼執行失敗，執行超過 %d 已逾時。"
-    IDS_ERR_CONFIG_EXIST "已有名為「%s」的連線設定檔。即使連線設定檔存在不同資料夾，\
+    IDS_ERR_CONFIG_EXIST "已有名為「%ls」的連線設定檔。即使連線設定檔存在不同資料夾，\
 您也不得使用相同名稱。"
     IDS_NFO_CONN_TIMEOUT "連限至管理介面失敗。\n\
-請檢視記錄檔 (%s) 取得更多詳細資訊。"
+請檢視記錄檔 (%ls) 取得更多詳細資訊。"
     /* main - Resources */
-    IDS_ERR_OPEN_DEBUG_FILE "開啟除錯文件 (%s) 時失敗。"
-    IDS_ERR_CREATE_PATH "無法建立 %s 路徑:\n%s"
+    IDS_ERR_OPEN_DEBUG_FILE "開啟除錯文件 (%ls) 時失敗。"
+    IDS_ERR_CREATE_PATH "無法建立 %ls 路徑:\n%ls"
     IDS_ERR_LOAD_RICHED20 "無法載入 RICHED20.DLL。"
     IDS_ERR_SHELL_DLL_VERSION "您的 shell32.dll 版本太舊 (0x%lx)，需要至少 5.0 版本或更新版。"
     IDS_NFO_SERVICE_STARTED "已啟動 OpenVPN 服務。"
@@ -424,26 +424,26 @@ Supported commands:\n\
 
 
     IDS_NFO_USAGECAPTION "OpenVPN GUI 使用方式"
-    IDS_ERR_BAD_PARAMETER "嘗試將「%s」剖析成 --option 的參數，\
+    IDS_ERR_BAD_PARAMETER "嘗試將「%ls」剖析成 --option 的參數，\
 但沒看到參數前面的「--」"
-    IDS_ERR_BAD_OPTION "選項錯誤: 無法識別選項，或缺少參數: --%s\n\
+    IDS_ERR_BAD_OPTION "選項錯誤: 無法識別選項，或缺少參數: --%ls\n\
 使用 openvpn-gui --help 取得更多資訊。"
 
     /* passphrase - Resources */
     IDS_ERR_CREATE_PASS_THREAD "CreateThread 以顯示變更密碼對話框失敗。"
-    IDS_NFO_CHANGE_PWD "變更私鑰密碼 (%s)"
+    IDS_NFO_CHANGE_PWD "變更私鑰密碼 (%ls)"
     IDS_ERR_PWD_DONT_MATCH "您輸入的密碼不符合，請再試一次。"
     IDS_ERR_PWD_TO_SHORT "您的新密碼必須要有至少 %d 字元長。"
     IDS_NFO_EMPTY_PWD "您確定要使用空白密碼嗎？"
     IDS_ERR_UNKNOWN_KEYFILE_FORMAT "未知格式的金鑰檔案。"
-    IDS_ERR_OPEN_PRIVATE_KEY_FILE "開啟私鑰檔案 (%s) 時發生錯誤。"
+    IDS_ERR_OPEN_PRIVATE_KEY_FILE "開啟私鑰檔案 (%ls) 時發生錯誤。"
     IDS_ERR_OLD_PWD_INCORRECT "舊密碼不正確。"
-    IDS_ERR_OPEN_WRITE_KEY "無法開啟私鑰檔案進行寫入 (%s)。"
-    IDS_ERR_WRITE_NEW_KEY "寫入新私鑰檔案時發生錯誤 (%s)。"
+    IDS_ERR_OPEN_WRITE_KEY "無法開啟私鑰檔案進行寫入 (%ls)。"
+    IDS_ERR_WRITE_NEW_KEY "寫入新私鑰檔案時發生錯誤 (%ls)。"
     IDS_NFO_PWD_CHANGED "您的密碼已經變更。"
-    IDS_ERR_READ_PKCS12 "讀取 PKCS #12 檔案時發生錯誤 (%s)。"
+    IDS_ERR_READ_PKCS12 "讀取 PKCS #12 檔案時發生錯誤 (%ls)。"
     IDS_ERR_CREATE_PKCS12 "無法建立新的 PKCS #12 物件，密碼變更失敗。"
-    IDS_ERR_OPEN_CONFIG "無法讀取連線設定檔: (%s)"
+    IDS_ERR_OPEN_CONFIG "無法讀取連線設定檔: (%ls)"
     IDS_ERR_ONLY_ONE_KEY_OPTION "您的連線設定檔中不能包含超過一個「key」選項。"
     IDS_ERR_ONLY_KEY_OR_PKCS12 "您的連線設定檔中不能同時包含「key」和「pkcs12」選項。"
     IDS_ERR_ONLY_ONE_PKCS12_OPTION "您的連線設定檔中不能包含超過一個「pkcs12」選項。"
@@ -466,7 +466,7 @@ Supported commands:\n\
     IDS_ERR_SOCKS_PROXY_ADDRESS "您必須指定 SOCKS Proxy 地址。"
     IDS_ERR_SOCKS_PROXY_PORT "您必須指定 SOCKS Proxy 通訊埠。"
     IDS_ERR_SOCKS_PROXY_PORT_RANGE "您必須指定在 1-65535 之間的 SOCKS Proxy 通訊埠"
-    IDS_ERR_CREATE_REG_HKCU_KEY "「HKEY_CURRENT_USER\\%s」登錄機碼建立失敗。"
+    IDS_ERR_CREATE_REG_HKCU_KEY "「HKEY_CURRENT_USER\\%ls」登錄機碼建立失敗。"
     IDS_ERR_GET_TEMP_PATH "使用 GetTempPath() 決定 TempPath 時發生錯誤。改用「C:\\」。"
 
     /* service */
@@ -499,24 +499,24 @@ Wintun driver will not work."
     IDS_ERR_PRECONN_SCRIPT_TIMEOUT "系統登錄值「preconnectscript_timeout」必須為 1 到 99 之間的數字。"
     IDS_ERR_CREATE_REG_KEY "建立 HKLM\\SOFTWARE\\OpenVPN-GUI 機碼時發生錯誤。"
     IDS_ERR_OPEN_WRITE_REG "無法開啟系統登錄檔進行寫入，您必須以管理員身分執行此應用程式更新註冊表。"
-    IDS_ERR_READ_SET_KEY "讀取並設定系統登錄機碼「%s」時發生錯誤。"
-    IDS_ERR_WRITE_REGVALUE "讀取系統登錄值「HKEY_CURRENT_USER\\%s\\%s」時發生錯誤。"
+    IDS_ERR_READ_SET_KEY "讀取並設定系統登錄機碼「%ls」時發生錯誤。"
+    IDS_ERR_WRITE_REGVALUE "讀取系統登錄值「HKEY_CURRENT_USER\\%ls\\%ls」時發生錯誤。"
 
     /* importation */
-    IDS_ERR_IMPORT_EXISTS "已有名為「%s」的連線設定檔。"
+    IDS_ERR_IMPORT_EXISTS "已有名為「%ls」的連線設定檔。"
     IDS_ERR_IMPORT_FAILED "檔案匯入失敗。無法建立下列路徑。\n\n\
-%s\n\n請確定您有正確的系統權限。"
+%ls\n\n請確定您有正確的系統權限。"
     IDS_NFO_IMPORT_SUCCESS "已成功匯入檔案。"
-    IDS_NFO_IMPORT_OVERWRITE "A config named ""%s"" already exists. Do you want to replace it?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%s> as it is already in the global or local config directory"
+    IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "請按「確定」刪除「%s」連線設定檔的已存密碼。"
+    IDS_NFO_DELETE_PASS "請按「確定」刪除「%ls」連線設定檔的已存密碼。"
 
     /* Token password related */
     IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN - Token 密碼"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "請輸入 Token「%S」的密碼或 PIN"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "請輸入 Token「%hs」的密碼或 PIN"
 
     IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
     IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
@@ -524,6 +524,6 @@ Wintun driver will not work."
     IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %s  out: %s"
+    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
 
 END

--- a/save_pass.c
+++ b/save_pass.c
@@ -76,13 +76,13 @@ get_entropy(const WCHAR *config_name, char *e, int sz, BOOL generate)
     if (len > 0)
     {
         e[len-1] = '\0';
-        PrintDebug(L"Got entropy from registry: %S (len = %d)", e, len);
+        PrintDebug(L"Got entropy from registry: %hs (len = %d)", e, len);
         return;
     }
     else if (generate && GetRandomPassword(e, sz))
     {
         e[sz-1] = '\0';
-        PrintDebug(L"Created new entropy string : %S", e);
+        PrintDebug(L"Created new entropy string : %hs", e);
         if (SetConfigRegistryValueBinary(config_name, ENTROPY_DATA, (BYTE *)e, sz))
             return;
     }
@@ -167,7 +167,7 @@ recall_encrypted(const WCHAR *config_name, WCHAR *password, DWORD capacity, cons
         retval = 1;
     }
     else
-        PrintDebug(L"recall_encrypted: saved '%s' too long (len = %d bytes)", name, len);
+        PrintDebug(L"recall_encrypted: saved '%ls' too long (len = %d bytes)", name, len);
 
     SecureZeroMemory(out, len);
     LocalFree(out);

--- a/scripts.c
+++ b/scripts.c
@@ -53,7 +53,7 @@ RunPreconnectScript(connection_t *c)
 
     /* Cut off extention from config filename and add "_pre.bat" */
     int len = _tcslen(c->config_file) - _tcslen(o.ext_string) - 1;
-    _sntprintf_0(cmdline, _T("%s\\%.*s_pre.bat"), c->config_dir, len, c->config_file);
+    _sntprintf_0(cmdline, _T("%ls\\%.*ls_pre.bat"), c->config_dir, len, c->config_file);
 
     /* Return if no script exists */
     if (_tstat(cmdline, &st) == -1)
@@ -61,7 +61,7 @@ RunPreconnectScript(connection_t *c)
 
     // Create the filename of the logfile
     TCHAR script_log_filename[MAX_PATH];
-    _sntprintf_0(script_log_filename, _T("%s\\%s_pre.log"), o.log_dir, c->config_name);
+    _sntprintf_0(script_log_filename, _T("%ls\\%ls_pre.log"), o.log_dir, c->config_name);
 
     // Create the log file
     SECURITY_ATTRIBUTES sa;
@@ -124,7 +124,7 @@ RunConnectScript(connection_t *c, int run_as_service)
 
     /* Cut off extention from config filename and add "_up.bat" */
     int len = _tcslen(c->config_file) - _tcslen(o.ext_string) - 1;
-    _sntprintf_0(cmdline, _T("%s\\%.*s_up.bat"), c->config_dir, len, c->config_file);
+    _sntprintf_0(cmdline, _T("%ls\\%.*ls_up.bat"), c->config_dir, len, c->config_file);
 
     /* Return if no script exists */
     if (_tstat(cmdline, &st) == -1)
@@ -135,7 +135,7 @@ RunConnectScript(connection_t *c, int run_as_service)
 
     // Create the filename of the logfile
     TCHAR script_log_filename[MAX_PATH];
-    _sntprintf_0(script_log_filename, _T("%s\\%s_up.log"), o.log_dir, c->config_name);
+    _sntprintf_0(script_log_filename, _T("%ls\\%ls_up.log"), o.log_dir, c->config_name);
 
     // Create the log file
     SECURITY_ATTRIBUTES sa;
@@ -217,7 +217,7 @@ RunDisconnectScript(connection_t *c, int run_as_service)
 
     /* Cut off extention from config filename and add "_down.bat" */
     int len = _tcslen(c->config_file) - _tcslen(o.ext_string) - 1;
-    _sntprintf_0(cmdline, _T("%s\\%.*s_down.bat"), c->config_dir, len, c->config_file);
+    _sntprintf_0(cmdline, _T("%ls\\%.*ls_down.bat"), c->config_dir, len, c->config_file);
 
     /* Return if no script exists */
     if (_tstat(cmdline, &st) == -1)
@@ -228,7 +228,7 @@ RunDisconnectScript(connection_t *c, int run_as_service)
 
     // Create the filename of the logfile
     TCHAR script_log_filename[MAX_PATH];
-    _sntprintf_0(script_log_filename, _T("%s\\%s_down.log"), o.log_dir, c->config_name);
+    _sntprintf_0(script_log_filename, _T("%ls\\%ls_down.log"), o.log_dir, c->config_name);
 
     // Create the log file
     SECURITY_ATTRIBUTES sa;

--- a/tray.c
+++ b/tray.c
@@ -242,7 +242,7 @@ CreatePopupMenus()
                 AppendMenu(parent->menu, MF_POPUP, (UINT_PTR) this->menu, this->name);
                 this->pos = parent->children++;
 
-                PrintDebug(L"Submenu %d named %s added to parent %s with position %d",
+                PrintDebug(L"Submenu %d named %ls added to parent %ls with position %d",
                         i, this->name, parent->name, this->pos);
             }
         }
@@ -263,7 +263,7 @@ CreatePopupMenus()
             AppendMenu(parent->menu, MF_POPUP, (UINT_PTR) hMenuConn[i], c->config_name);
             c->pos = parent->children++;
 
-            PrintDebug(L"Config %d named %s added to submenu %s with position %d",
+            PrintDebug(L"Config %d named %ls added to submenu %ls with position %d",
                         i, c->config_name, parent->name, c->pos);
         }
 
@@ -601,7 +601,7 @@ SetMenuStatusById(int i, conn_state_t state)
         }
         CheckMenuItem(parent->menu, pos, MF_BYPOSITION | (checked ? MF_CHECKED : MF_UNCHECKED));
 
-        PrintDebug(L"Setting state of config %s checked = %d, parent %s, pos %d",
+        PrintDebug(L"Setting state of config %ls checked = %d, parent %ls, pos %d",
                     c->config_name, checked, (parent->id == 0)? L"Main Menu" : L"SubMenu", pos);
 
         if (checked) /* also check all parent groups */

--- a/viewlog.c
+++ b/viewlog.c
@@ -60,9 +60,9 @@ void ViewLog(int config)
     return;
   else
     PrintDebug (L"Opening log file using ShellExecute with verb = open failed"
-                 " for config '%s' (status = %lu)", o.conn[config].config_name, status);
+                 " for config '%ls' (status = %lu)", o.conn[config].config_name, status);
 
-  _sntprintf_0(filename, _T("%s \"%s\""), o.log_viewer, o.conn[config].log_path);
+  _sntprintf_0(filename, _T("%ls \"%ls\""), o.log_viewer, o.conn[config].log_path);
 
   /* fill in STARTUPINFO struct */
   GetStartupInfo(&start_info);
@@ -108,7 +108,7 @@ void EditConfig(int config)
   CLEAR (sd);
 
   /* Try first using file association */
-  _sntprintf_0(filename, L"%s\\%s", o.conn[config].config_dir, o.conn[config].config_file);
+  _sntprintf_0(filename, L"%ls\\%ls", o.conn[config].config_dir, o.conn[config].config_file);
 
   CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE); /* Safe to init COM multiple times */
   status = ShellExecuteW (o.hWnd, L"open", filename, NULL, o.conn[config].config_dir, SW_SHOWNORMAL);
@@ -116,9 +116,9 @@ void EditConfig(int config)
     return;
   else
     PrintDebug (L"Opening config file using ShellExecute with verb = open failed"
-                 " for config '%s' (status = %lu)", o.conn[config].config_name, status);
+                 " for config '%ls' (status = %lu)", o.conn[config].config_name, status);
 
-  _sntprintf_0(filename, _T("%s \"%s\\%s\""), o.editor, o.conn[config].config_dir, o.conn[config].config_file);
+  _sntprintf_0(filename, _T("%ls \"%ls\\%ls\""), o.editor, o.conn[config].config_dir, o.conn[config].config_file);
 
   /* fill in STARTUPINFO struct */
   GetStartupInfo(&start_info);


### PR DESCRIPTION
Commits 1 and 2 are minor bug-fixes.
Commit 3:  Some wide strings are truncated to single character when built with latest mingw-w64 because of changes related to implicit enabling of __USE_MINGW_ANSI_STDIO with _GNU_SOURCE. 

Assigned IP for example: <img width="132" alt="truncation" src="https://user-images.githubusercontent.com/3981391/138582239-4c02565f-2953-4281-8186-fd5f62e59885.png">

Instead of a quick-fix,  use standard "%ls" or "%hs" instead of %s and %S for wide strings everywhere. Majority of the changes (~970 lines) are in resource files made using sed. The rest (~80 lines) edited manually.