### PR TITLE
Automatically choose management interface port number

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -89,4 +89,13 @@ void set_openssl_env_vars(void);
 /* Return escaped copy of a string */
 char *escape_string(const char *str);
 
+/**
+ * Find a free port to bind to
+ * @param addr : Address to bind to -- if port >0 it's tried first.
+ *               On return the port is set to the one found.
+ * @returns true on success, false on error. In case of error
+ * addr is unchanged.
+ */
+BOOL find_free_tcp_port(SOCKADDR_IN *addr);
+
 #endif

--- a/openvpn.c
+++ b/openvpn.c
@@ -2193,6 +2193,8 @@ StartOpenVPN(connection_t *c)
     /* Create a management interface password */
     GetRandomPassword(c->manage.password, sizeof(c->manage.password) - 1);
 
+    find_free_tcp_port(&c->manage.skaddr);
+
     /* Construct command line -- put log first */
     _sntprintf_0(cmdline, _T("openvpn --log%ls \"%ls\" --config \"%ls\" "
         "--setenv IV_GUI_VER \"%hs\" --setenv IV_SSO openurl,crtext --service %ls 0 --auth-retry interact "


### PR DESCRIPTION
Bind a socket to a dynamic port and then close to identify
a free port and use it when starting openvpn.exe.

Signed-off-by: Selva Nair <selva.nair@gmail.com>

Trac: 1051