### PR TITLE
Support sending multiple commands to a running instance 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,10 @@ it using the command line interface using the following syntax::
 
     openvpn-gui.exe --command *cmd* [*args*]
 
+Or::
+
+    openvpn-gui.exe --cmd [*args*]
+
 Currently supported *cmds* are
 
 connect ``config-name``
@@ -162,6 +166,10 @@ disconnect ``config-name``
 reconnect ``config-name``
      Disconnect and then reconnect the configuration named *config-name*
      if connected.
+
+status ``config-name``
+     Show the status window of the configuration named *config-name*
+     if connected or is in the process of connecting.
 
 disconnect\_all
      Disconnect all active connections.
@@ -178,9 +186,10 @@ rescan
 import ``path``
      Import the config file pointed to by ``path``.
 
-If no running instance of the GUI is found, these commands do nothing
-except for *--command connect config-name* which gets interpreted
-as *--connect config-name*
+If no running instance of the GUI is found, these commands have no
+effect except for *connect*, *import*, and *silent_connection* which
+get interpreted resepctively as *--connect*, *--import*, and
+*--silent_connection*.
 
 Registry Values affecting the OpenVPN GUI operation
 ***************************************************

--- a/main.c
+++ b/main.c
@@ -258,9 +258,9 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
   {
       for (struct action *a = o.action_list.head; a; a = a->next)
       {
-          if (a->type == WM_OVPN_START)
+          if (a->type == WM_OVPN_START || a->type == WM_OVPN_SILENT)
           {
-              PrintDebug(L"Instance 1: Called with --command connect xxx. Treating it as --connect xxx");
+              ; /* pass these could get set by --connect or --silent_connection */
           }
           else if (a->type == WM_OVPN_IMPORT)
           {
@@ -268,8 +268,8 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
           }
           else
           {
-              MsgToEventLog(EVENTLOG_ERROR_TYPE, L"Called with --command when no previous instance available (action type = %d arg = %s", a->type, a->arg ? a->arg : L"");
-              exit(OVPN_EXITCODE_ERROR);
+              /* log an error, but do not treat as fatal */
+              MsgToEventLog(EVENTLOG_ERROR_TYPE, L"Called with options relevant only when a previous instance is available (action type = %d arg = %s", a->type, a->arg ? a->arg : L"");
           }
       }
   }

--- a/main.c
+++ b/main.c
@@ -100,7 +100,7 @@ VerifyAutoConnections()
  * to the running instance and return success or error.
  */
 static int
-NotifyRunningInstance()
+NotifyRunningInstance(int action_type, wchar_t *action_arg)
 {
     /* Check if a previous instance has a window initialized
      * Even if we are not the first instance this may return null
@@ -110,22 +110,16 @@ NotifyRunningInstance()
     int exit_code = 0;
     if (hwnd_master)
     {
-        /* GUI up and running -- send a message if any action is pecified,
-           else show the balloon */
+        /* GUI up and running -- send a message for the specified action */
         COPYDATASTRUCT config_data = {0};
         int timeout = 30*1000;             /* 30 seconds */
-        if (!o.action)
+        config_data.dwData = action_type;
+        if (action_arg)
         {
-            o.action = WM_OVPN_NOTIFY;
-            o.action_arg = LoadLocalizedString(IDS_NFO_CLICK_HERE_TO_START);
+            config_data.cbData = (wcslen(action_arg)+1)*sizeof(action_arg[0]);
+            config_data.lpData = (void *) action_arg;
         }
-        config_data.dwData = o.action;
-        if (o.action_arg)
-        {
-            config_data.cbData = (wcslen(o.action_arg)+1)*sizeof(o.action_arg[0]);
-            config_data.lpData = (void *) o.action_arg;
-        }
-        PrintDebug(L"Instance 2: called with action %d : %ls", o.action, o.action_arg);
+        PrintDebug(L"Instance 2: called with action %d : %ls", action_type, action_arg);
         if (!SendMessageTimeout (hwnd_master, WM_COPYDATA, 0,
                                  (LPARAM) &config_data, 0, timeout, NULL))
         {
@@ -245,23 +239,40 @@ int WINAPI _tWinMain (HINSTANCE hThisInstance,
 
   if (!first_instance)
   {
-      int res = NotifyRunningInstance();
-      exit(res);
+      int exit_code = 0;
+      struct action *a = o.action_list.head;
+      if (!a) /* no actions -- send a balloon notification */
+      {
+          exit_code = NotifyRunningInstance(WM_OVPN_NOTIFY,
+                LoadLocalizedString(IDS_NFO_CLICK_HERE_TO_START));
+      }
+      else while (a)
+      {
+          int res = NotifyRunningInstance(a->type, a->arg);
+          exit_code = res > exit_code ? res : exit_code;
+          a = a->next;
+      }
+      exit(exit_code);
   }
-  else if (o.action == WM_OVPN_START)
+  else
   {
-      PrintDebug(L"Instance 1: Called with --command connect xxx. Treating it as --connect xxx");
+      for (struct action *a = o.action_list.head; a; a = a->next)
+      {
+          if (a->type == WM_OVPN_START)
+          {
+              PrintDebug(L"Instance 1: Called with --command connect xxx. Treating it as --connect xxx");
+          }
+          else if (a->type == WM_OVPN_IMPORT)
+          {
+              ; /* pass -- import is handled after Window initialization */
+          }
+          else
+          {
+              MsgToEventLog(EVENTLOG_ERROR_TYPE, L"Called with --command when no previous instance available (action type = %d arg = %s", a->type, a->arg ? a->arg : L"");
+              exit(OVPN_EXITCODE_ERROR);
+          }
+      }
   }
-  else if (o.action == WM_OVPN_IMPORT)
-  {
-     ; /* pass -- import is handled after Window initialization */
-  }
-  else if (o.action)
-  {
-      MsgToEventLog(EVENTLOG_ERROR_TYPE, L"Called with --command when no previous instance available");
-      exit(OVPN_EXITCODE_ERROR);
-  }
-
   if (!CheckVersion()) {
     exit(1);
   }
@@ -528,9 +539,12 @@ LRESULT CALLBACK WindowProcedure (HWND hwnd, UINT message, WPARAM wParam, LPARAM
         CheckServiceStatus();	// Check if service is running or not
 
       /* if '--import' was specified, do it now */
-      if (o.action == WM_OVPN_IMPORT && o.action_arg)
+      for (struct action *a = o.action_list.head; a ; a = a->next)
       {
-        ImportConfigFile(o.action_arg, true); /* prompt user */
+          if (a->type == WM_OVPN_IMPORT && a->arg)
+          {
+              ImportConfigFile(a->arg, true); /* prompt user */
+          }
       }
 
       if (!AutoStartConnections()) {

--- a/options.c
+++ b/options.c
@@ -36,6 +36,7 @@
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <combaseapi.h>
+#include <assert.h>
 
 #include "options.h"
 #include "main.h"
@@ -81,9 +82,32 @@ ExpandOptions (void)
     ExpandString (o.install_path, _countof(o.install_path));
 }
 
+static void
+add_action(struct action_list *al, DWORD type, wchar_t *arg)
+{
+    struct action *a = calloc(sizeof(*a), 1);
+    if (!a)
+    {
+        ErrorExit(1, L"Out of memory while parsing command line");
+    }
+    a->type = type;
+    a->arg = arg;
+    if (!al->head)  /* first entry */
+    {
+        al->head = a;
+    }
+    else
+    {
+        assert(al->tail);
+        al->tail->next = a;
+    }
+    al->tail = a;
+}
+
 static int
 add_option(options_t *options, int i, TCHAR **p)
 {
+    struct action_list *al = &options->action_list;
     if (streq(p[0], _T("help")))
     {
         TCHAR caption[200];
@@ -112,14 +136,10 @@ add_option(options_t *options, int i, TCHAR **p)
             options->auto_connect = tmp;
         }
         options->auto_connect[options->num_auto_connect++] = p[1];
-        /* Treat the first connect option to also mean --command connect profile.
+        /* Treat connect option to also mean --command connect profile.
          * This gets used if we are not the first instance.
          */
-        if (options->num_auto_connect == 1)
-        {
-            options->action = WM_OVPN_START;
-            options->action_arg = p[1];
-        }
+        add_action(al, WM_OVPN_START, p[1]);
     }
     else if (streq(p[0], L"import") && p[1])
     {
@@ -127,8 +147,7 @@ add_option(options_t *options, int i, TCHAR **p)
         /* This is interpreted directly or as a command depending
          * on we are the first instance or not. So, set as an action.
          */
-        options->action = WM_OVPN_IMPORT;
-        options->action_arg = p[1];
+        add_action(al, WM_OVPN_IMPORT, p[1]);
     }
     else if (streq(p[0], _T("exe_path")) && p[1])
     {
@@ -248,52 +267,44 @@ add_option(options_t *options, int i, TCHAR **p)
         if (streq(p[1], _T("connect")) && p[2])
         {
             /* Treat this as "--connect profile" in case this is the first instance */
-            add_option(options, i, &p[1]);
-            ++i;
-            options->action = WM_OVPN_START;
-            options->action_arg = p[2];
+            i = add_option(options, i, &p[1]);
         }
         else if (streq(p[1], _T("disconnect")) && p[2])
         {
             ++i;
-            options->action = WM_OVPN_STOP;
-            options->action_arg = p[2];
+            add_action(al, WM_OVPN_STOP, p[2]);
         }
         else if (streq(p[1], _T("reconnect")) && p[2])
         {
             ++i;
-            options->action = WM_OVPN_RESTART;
-            options->action_arg = p[2];
+            add_action(al, WM_OVPN_RESTART, p[2]);
         }
         else if (streq(p[1], _T("status")) && p[2])
         {
             ++i;
-            options->action = WM_OVPN_SHOWSTATUS;
-            options->action_arg = p[2];
+            add_action(al, WM_OVPN_SHOWSTATUS, p[2]);
         }
         else if (streq(p[1], L"import") && p[2])
         {
             ++i;
-            options->action = WM_OVPN_IMPORT;
-            options->action_arg = p[2];
+            add_action(al, WM_OVPN_IMPORT, p[2]);
         }
         else if (streq(p[1], _T("silent_connection")))
         {
             ++i;
-            options->action = WM_OVPN_SILENT;
-            options->action_arg = p[2] ? p[2] : _T("1");
+            add_action(al, WM_OVPN_SILENT, p[2] ? p[2] : L"1");
         }
         else if (streq(p[1], _T("disconnect_all")))
         {
-            options->action = WM_OVPN_STOPALL;
+            add_action(al, WM_OVPN_STOPALL, NULL);
         }
         else if (streq(p[1], _T("exit")))
         {
-            options->action = WM_OVPN_EXIT;
+            add_action(al, WM_OVPN_EXIT, NULL);
         }
         else if (streq(p[1], _T("rescan")))
         {
-            options->action = WM_OVPN_RESCAN;
+            add_action(al, WM_OVPN_RESCAN, NULL);
         }
         else
         {

--- a/options.h
+++ b/options.h
@@ -158,6 +158,17 @@ struct connection {
     struct echo_msg echo_msg;      /* Message echo-ed from server or client config and related data */
 };
 
+/* Command actions to be send to running instance */
+struct action {
+    int type;
+    wchar_t *arg;
+    struct action *next;
+};
+
+struct action_list {
+    struct action *head, *tail;
+};
+
 /* All options used within OpenVPN GUI */
 typedef struct {
     /* Array of configs to autostart */
@@ -223,8 +234,7 @@ typedef struct {
     unsigned int dpi_scale;
     COLORREF clr_warning;
     COLORREF clr_error;
-    int action;            /* action to send to a running instance */
-    TCHAR *action_arg;
+    struct action_list action_list; /* list of actions to send to a running instance */
     HANDLE session_semaphore;
     HANDLE event_log;
 } options_t;

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -392,7 +392,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Volby k použití explicitního nastavení namísto výchozího z registru:\n\
 --exe_path\t\t: Cesta k openvpn.exe.\n\

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -394,7 +394,10 @@ Unterstützte Befehle:\n\
     status cnn           \t\t: Zeige das Satusfenster der Konfiguration ""cnn"", falls verbunden\n\
     silent_connection [0|1]\t: Schalte die silent_connection-Option ein (1) oder aus (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Option zum Überschreiben der Registry Einstellungen:\n\
 --exe_path\t\t: Pfad zu openvpn.exe.\n\

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -391,7 +391,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Parametre som vil tilsidesætte indstillinger i registreringsdatabasen:\n\
 --exe_path\t\t: Sti til openvpn.exe.\n\

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -406,7 +406,10 @@ Supported commands:\n\
     status cnn             \t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Options to override registry settings:\n\
 --exe_path\t\t: Path to openvpn.exe.\n\

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -388,7 +388,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Opciones para sobreescribir opciones del registro:\n\
 --exe_path\t\t: Ruta a openvpn.exe.\n\

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -394,7 +394,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Options to override registry settings:\n\
 --exe_path\t\t: Path to openvpn.exe.\n\

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -391,7 +391,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Rekisterin asetukset kumoavat valinnat:\n\
 --exe_path\t\t: Polku openvpn.exe -tiedostoon.\n\

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -391,7 +391,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Options pour corriger la configuration de registre:\n\
 --exe_path\t\t: Chemin vers openvpn.exe.\n\

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -391,7 +391,10 @@ Comandi supportati:\n\
     status cnn           \t\t: mostra lo stato della configurazione ""cnn"" se connessa\n\
     silent_connection [0|1]\t: imposta la flag silent_connection on (1) oppure off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tEsempio: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Opzioni per ignorare il registro di sistema:\n\
 --exe_path\t\t: Percorso di openvpn.exe.\n\

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -392,7 +392,10 @@ OpenVPN GUIをこのまま終了しますか？"
     status cnn           \t\t: 設定 ""cnn"" のステータスウィンドウを表示（接続時のみ）\n\
     silent_connection [0|1]\t: サイレント接続フラグをON (1) または OFF (0) に設定する\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\t例: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 各オプションはレジストリの設定に優先されます:\n\
 --exe_path\t\t: openvpn.exeへのパス。\n\

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -389,7 +389,10 @@ OpenVPN GUI를 이대로 종료 하겠습니까?"
     status cnn           \t\t: 연결 되어 있는 ""cnn"" 설정의 상태를 표시\n\
     silent_connection [0|1]\t: silent_connection 플래그를 on(1) 또는 off(0)로 설정\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\t예제: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 각 옵션은 레지스트리 설정보다 우선 합니다:\n\
 --exe_path\t\t: openvpn.exe 경로.\n\

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -392,7 +392,10 @@ Ondersteunde commando's:\n\
     status cnn           \t\t: het status-scherm van de configuratie ""cnn"" laten zien als de verbinding is gemaakt\n\
     silent_connection [0|1]\t: de vlag ""silent_connection"" aan- (1) of uitzetten (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tVoorbeeld: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Instellingen die de registerinstellingen overschrijven:\n\
 --exe_path\t\t: Pad naar openvpn.exe.\n\

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -386,7 +386,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Parametere som vil overstyre innstillinger gjort i registeret:\n\
 --exe_path\t\t: Sti til openvpn.exe.\n\

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -390,7 +390,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Opcje oddalające ustawienia rejestru:\n\
 --exe_path\t\t: Ścieżka do openvpn.exe.\n\

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -390,7 +390,10 @@ Supported commands:\n\
     status cnn           \t\t: mostra a janela de status da configuração ""cnn"", se conectado\n\
     silent_connection [0|1]\t: define o sinalizador silent_connection em ligado (1) ou desligado (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExemplo: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Opções para sobrescrever opções do registro:\n\
 --exe_path\t\t: Caminho para openvpn.exe.\n\

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -391,7 +391,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Опции для переназначения настроек реестра:\n\
 --exe_path\t\t: Путь к openvpn.exe.\n\

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -387,7 +387,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Parametrar som ersätter inställningar gjorda i registret:\n\
 --exe_path\t\t: Path till openvpn.exe.\n\

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -390,7 +390,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Registry ayarları için:\n\
 --exe_path\t\t: openvpn.exe yolu.\n\

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -390,7 +390,10 @@ BEGIN
     status cnn           \t\t: показати вікно стану конфігурації ""cnn"", якщо з'єднання активне\n\
     silent_connection [0|1]\t: щоб встановити режим silent_connection, вкажіть (1), Щоб вимкнути, вкажіть (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tНаприклад: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 Опції спрямовані на переконфігурацію налаштувань реєстру:\n\
 --exe_path\t\t: Розташування openvpn.exe.\n\

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -393,7 +393,10 @@ BEGIN
     status cnn           \t\t: 如果已连接,显示配置""cnn""的状态\n\
     silent_connection [0|1]\t: 设置静默连接开启 (1) 或者关闭 (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\t例如: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 可覆盖系统注册表设定的选项:\n\
 --exe_path\t\t: openvpn.exe 的路径。\n\

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -393,7 +393,10 @@ Supported commands:\n\
     status cnn           \t\t: show the status window of config ""cnn"" if connected\n\
     silent_connection [0|1]\t: set the silent_connection flag on (1) or off (0)\n\
     import path          \t\t: Import the config file pointed to by path\n\
+    rescan               \t\t: Rescan config directories for config files\n\
 \t\t\tExample: openvpn-gui.exe --command disconnect myconfig\n\
+    As a shortcut, --command cmd may be simplified to --cmd\n\
+    e.g., --exit is the same as --command exit.\n\
 \n\
 可覆蓋系統登錄表設定的選項:\n\
 --exe_path\t\t: openvpn.exe 的路徑。\n\


### PR DESCRIPTION
Make it possible to use --command action arg multiple times.
See Trac #498
Summary of commits:
(i) Usages like `--command connect vpn1 --command connect vpn2 --command disconnect vpn3 ` when the GUI is already running is now supported.
(ii) When sending multiple commands to a running instance of the GUI, simplify usage of the form
`openvpn-gui.exe --command connect vpn1 --command connect vpn2  --command disconnect vpn3`
by omitting `command` so that one could also write
`openvpn-gui.exe --connect vpn1 --connect vpn2 --disconnect vpn3`  For connect this already worked, but do so for other commands too.
(iii) copy resource file changes to all langauge files