### PR TITLE
Fix crash when clicking on tray icon after importing the first profile

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -704,6 +704,6 @@ ImportConfigFile(const TCHAR* source)
     }
 
     ShowTrayBalloon(LoadLocalizedString(IDS_NFO_IMPORT_SUCCESS), fileName);
-    /* rescan file list after import */
-    BuildFileList();
+    /* destroy popup menus, based on existing num_configs, rescan file list and recreate menus */
+    RecreatePopupMenus();
 }

--- a/tray.c
+++ b/tray.c
@@ -332,7 +332,7 @@ DestroyPopupMenus()
 }
 
 /* Rescan config folders and recreate popup menus */
-static void
+void
 RecreatePopupMenus(void)
 {
     DestroyPopupMenus();

--- a/tray.h
+++ b/tray.h
@@ -45,6 +45,7 @@
 #define IDM_CLEARPASSMENU       (1 + IDM_PASSPHRASEMENU)
 #define IDM_RECONNECTMENU       (1 + IDM_CLEARPASSMENU)
 
+void RecreatePopupMenus(void);
 void CreatePopupMenus();
 void OnNotifyTray(LPARAM);
 void OnDestroyTray(void);


### PR DESCRIPTION
When clicking on tray icon, menu items are deleted and then recreated.
Deletion uses o.num_config:

    for (i = 0; i < o.num_configs; i++)
        DestroyMenu(hMenuConn[i]);

Commit 8e4183f9 ("Add '--command import' command line option")
added BuildFileList() call which modifies o.num_configs
but doesn't touch menus. When clicking on tray icon after import,
abovementioned code attemps to access invalid item in hMenuConn array
and crashes when this is the first imported profile and hMenuConn is NULL.
In other DestryMenu is called with invalid argument.

Fix by recreating popup menus instead of just rescan file list -
this will first delete menus with correct o.num_config value.

Signed-off-by: Lev Stipakov <lev@openvpn.net>