### PR TITLE
Fix passing username for CRV1 response

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -86,4 +86,7 @@ GetDlgItemTextUtf8(HWND hDlg, int id, LPSTR* str, int* len);
  */
 void set_openssl_env_vars(void);
 
+/* Return escaped copy of a string */
+char *escape_string(const char *str);
+
 #endif

--- a/openvpn.c
+++ b/openvpn.c
@@ -733,13 +733,13 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             {
                 /* send username */
                 template = "username \"Auth\" \"%s\"";
-                fmt = malloc(strlen(template) + strlen(param->user));
+                char *username = escape_string(param->user);
+                fmt = malloc(strlen(template) + strlen(username));
 
-                if (fmt)
+                if (fmt && username)
                 {
-                    sprintf(fmt, template, param->user);
+                    sprintf(fmt, template, username);
                     ManagementCommand(param->c, fmt, NULL, regular);
-                    free(fmt);
                 }
                 else /* no memory? send an emty username and let it error out */
                 {
@@ -747,6 +747,8 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
                         L"Out of memory: sending a generic username for dynamic CR", false);
                     ManagementCommand(param->c, "username \"Auth\" \"user\"", NULL, regular);
                 }
+                free(fmt);
+                free(username);
 
                 /* password template */
                 template = "password \"Auth\" \"CRV1::%s::%%s\"";


### PR DESCRIPTION
Escape the username string before passing to management
interface. For other dialogs this is already done.

Move string-escape to a function and process the username
through it.
Also escape space, single quote in addition to double quote
and backslash.

Reported by: Jakob Curdes <jc@info-systems.de>

Signed-off-by: Selva Nair <selva.nair@gmail.com>
Issue: #482 