### PR TITLE
Fix crash on empty state response

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -286,6 +286,9 @@ OnStateChange(connection_t *c, char *data)
 {
     char *pos, *state, *message;
 
+    if (data == NULL)
+        return;
+
     pos = strchr(data, ',');
     if (pos == NULL)
         return;


### PR DESCRIPTION
OpenVPN3 doesn't yet support "state"
management command without parameters.

While this has to be fixed on OpenVPN3
side, it doesn't mean that gui could simply crash.

Signed-off-by: Lev Stipakov <lev@openvpn.net>