### PR TITLE
CMakePresets.json: use MSVC generator for ARM64 builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,11 +38,10 @@
         },
         {
             "name": "arm64",
-            "generator": "Ninja",
+            "generator": "Visual Studio 16 2019",
             "hidden": true,
             "architecture": {
-                "value": "arm64",
-                "strategy": "external"
+                "value": "arm64"
             }
         },
         {


### PR DESCRIPTION
Sadly, CMake/Ninja combo doesn't work well for ARM64
(similar to
https://stackoverflow.com/questions/47581784/building-a-x86-application-with-cmake-ninja-and-clang-on-x64-windows)
- it silently produces x64 binaries instead of arm64.

Switch to slower MSVC generator.

Signed-off-by: Lev Stipakov <lev@openvpn.net>