### PR TITLE
Show a prompt during profile import using --import

### DIFF
--- a/as.c
+++ b/as.c
@@ -682,7 +682,7 @@ ImportProfileFromURLDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lPa
             if (downloaded) {
                 EndDialog(hwndDlg, LOWORD(wParam));
 
-                ImportConfigFile(path);
+                ImportConfigFile(path, false); /* do not prompt user */
                 _wunlink(path);
             }
             return TRUE;

--- a/main.c
+++ b/main.c
@@ -471,7 +471,7 @@ HandleCopyDataMessage(const COPYDATASTRUCT *copy_data)
     }
     else if(copy_data->dwData == WM_OVPN_IMPORT && str)
     {
-        ImportConfigFile(str);
+        ImportConfigFile(str, true); /* prompt user */
     }
     else if (copy_data->dwData == WM_OVPN_NOTIFY)
     {
@@ -531,7 +531,7 @@ LRESULT CALLBACK WindowProcedure (HWND hwnd, UINT message, WPARAM wParam, LPARAM
       /* if '--import' was specified, do it now */
       if (o.action == WM_OVPN_IMPORT && o.action_arg)
       {
-        ImportConfigFile(o.action_arg);
+        ImportConfigFile(o.action_arg, true); /* prompt user */
       }
 
       if (!AutoStartConnections()) {
@@ -794,7 +794,7 @@ ImportConfigFileFromDisk()
 
     if (GetOpenFileName(&fn))
     {
-        ImportConfigFile(source);
+        ImportConfigFile(source, false); /* do not prompt user */
     }
 }
 

--- a/misc.c
+++ b/misc.c
@@ -646,7 +646,7 @@ open_url(const wchar_t *url)
 extern options_t o;
 
 void
-ImportConfigFile(const TCHAR* source)
+ImportConfigFile(const TCHAR* source, bool prompt_user)
 {
     TCHAR fileName[MAX_PATH] = _T("");
     TCHAR ext[MAX_PATH] = _T("");
@@ -683,6 +683,12 @@ ImportConfigFile(const TCHAR* source)
     }
     else
     {
+        if (prompt_user
+            && ShowLocalizedMsgEx(MB_YESNO, NULL, TEXT(PACKAGE_NAME),
+                              IDS_NFO_IMPORT_SOURCE, fileName) == IDNO)
+        {
+            return;
+        }
         WCHAR dest_dir[MAX_PATH+1];
         swprintf(dest_dir, MAX_PATH, L"%ls\\%ls", o.config_dir, fileName);
         dest_dir[MAX_PATH] = L'\0';

--- a/misc.h
+++ b/misc.h
@@ -72,7 +72,7 @@ DWORD md_final(md_ctx *ctx, BYTE *md);
 /* Open specified http/https URL using ShellExecute. */
 BOOL open_url(const wchar_t *url);
 
-void ImportConfigFile(const TCHAR* path);
+void ImportConfigFile(const TCHAR* path, bool prompt_user);
 
 /*
  * Helper function to convert UCS-2 text from a dialog item to UTF-8.

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -339,6 +339,7 @@
 #define IDS_NFO_IMPORT_OVERWRITE        1904
 #define IDS_ERR_IMPORT_SOURCE           1905
 #define IDS_ERR_IMPORT_ACCESS           1906
+#define IDS_NFO_IMPORT_SOURCE           1907
 
 /* Save password related messages */
 #define IDS_NFO_DELETE_PASS             2001

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -507,6 +507,7 @@ jednou jako správce, aby se registr aktualizoval."
 %ls\n\nUjistěte se prosím, že máte potřebná oprávnění."
     IDS_NFO_IMPORT_SUCCESS "Konfigurace úspěšně importována."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -510,6 +510,7 @@ als Administrator ausführen, um die Registry zu aktualisieren."
 %ls\n\nVergewissern Sie sich, dass Sie die erforderlichen Berechtigungen besitzen."
     IDS_NFO_IMPORT_SUCCESS "Die Konfigurationsdatei wurde erfolgreich importiert."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -507,6 +507,7 @@ en gang som administrator for at opdatere registret."
 %ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -521,6 +521,7 @@ once as Administrator to update the registry."
 %ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -504,6 +504,7 @@ nuevo como Administrator para actualizar el registro."
 %ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -510,6 +510,7 @@ once as Administrator to update the registry."
 %ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -508,6 +508,7 @@ ajaa ylläpitäjän oikeuksin, jotta se saa lisättyä rekisteriin tietoja."
 %ls\n\nVarmista, että sinulla on tarvittavat tiedosto-oikeudet."
     IDS_NFO_IMPORT_SUCCESS "Asetustiedoston tuonti onnistui."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -507,6 +507,7 @@ en tant qu'Administrator pour mettre à jour la base de registre."
 %ls\n\nAssurez-vous d'avoir les bonnes autorisations."
     IDS_NFO_IMPORT_SUCCESS "Fichier importé avec succès."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -507,6 +507,7 @@ una volta che l'amministratore ha aggiornato il registro."
 %ls\n\nControlla di avere i permessi giusti."
     IDS_NFO_IMPORT_SUCCESS "File importato con successo."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -507,6 +507,7 @@ OpenVPNがインストールされていない可能性があります。"
 %ls\n\n適切な権限があることを確認してください。"
     IDS_NFO_IMPORT_SUCCESS "ファイルが正しくインポートされました。"
     IDS_NFO_IMPORT_OVERWRITE "設定 ""%ls"" は既に存在しています。上書きしますか？"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "<%ls> はグローバル/ローカル設定フォルダにあるためインポートできません。"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -505,6 +505,7 @@ Administrator 권한으로 이 프로그램을 실행해야 합니다."
 %ls\n\n올바른 권한을 가지고 있는지 확인 해 보십시오."
     IDS_NFO_IMPORT_SUCCESS "파일 불러오기 성공."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -508,6 +508,7 @@ om de registerinstellingen te updaten."
 %ls\n\nControleer of de juiste rechten gebruikt worden."
     IDS_NFO_IMPORT_SUCCESS "Importeren bestand gelukt."
     IDS_NFO_IMPORT_OVERWRITE "Een configuratie met de naam ""%ls"" bestaat al. Wilt u deze vervangen?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Het bestand <%ls> kan niet worden geïmporteerd omdat het al in de globale of lokale configuratiemap bestaat"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -498,6 +498,7 @@ Wintun driver will not work."
 %ls\n\nDet kan hende du trenger administrator-rettigheter for å importere filer."
     IDS_NFO_IMPORT_SUCCESS "Importeringen var vellykket."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -506,6 +506,7 @@ z prawami administratora aby uaktualnić rejestr."
 %ls\n\nUpewnij się, że posiadasz właściwe uprawnienia."
     IDS_NFO_IMPORT_SUCCESS "Plik został zaimportowany."
     IDS_NFO_IMPORT_OVERWRITE "Konfiguracja o nazwie ""%ls"" już istnieje. Czy chcesz ją zamienić?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Nie można zaimportować pliku <%ls> ponieważistnieje on już w globalnym lub lokalnym katalogu konfiguracji"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -506,6 +506,7 @@ uma vez como Administrador para alterar o registro."
 %ls\n\nCertifique-se de que você possui as permissões necessárias."
     IDS_NFO_IMPORT_SUCCESS "Arquivo importado com sucesso."
     IDS_NFO_IMPORT_OVERWRITE "Uma configuração nomeada ""%ls"" já existe. Você deseja substituí-la?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Não é possível importar o arquivo <%ls>, pois ele já está na pasta de configurações global ou local"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -507,6 +507,7 @@ OpenVPN, возможно, не установлен."
 Убедитесь, что у вас есть необходимые привилегии для данного действия."
     IDS_NFO_IMPORT_SUCCESS "Импорт файла успешно завершен."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -501,6 +501,7 @@ Wintun driver ska inte fungera."
 %ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -506,6 +506,7 @@ sistem yönetici haklarına sahip olmanız gerekmektedir.."
 %ls\n\nMake sure you have the right permissions."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -507,6 +507,7 @@ OpenVPN, можливо, не встановлений."
 Перевірте, що в вас є необхідні права для цієї операції."
     IDS_NFO_IMPORT_SUCCESS "Імпорт файла успішно завершено."
     IDS_NFO_IMPORT_OVERWRITE "Конфігурація з назвою ""%ls"" вже існує. Замінити?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Не вдається імпортувати файл <%ls>, оскільки він уже є в глобальному або локальному каталозі конфігурації"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -508,6 +508,7 @@ Wintun driver will not work."
 %ls\n\n请确定您有正确的系统权限。"
     IDS_NFO_IMPORT_SUCCESS "已成功导入文件。"
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -508,6 +508,7 @@ Wintun driver will not work."
 %ls\n\n請確定您有正確的系統權限。"
     IDS_NFO_IMPORT_SUCCESS "已成功匯入檔案。"
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
+    IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
     IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
     IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
 


### PR DESCRIPTION
The user is prompted with a message showing the config
name that will be imported. The user can accept or cancel
the operation.

If the user was already prompted for over-write permission
because a config with the same name exists, no further dialog
is shown.

Import using the menu (Import File...) is not affected.

Rationale:
We want to set "Import" as the default verb for the context
menu of .ovpn files. This will allow import of configs by
double-click. Also when .ovpn file is downloaded using a browser,
setting the default browser action to "open" will result in an import.
In such cases a silent import action could be surprising, and a
prompt showing what is being imported could provide a better UX.

On the flip-side, the prompt/dialog will also be shown when import
is done from the context menu of .ovpn by "right click and
choose import" or when "openvpn-gui.exe --import foo"
or "openvpn-gui.exe --command import foo" is executed. As import
is an action that does not result in an immediately visible result
(unlike, say, edit or print), a prompt requiring user action is of
some value even in these cases. At worst it's a minor annoyance.

See also: OpenVPN/openvpn-build#227 and discussions there-in
