### PR TITLE
Import URL: some enhancements

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -466,22 +466,23 @@ CheckFileAccess (const TCHAR *path, int access)
     return ret;
 }
 
-/*
- * Convert a NUL terminated utf8 string to widechar. The caller must free
+/**
+ * Convert a NUL terminated narrow string to wide string using
+ * specified codepage. The caller must free
  * the returned pointer. Return NULL on error.
  */
 WCHAR *
-Widen(const char *utf8)
+WidenEx(UINT codepage, const char *str)
 {
     WCHAR *wstr = NULL;
-    if (!utf8)
+    if (!str)
         return wstr;
 
-    int nch = MultiByteToWideChar(CP_UTF8, 0, utf8, -1, NULL, 0);
+    int nch = MultiByteToWideChar(codepage, 0, str, -1, NULL, 0);
     if (nch > 0)
         wstr = malloc(sizeof(WCHAR) * nch);
     if (wstr)
-        nch =  MultiByteToWideChar(CP_UTF8, 0, utf8, -1, wstr, nch);
+        nch =  MultiByteToWideChar(codepage, 0, str, -1, wstr, nch);
 
     if (nch == 0 && wstr)
     {
@@ -490,6 +491,15 @@ Widen(const char *utf8)
     }
 
     return wstr;
+}
+
+/*
+ * Same as WidenEx with codepage = UTF8
+ */
+WCHAR *
+Widen(const char *utf8)
+{
+    return WidenEx(CP_UTF8, utf8);
 }
 
 /* Return false if input contains any characters in exclude */

--- a/misc.c
+++ b/misc.c
@@ -39,6 +39,7 @@
 #include "main.h"
 #include "openvpn_config.h"
 #include "openvpn-gui-res.h"
+#include "tray.h"
 
 /*
  * Helper function to do base64 conversion through CryptoAPI
@@ -692,7 +693,7 @@ ImportConfigFile(const TCHAR* source)
        return;
     }
 
-    ShowLocalizedMsg(IDS_NFO_IMPORT_SUCCESS);
+    ShowTrayBalloon(LoadLocalizedString(IDS_NFO_IMPORT_SUCCESS), fileName);
     /* rescan file list after import */
     BuildFileList();
 }

--- a/misc.h
+++ b/misc.h
@@ -46,6 +46,7 @@ BOOL CheckFileAccess (const TCHAR *path, int access);
 BOOL Base64Encode(const char *input, int input_len, char **output);
 int Base64Decode(const char *input, char **output);
 WCHAR *Widen(const char *utf8);
+WCHAR *WidenEx(UINT codepage, const char *utf8);
 BOOL validate_input(const WCHAR *input, const WCHAR *exclude);
 /* Concatenate two wide strings with a separator */
 void wcs_concat2(WCHAR *dest, int len, const WCHAR *src1, const WCHAR *src2, const WCHAR *sep);


### PR DESCRIPTION
As suggested in #450, parse Content-disposition: header for filename. If not found fallback to parsing the file content for metadata as before. In case of import from AS, no change.

May be tested using the following URLs in the "Import from URL" dialog:
(i) https://webhost1.sansel.ca/zbcm_4Lin4hyxkknkOLqWgdkWAf7mOmv/test-8859.php
(ii)https://webhost1.sansel.ca/zbcm_4Lin4hyxkknkOLqWgdkWAf7mOmv/test-utf8.php

The first one sets `filename="test-8859-with-e-acute-é.conf"` with an iso-8859 e-acute character in name, (ii) sets `filename*=utf-8''test-utf8-with-e-acute-é.conf` in addition encoded as utf8. The parser should pick the utf-8 name in the latter case. Note that the extension in the file name is replaced by whatever extension is in effect in the GUI (".ovpn" by default) during import.

The first commit is a minor change in the way successful import is notified -- use balloon notification instead of a message box and show the imported profile name as well.