### PR TITLE
Fix broken "change password" functionality

### DIFF
--- a/passphrase.c
+++ b/passphrase.c
@@ -28,6 +28,11 @@
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/pkcs12.h>
+
+#if defined(_MSC_VER) && !defined(_M_ARM64)
+#include <openssl/applink.c>
+#endif
+
 #endif
 
 #include <windows.h>


### PR DESCRIPTION
When we link with natively-built OpenSSL .DLLs
(not cross compiled with MinGW), we are expected to include
applink.c, which provides glue between OpenSSL BIO layer
and compiler run-time. This doesn't apply to ARM64.

Failure to do that results in "no OPENSSL_Applink" fatal error
during password change.

See the corresponding fix in openvpn2:

https://sourceforge.net/p/openvpn/mailman/message/37361982/
Signed-off-by: Lev Stipakov <lev@openvpn.net>