### PR TITLE
PLAP: Add an option to register the COM dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(${PROJECT_NAME_PLAP} SHARED
     pkcs11.c
     registry.c
     config_parser.c
+    service.c
     plap/ui_glue.c
     plap/stub.c
     plap/plap_common.c

--- a/access.c
+++ b/access.c
@@ -37,6 +37,7 @@
 #include "service.h"
 #include "localization.h"
 #include "openvpn-gui-res.h"
+#include "misc.h"
 
 extern options_t o;
 
@@ -45,35 +46,6 @@ extern options_t o;
 static BOOL GetOwnerSID(PSID sid, DWORD sid_size);
 static BOOL IsUserInGroup(PSID sid, PTOKEN_GROUPS token_groups, const WCHAR *group_name);
 static PTOKEN_GROUPS GetProcessTokenGroups(void);
-
-/*
- * Run a command as admin using shell execute and return the exit code.
- * If the command fails to execute, the return value is (DWORD) -1.
- */
-static DWORD
-RunAsAdmin(const WCHAR *cmd, const WCHAR *params)
-{
-    SHELLEXECUTEINFO shinfo;
-    DWORD status = -1;
-
-    CLEAR (shinfo);
-    shinfo.cbSize = sizeof(shinfo);
-    shinfo.fMask = SEE_MASK_NOCLOSEPROCESS;
-    shinfo.hwnd = NULL;
-    shinfo.lpVerb = L"runas";
-    shinfo.lpFile = cmd;
-    shinfo.lpDirectory = NULL;
-    shinfo.nShow = SW_HIDE;
-    shinfo.lpParameters = params;
-
-    if (ShellExecuteEx(&shinfo) && shinfo.hProcess)
-    {
-        WaitForSingleObject(shinfo.hProcess, INFINITE);
-        GetExitCodeProcess(shinfo.hProcess, &status);
-        CloseHandle(shinfo.hProcess);
-    }
-    return status;
-}
 
 /*
  * The Administrators group may be localized or renamed by admins.

--- a/localization.c
+++ b/localization.c
@@ -37,6 +37,7 @@
 #include "openvpn-gui-res.h"
 #include "options.h"
 #include "registry.h"
+#include "misc.h"
 
 extern options_t o;
 
@@ -522,6 +523,23 @@ GeneralSettingsDlgProc(HWND hwndDlg, UINT msg, UNUSED WPARAM wParam, LPARAM lPar
         else if (o.enable_persistent == 2) /* Enabled and auto-attach */
             CheckRadioButton (hwndDlg, ID_RB_BALLOON3, ID_RB_BALLOON5, ID_RB_BALLOON3);
 
+        int plap_status = GetPLAPRegistrationStatus();
+        if (plap_status == -1) /* PLAP not supported in this version */
+            ShowWindow(GetDlgItem(hwndDlg, ID_CHK_PLAP_REG), SW_HIDE);
+        else if (plap_status != 0)
+            Button_SetCheck(GetDlgItem(hwndDlg, ID_CHK_PLAP_REG), BST_CHECKED);
+
+        break;
+
+    case WM_COMMAND:
+        if (LOWORD(wParam) == ID_CHK_PLAP_REG && HIWORD(wParam) == BN_CLICKED)
+        {
+            /* change PLAPRegistration state */
+            HWND h = GetDlgItem(hwndDlg, ID_CHK_PLAP_REG);
+            BOOL newstate = Button_GetCheck(h) == BST_CHECKED ?  TRUE : FALSE;
+            if (SetPLAPRegistration(newstate) != 0) /* failed or user cancelled -- reset checkmark */
+                Button_SetCheck(h, newstate  ? BST_UNCHECKED : BST_CHECKED);
+        }
         break;
 
     case WM_NOTIFY:

--- a/main.c
+++ b/main.c
@@ -590,7 +590,7 @@ LRESULT CALLBACK WindowProcedure (HWND hwnd, UINT message, WPARAM wParam, LPARAM
         break;
       }
       /* A timer to periodically tend to persistent connections */
-      SetTimer(hwnd, 0, 100, ManagePersistent);
+      SetTimer(hwnd, 1, 100, ManagePersistent);
 
       break;
 
@@ -686,12 +686,14 @@ LRESULT CALLBACK WindowProcedure (HWND hwnd, UINT message, WPARAM wParam, LPARAM
           o.session_locked = TRUE;
           /* Detach persistent connections so that other users can connect to it */
           HandleSessionLock();
+          KillTimer(hwnd, 1); /* This ensure ManagePersistent is not called when session is locked */
           break;
 
         case WTS_SESSION_UNLOCK:
           PrintDebug(L"Session unlock triggered");
           o.session_locked = FALSE;
           HandleSessionUnlock();
+          SetTimer(hwnd, 1, 100, ManagePersistent);
           if (CountConnState(suspended) != 0)
             ResumeConnections();
           break;

--- a/misc.h
+++ b/misc.h
@@ -126,4 +126,28 @@ void dpi_initialize(options_t *o);
  */
 void MsgToEventLog(WORD type, wchar_t *format, ...);
 
+/**
+ * Check PLAP COM object is is registered
+ * @returns 1 if yes, 0 if no, or -1 if PLAP dll not installed.
+ */
+int GetPLAPRegistrationStatus(void);
+
+/**
+ * Register/Unregister PLAP COM object
+ * @param action TRUE to register, FALSE to unregister
+ * @returns 0 on success or a non-zero error code on error.
+ * Requires admin privileges -- user will prompted for admin
+ * credentials or UAC consent if required.
+ */
+DWORD SetPLAPRegistration(BOOL action);
+
+/**
+ * Run a command as admin using shellexecute
+ * @param cmd The command to run
+ * @param params Parameters to the command
+ * @returns 0 on success or a non-zero exit code from the
+ * command. If the command fails to startup, -1 is returned.
+ */
+DWORD RunAsAdmin(const WCHAR *cmd, const WCHAR *params);
+
 #endif

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -252,6 +252,7 @@
 #define IDS_ERR_ADD_USER_TO_ADMIN_GROUP 1257
 #define IDS_NFO_BYTECOUNT               1258
 #define IDS_NFO_STATE_ONHOLD            1259
+#define IDS_ERR_PARSE_MGMT_OPTION       1260
 
 /* Program Startup Related */
 #define IDS_ERR_OPEN_DEBUG_FILE         1301

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -116,6 +116,7 @@
 #define ID_RB_BALLOON4                   245
 #define ID_RB_BALLOON5                   246
 #define ID_TXT_PERSISTENT                247
+#define ID_CHK_PLAP_REG                  248
 
 /* Proxy Auth Dialog */
 #define ID_DLG_PROXY_AUTH                250
@@ -343,6 +344,8 @@
 #define IDS_ERR_READ_SET_KEY            1811
 #define IDS_ERR_WRITE_REGVALUE          1812
 #define IDS_ERR_GET_PROFILE_DIR         1813
+#define IDS_ERR_PLAP_REG                1814
+#define IDS_ERR_PLAP_UNREG              1815
 
 /* Importation Related */
 

--- a/openvpn.c
+++ b/openvpn.c
@@ -2326,6 +2326,12 @@ StartOpenVPN(connection_t *c)
     {
         if (!ParseManagementAddress(c))
         {
+            /* Show an error if manually connecting */
+            if (c->state == disconnected)
+                ShowLocalizedMsgEx(MB_OK|MB_ICONERROR, o.hWnd, TEXT(PACKAGE_NAME), IDS_ERR_PARSE_MGMT_OPTION,
+                                   c->config_dir, c->config_file);
+            else
+                c->state = disconnected;
             TerminateThread(hThread, 1);
             return false;
         }

--- a/plap/Makefile.am
+++ b/plap/Makefile.am
@@ -89,6 +89,7 @@ libopenvpn_plap_la_SOURCES = \
 	$(top_srcdir)/openvpn_config.c \
 	$(top_srcdir)/config_parser.c \
 	$(top_srcdir)/pkcs11.c \
+	$(top_srcdir)/service.c \
 	openvpn-plap-res.rc
 
 libopenvpn_plap_la_LIBADD = \

--- a/plap/ui_glue.c
+++ b/plap/ui_glue.c
@@ -275,7 +275,8 @@ FindPLAPConnections(connection_t *conn[], size_t max_count)
     for (int i = 0; i < o.num_configs && count < max_count; i++)
     {
         connection_t *c = &o.conn[i];
-        if (!(c->flags & FLAG_DAEMON_PERSISTENT))
+        if (!(c->flags & FLAG_DAEMON_PERSISTENT)
+            || !ParseManagementAddress(c))
         {
             continue;
         }

--- a/plap/ui_glue.c
+++ b/plap/ui_glue.c
@@ -40,6 +40,7 @@
 #include "localization.h"
 #include "misc.h"
 #include "tray.h"
+#include "service.h"
 
 /* Global options structure */
 options_t o;
@@ -259,6 +260,20 @@ InitializeUI(HINSTANCE hinstance)
     dmsg(L"BuildFileList Done");
 
     dpi_initialize(&o);
+
+    /* If openvpn service is not running but, available, attempt to start it */
+    CheckServiceStatus();
+    int num_persistent = 0;
+
+    for (int i = 0; i < o.num_configs; i++) {
+        if (o.conn[i].flags & FLAG_DAEMON_PERSISTENT) num_persistent++;
+    }
+
+    if (o.service_state == service_disconnected && num_persistent > 0) {
+        dmsg(L"Attempting to start automatic service");
+        StartAutomaticService();
+        CheckServiceStatus();
+    }
 
     return 0;
 }

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -160,7 +160,7 @@ BEGIN
     GROUPBOX "Spuštění", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Spustit při startu Windows", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Volby", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Volby", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Připojovat záznamy na konec logu", ID_CHK_LOG_APPEND, 17, 95, 130, 10
     AUTOCHECKBOX "Zobrazit okno skriptu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Tiché spojení", ID_CHK_SILENT, 17, 125, 200, 10
@@ -173,6 +173,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -530,6 +531,8 @@ OpenVPN pravděpodobně není nainstalováno."
 jednou jako správce, aby se registr aktualizoval."
     IDS_ERR_READ_SET_KEY "Došlo k chybě při čtení a zápisu klíče registru ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Došlo k chybě při zápisu hodnoty registru ""HKCU\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "Konfigurace s názvem ""%ls"" již existuje."

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -404,6 +404,7 @@ Více informací najdete v logu (%ls)."
     IDS_NFO_SERVICE_STOPPED "Služba OpenVPN zastavena."
     IDS_NFO_ACTIVE_CONN_EXIT "Některá spojení jsou stále aktivní. Pokud OpenVPN GUI ukončíte, budou přerušena.\
 \n\nOpravdu chcete aplikaci ukončit?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Některá spojení jsou stále aktivní. Díky běžící službě OpenVPN \
 zůstanete připojeni, i když ukončíte OpenVPN GUI.\n\n\
 Chcete pokračovat a aplikaci ukončit?"

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -157,7 +157,7 @@ BEGIN
     LTEXT "Spr&ache:", ID_TXT_LANGUAGE, 17, 25, 29, 12
     COMBOBOX ID_CMB_LANGUAGE, 51, 23, 177, 400, CBS_DROPDOWNLIST | WS_TABSTOP
 
-    GROUPBOX "Einstellungen", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Einstellungen", ID_GROUPBOX3, 6, 82, 235, 150
     GROUPBOX "Systemstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Mit &Windows starten", ID_CHK_STARTUP, 17, 59, 200, 12
 
@@ -174,6 +174,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -533,6 +534,8 @@ OpenVPN ist vermutlich nicht installiert"
 als Administrator ausführen, um die Registry zu aktualisieren."
     IDS_ERR_READ_SET_KEY "Fehler beim Lesen und Setzen des Registry-Schlüssels ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Fehler beim Schreiben des Registry-Schlüssels ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "Eine Konfigurationsdatei namens ""%ls"" existiert bereits."

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -406,6 +406,7 @@ Konsultieren Sie die Log-Datei (%ls) für weitere Informationen."
     IDS_NFO_SERVICE_STOPPED "OpenVPN-Dienst beendet."
     IDS_NFO_ACTIVE_CONN_EXIT "Es exisiert noch eine aktive Verbindung, welche geschlossen wird, wenn Sie OpenVPN GUI beenden.\
 \n\nSind Sie sicher, dass Sie das Programm beenden möchten?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Der OpenVPN-Dienst ist gestartet und verbunden. \
 Die Verbindung besteht solange, bis Sie OpenVPN GUI beenden.\n\n\
 \n\nSind Sie sicher, dass Sie das Programm beenden möchten?"

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -403,6 +403,7 @@ ligger i forskellige kataloger."
     IDS_NFO_ACTIVE_CONN_EXIT "Aktive forbindelser vil blive afbrudt hvis du afslutter OpenVPN GUI. \
  \n\nVil du afslutte?"
 
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Du er forbundet med OpenVPN (OpenVPN tjenesten kører). \
 Aktive forbindelser vil forblive tilsluttet hvis du afslutter OpenVPN GUI.\n\n\
 Vil du afslutte?"

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -160,7 +160,7 @@ BEGIN
     GROUPBOX "Autostart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Start med Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Indstillinger", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Indstillinger", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Tilføj til log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Vis script vindue", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille forbindelse", ID_CHK_SILENT, 17, 125, 200, 10
@@ -173,6 +173,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -530,6 +531,8 @@ OpenVPN er måske ikke installeret."
 en gang som administrator for at opdatere registret."
     IDS_ERR_READ_SET_KEY "Fejl under læsning og skrivning af register-værdi ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Fejl under skrivning af register-værdi ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -418,6 +418,7 @@ View log file (%ls) for more details."
     IDS_NFO_SERVICE_STOPPED "OpenVPN Service stopped."
     IDS_NFO_ACTIVE_CONN_EXIT "There are still active connections that will be closed if you exit OpenVPN GUI.\
 \n\nAre you sure you want to exit?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "You are currently connected (the OpenVPN Service is running). \
 You will stay connected even if you exit OpenVPN GUI.\n\n\
 Do you want to proceed and exit OpenVPN GUI?"

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -174,7 +174,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on User &Logon", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 135
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "A&ppend to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script &window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "S&ilent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -187,6 +187,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -544,6 +545,8 @@ OpenVPN is probably not installed"
 once as Administrator to update the registry."
     IDS_ERR_READ_SET_KEY "Error reading and setting registry key ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Error writing registry value ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -158,7 +158,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -171,6 +171,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -527,6 +528,8 @@ OpenVPN probablemente no está instalado"
 nuevo como Administrator para actualizar el registro."
     IDS_ERR_READ_SET_KEY "Error al leer y escribir la clave de registro ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Error al escribir el valor del registro ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -400,6 +400,7 @@ están en directorios diferentes."
     IDS_NFO_SERVICE_STOPPED "Servicio OpenVPN detenido."
     IDS_NFO_ACTIVE_CONN_EXIT "Aún hay conexiones activas que serán cerradas si se sale de OpenVPN GUI.\
 \n\nEstá seguro de querer salir?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Ahora mismo está conectado (el servicio OpenVPN está corriendo). \
 Seguriá conectado incluso si sale de OpenVPN GUI.\n\n\
 ¿Quiere proceder y salir de OpenVPN GUI?"

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -162,7 +162,7 @@ BEGIN
     GROUPBOX "شروع به کار", 202, 6, 47, 235, 30
     AUTOCHECKBOX "شروع به کار - وقتی کاربر وارد شد", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "تنظیمات", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "تنظیمات", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "چسباندن به گزارشات", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "نمایش پنجره اسکریپت", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "بی صدا(اعلان) متصل شدن", ID_CHK_SILENT, 17, 125, 200, 10
@@ -175,6 +175,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -533,6 +534,8 @@ OpenVPN is probably not installed"
 once as Administrator to update the registry."
     IDS_ERR_READ_SET_KEY "Error reading and setting registry key ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Error writing registry value ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -406,6 +406,7 @@ BEGIN
     IDS_NFO_SERVICE_STOPPED "خدمت OpenVPN پایان یافت."
     IDS_NFO_ACTIVE_CONN_EXIT "هنوز اتصالات فعال وجود دارد که در صورت خروج بسته خواهد شد - OpenVPN GUI.\
 \n\nشما مطمئن هستید میخواهید خارج شوید?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "شما فعلا متصل هستید (سرویس OpenVPN در حالت اجراست). \
 شما می توانید متصل بمانید حتی اگر از OpenVPN GUI خارج شدید.\n\n\
 شما می خواهید پروسه خارج شدن رو انجام بدهید - OpenVPN GUI?"

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -403,6 +403,7 @@ Lisätietoja lokitiedostossa (%ls)."
     IDS_NFO_SERVICE_STOPPED "OpenVPN-palvelu pysäytetty."
     IDS_NFO_ACTIVE_CONN_EXIT "Jos OpenVPN GUI suljetaan, aktiiviset yhteydet katkeavat.\
 \n\nHaluatko varmasti jatkaa?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Yhteys on muodostettu OpenVPN-palvelun avulla. \
 Yhteydet eivät katkea, vaikka OpenVPN GUI suljettaisiinkin.\n\n\
 Suljetaanko OpenVPN GUI?"

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -159,7 +159,7 @@ BEGIN
     GROUPBOX "Käynnistäminen", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Käynnistä Windowsiin kirjautuessa", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Valinnat", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Valinnat", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Lisää lokitiedostoon", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Näytä komentosarjaikkuna", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Yhdistä taustalla", ID_CHK_SILENT, 17, 125, 200, 10
@@ -172,6 +172,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -531,6 +532,8 @@ OpenVPN:ää ei todennäköisesti ole asennettu."
 ajaa ylläpitäjän oikeuksin, jotta se saa lisättyä rekisteriin tietoja."
     IDS_ERR_READ_SET_KEY "Virhe luettaessa ja määritettäessä rekisteriavainta ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Virhe kirjoitettaessa rekisterin arvoa ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "Samanniminen (""%ls"") asetustiedosto on jo olemassa."

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -159,7 +159,7 @@ BEGIN
     GROUPBOX "Démarrage", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Lancer au démarrage de Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Préférences", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Préférences", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Ajouter au fichier log", ID_CHK_LOG_APPEND, 17, 95, 81, 10
     AUTOCHECKBOX "Afficher la fenêtre des scripts", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connexion silencieuse", ID_CHK_SILENT, 17, 125, 200, 10
@@ -172,6 +172,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -530,6 +531,8 @@ OpenVPN n'est probablement pas installé."
 en tant qu'Administrator pour mettre à jour la base de registre."
     IDS_ERR_READ_SET_KEY "Impossible de lire et modifier la clé de registre ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Impossible d'écrire la valeur de registre ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "Une configuration nommée ""%ls"" existe déjà."

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -403,6 +403,7 @@ Afficher le fichier journal (%ls) pour plus de détails."
     IDS_NFO_SERVICE_STOPPED "Service OpenVPN arreté."
     IDS_NFO_ACTIVE_CONN_EXIT "Les connexions en cours seront interrompues si vous fermez OpenVPN GUI.\
 \n\nVous êtes sûr de vouloir fermer l'application ?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Vous êtes actuellement connecté (Le service OpenVPN est actif). \
 Vous restez connecté même si vous terminez l'OpenVPN GUI.\n\n\
 Voulez-vous continuer et fermer l'OpenVPN GUI ?"

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -403,6 +403,7 @@ Consulta il file di log (%ls) per maggiori dettagli."
     IDS_NFO_SERVICE_STOPPED "Servizio OpenVPN arrestato."
     IDS_NFO_ACTIVE_CONN_EXIT "Ci sono ancora connessioni attive che verranno chiuse se esci dall'interfaccia di OpenVPN.\
 \n\nSei sicuro di voler uscire?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Al momento sei connesso (il servizio di OpenVPN è in funzione). \
 Rimarrai connesso anche se esci dall'interfaccia di OpenVPN.\n\n\
 Vuoi continuare e uscire da dall'interfaccia di OpenVPN?"

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -159,7 +159,7 @@ BEGIN
     GROUPBOX "Avvio", 202, 6, 47, 235, 30
     AUTOCHECKBOX "&Avvia all'apertura di Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferenze", ID_GROUPBOX3, 6, 82, 235, 135
+    GROUPBOX "Preferenze", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Aggiungi in coda al f&ile di log", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Mostra &finestra script", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connessione &silenziosa", ID_CHK_SILENT, 17, 125, 200, 10
@@ -172,6 +172,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -530,6 +531,8 @@ OpenVPN probabilmente non è installato"
 una volta che l'amministratore ha aggiornato il registro."
     IDS_ERR_READ_SET_KEY "Errore nella lettura e modifica della chiave di registro ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Errore nella scrittura del valore di registro ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "Esiste già una configurazione con il nome ""%ls""."

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -404,6 +404,7 @@ BEGIN
     IDS_NFO_SERVICE_STOPPED "OpenVPNサービスが停止されました。"
     IDS_NFO_ACTIVE_CONN_EXIT "OpenVPN GUIを終了すると、現在接続中の接続が切断されます。\
 \n\n終了してもよろしいですか？"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "現在接続中です（OpenVPN サービスが実行中です）。\
 OpenVPN GUIを終了してもこの接続を継続します。\n\n\
 OpenVPN GUIをこのまま終了しますか？"

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -160,7 +160,7 @@ BEGIN
     GROUPBOX "起動", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Windows起動時に開始(&L)", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "設定", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "設定", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "ログ追記モード(&P)", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "スクリプト実行ウィンドウを表示(&W)", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "サイレント接続モード(&I)", ID_CHK_SILENT, 17, 125, 200, 10
@@ -173,6 +173,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -530,6 +531,8 @@ OpenVPNがインストールされていない可能性があります。"
     IDS_ERR_OPEN_WRITE_REG "レジストリの書き込みに失敗しました。レジストリの更新時にはアプリケーションを管理者権限で実行する必要があります。"
     IDS_ERR_READ_SET_KEY "レジストリ ""%ls"" の読み取り/書き込みに失敗しました。"
     IDS_ERR_WRITE_REGVALUE "レジストリ ""HKEY_CURRENT_USER\\%ls\\%ls"" への書き込みに失敗しました。"
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "設定 ""%ls"" は既に存在しています。"

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -401,6 +401,7 @@ BEGIN
     IDS_NFO_SERVICE_STOPPED "OpenVPN Service가 중지 되었습니다."
     IDS_NFO_ACTIVE_CONN_EXIT "OpenVPN GUI을 종료하면 현재 연결되어 있는 접속이 중단 됩니다.\
 \n\n그래도 종료 하겠습니까?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "현재 접속 중 입니다. (OpenVPN Service가 실행 중 입니다.) \
 OpenVPN GUI를 종료 하더라도, 접속은 중단되지 않습니다.\n\n\
 OpenVPN GUI를 이대로 종료 하겠습니까?"

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -161,7 +161,7 @@ BEGIN
     GROUPBOX "시작 설정", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Windows 시작 시에 실행", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "환경 설정", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "환경 설정", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "로그 파일에 추가", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "스크립트 창 보기", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "연결 시 상태 대화 상자 표시하지 않기", ID_CHK_SILENT, 17, 125, 200, 10
@@ -174,6 +174,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -528,6 +529,8 @@ OpenVPN이 설치 되어 있지 않은 것 같습니다."
 Administrator 권한으로 이 프로그램을 실행해야 합니다."
     IDS_ERR_READ_SET_KEY "레지스트리 ""%ls""키 읽기/쓰기를 할 수 없습니다."
     IDS_ERR_WRITE_REGVALUE "레지스트리 ""HKEY_CURRENT_USER\\%ls\\%ls"" 값을 기록할 수 없습니다."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS """%ls"" 설정 파일은 이미 존재 합니다."

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -160,7 +160,7 @@ BEGIN
     GROUPBOX "Opstarten", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Opstarten met Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Voorkeuren", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Voorkeuren", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Aan logbestand toevoegen", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Script-venster tonen", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille verbinding", ID_CHK_SILENT, 17, 125, 200, 10
@@ -173,6 +173,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -531,6 +532,8 @@ OpenVPN is waarschijnlijk niet geïnstalleerd"
 om de registerinstellingen te updaten."
     IDS_ERR_READ_SET_KEY "Fout tijdens lezen en instellen van registersleutel ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Fout tijdens schrijven van registersleutel ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "Een configuratie met de naam ""%ls"" bestaat al."

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -404,6 +404,7 @@ Bekijk logbestand (%ls) voor meer informatie."
     IDS_NFO_SERVICE_STOPPED "OpenVPN Service gestopt."
     IDS_NFO_ACTIVE_CONN_EXIT "Er zijn nog actieve connecties die verbroken zullen worden indien OpenVPN GUI afgesloten wordt.\
 \n\nBent u zeker dan u wilt afsluiten?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Er is momenteel een actieve verbinding (OpenVPN services is gestart). \
 De verbinding blijft actief ook als OpenVPN GUI afgesloten wordt.\n\n\
 OpenVPN GUI afsluiten?"

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -398,6 +398,7 @@ konfigurasjonsfiler med samme navn, selv om de ligger i ulike kataloger."
     IDS_NFO_SERVICE_STARTED "OpenVPN-tjenesten startet."
     IDS_NFO_SERVICE_STOPPED "OpenVPN-tjenesten stoppet."
     IDS_NFO_ACTIVE_CONN_EXIT "Aktive tilkoblinger vil bli avbrutt om du avslutter OpenVPN GUI.\n\nVil du avslutte?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Du er tilkoblet med OpenVPN (OpenVPN-tjenesten kjører). \
 Aktive tilkoblinger vil forbli tilkoblet om du avslutter OpenVPN GUI.\n\n\
 Vil du avslutte?"

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -159,7 +159,7 @@ BEGIN
     GROUPBOX "Oppstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Kjør automatisk når Windows starter", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Innstillinger", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Innstillinger", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Tilføy til eksisterende logg", ID_CHK_LOG_APPEND, 17, 95, 93, 10
     AUTOCHECKBOX "Vis scriptvindu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Skjul statusvindu ved tilkobling", ID_CHK_SILENT, 17, 125, 200, 10
@@ -172,6 +172,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -521,6 +522,8 @@ Wintun driver will not work."
     IDS_ERR_OPEN_WRITE_REG "Kunne ikke oppdatere registeret. Du må starte programmet med administrator-rettigheter for å kunne gjøre endringer i registeret."
     IDS_ERR_READ_SET_KEY "Kunne ikke lese eller skrive til registernøkkelen ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Feil ved oppdatering av registerverdien ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "En konfigurasjon med navnet ""%ls"" eksisterer allerede."

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -160,7 +160,7 @@ BEGIN
     GROUPBOX "Uruchamianie", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Uruchamiaj po zalogowaniu się użytkownika", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferencje", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Preferencje", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Dodaj do dziennika", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Pokaż okno skryptu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Połączenie dyskretne", ID_CHK_SILENT, 17, 125, 200, 10
@@ -173,6 +173,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -529,6 +530,8 @@ Prawdopodobnie OpenVPN nie jest zainstalowany."
 z prawami administratora aby uaktualnić rejestr."
     IDS_ERR_READ_SET_KEY "Błąd odczytu/zmiany klucza rejestru ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Błąd zapisu rejestru ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "Konfiguracja o nazwie ""%ls"" już istnieje."

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -402,6 +402,7 @@ umieszczone są w innych katalogach."
     IDS_NFO_SERVICE_STOPPED "Usługa OpenVPN zatrzymana."
     IDS_NFO_ACTIVE_CONN_EXIT "Istnieją aktywne połączenia, które zostaną zakończone jeśli zamkniesz OpenVPN GUI.\
 \n\nCzy chcesz kontynuować?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Obecnie jesteś połączony (usługa OpenVPN jest uruchomiona). \
 Połączenie zostanie aktywne nawet po zakończeniu programu OpenVPN GUI.\n\n\
 Czy chcesz kontynuować i zakończyć OpenVPN GUI?"

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -158,7 +158,7 @@ BEGIN
     GROUPBOX "Inicialização", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Executar ao iniciar o Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferências", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Preferências", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Anexar ao log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Mostrar janela de script", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Conexão silenciosa", ID_CHK_SILENT, 17, 125, 200, 10
@@ -171,6 +171,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -529,6 +530,8 @@ OpenVPN provavelmente não está instalado"
 uma vez como Administrador para alterar o registro."
     IDS_ERR_READ_SET_KEY "Erro ao ler e ajustar chave de registro ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Erro ao gravar valor da chave de registro ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "Já existe uma configuração com o nome ""%ls""."

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -402,6 +402,7 @@ Consulte o arquivo de log (%ls) para mais detalhes."
     IDS_NFO_SERVICE_STOPPED "Serviço OpenVPN parado."
     IDS_NFO_ACTIVE_CONN_EXIT "Ainda existem conexões ativas. Estas conexões serão encerradas se você sair do OpenVPN GUI.\
 \n\nVocê tem certeza de que deseja sair?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Você está conectado atualmente (Serviço OpenVPN está rodando). \
 Você permanecerá conectado mesmo que feche o OpenVPN GUI.\n\n\
 Você deseja continuar e fechar o OpenVPN GUI?"

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -403,6 +403,7 @@ BEGIN
     IDS_NFO_SERVICE_STOPPED "Служба OpenVPN остановлена."
     IDS_NFO_ACTIVE_CONN_EXIT "Ещё присутствуют активные соединения, которые будут закрыты, если вы выйдите из OpenVPN GUI.\
 \n\nВы уверены, что хотите выйти?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Вы в данный момент подключены (служба OpenVPN запущена). \
 Вы останетесь подключенными, даже если вы выйдете из OpenVPN GUI.\n\n\
 Вы хотите продолжить и выйти из OpenVPN GUI?"

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -161,7 +161,7 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускать при старте Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Настройки", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Настройки", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Дописывать, а не перезаписывать журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показывать окно выполнения", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихое» подключение", ID_CHK_SILENT, 17, 125, 200, 10
@@ -174,6 +174,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -530,6 +531,8 @@ OpenVPN, возможно, не установлен."
 однократно с правами администратора, чтобы обновить реестр."
     IDS_ERR_READ_SET_KEY "Ошибка чтения и установки значения ключа ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Ошибка записи значения реестра ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "Файл конфигурации ""%ls"" уже существует."

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -158,7 +158,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -171,6 +171,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -524,6 +525,8 @@ Wintun driver ska inte fungera."
     IDS_ERR_OPEN_WRITE_REG "Fel vid öppnande av registret för skrivning. Du måste starta programmet en gång som administratör för att uppdatera registret."
     IDS_ERR_READ_SET_KEY "Fel vid läsning och skrivning av register värde ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Fel vid skrivning av register värdet ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -399,6 +399,7 @@ konfigurations filer med samma namn, även om de ligger i olika kataloger."
     IDS_NFO_SERVICE_STARTED "OpenVPN Service startad."
     IDS_NFO_SERVICE_STOPPED "OpenVPN Service stoppad."
     IDS_NFO_ACTIVE_CONN_EXIT "Du har aktiva uppkopplingar i gång som kommer kopplas ner om du avslutar OpenVPN GUI.\n\nÄr du säker på att du vill avsluta?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Du är uppkopplad med OpenVPN (OpenVPN tjänsten är igång). \
 Du kommer att förbli uppkopplad även om du avslutar OpenVPN GUI.\n\n\
 Är du säker på att du vill avsluta OpenVPN GUI?"

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -160,7 +160,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -173,6 +173,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -529,6 +530,8 @@ Muhtemelen OpenVPN yüklü değil."
 sistem yönetici haklarına sahip olmanız gerekmektedir.."
     IDS_ERR_READ_SET_KEY """%ls"" anahtarı ayarlanırken hata oluştu."
     IDS_ERR_WRITE_REGVALUE """HKEY_CURRENT_USER\\%ls\\%ls"" anahtarı yazılırken hata oluştu."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "A config named ""%ls"" already exists."

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -402,6 +402,7 @@ kayıt edemezsiniz."
     IDS_NFO_SERVICE_STOPPED "OpenVPN Service durduruldu."
     IDS_NFO_ACTIVE_CONN_EXIT "OpenVPN GUI ' yi kapatırsanız, açık olan bağlantılarınız sonlandırılacaktır.\
 \n\nÇıkmak istediğinize emin misiniz?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "Şu an bağlısınız(OpenVPN Servisi çalışıyor). \
 OpenVPN GUI yi kapatsanız dahi bağlantı devam edecek.\n\n\
 OpenVPN GUI den çıkmak istiyor musunuz?"

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -159,7 +159,7 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускати при старті Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Налаштування", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "Налаштування", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "Додати, а не перезаписувати журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показувати вікно виконання", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихе» підключення", ID_CHK_SILENT, 17, 125, 200, 10
@@ -172,6 +172,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -529,6 +530,8 @@ OpenVPN, можливо, не встановлений."
  із правами адміністратора, щоб відновити реєстр."
     IDS_ERR_READ_SET_KEY "Помилка читання і встановлення перемінної ""%ls""."
     IDS_ERR_WRITE_REGVALUE "Помилка запису перемінної реєстру до ""HKEY_CURRENT_USER\\%ls\\%ls""."
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
 
     /* importation */

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -402,6 +402,7 @@ BEGIN
     IDS_NFO_SERVICE_STOPPED "Служба OpenVPN зупинена."
     IDS_NFO_ACTIVE_CONN_EXIT "Ще є активні з'єднання, які будуть зупинені, якщо ви завершите роботу OpenVPN GUI.\
 \n\nВи впевнені, що бажаєте завершити?"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "У цей час система підключена (сервіс OpenVPN стартував). \
 Ви залишитися підключені, навіть якщо ви завершили роботу OpenVPN GUI.\n\n\
 Ви бажаєте залишити активним сервіс та завершити роботу OpenVPN GUI?"

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -162,7 +162,7 @@ BEGIN
     GROUPBOX "启动", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 开机时启动", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好设置", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "偏好设置", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "追加日志文件", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "显示脚本窗口", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "静默连接", ID_CHK_SILENT, 17, 125, 200, 10
@@ -175,6 +175,7 @@ BEGIN
     AUTORADIOBUTTON "自动", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "手动", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "禁用", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -531,6 +532,8 @@ Wintun驱动程序将无法正常工作。"
     IDS_ERR_OPEN_WRITE_REG "无法打开系统注册表进行写入，您必须以管理员身分执行此应用程序更新注册表。"
     IDS_ERR_READ_SET_KEY "读取并设定系统注册表项「%ls」时发生错误。"
     IDS_ERR_WRITE_REGVALUE "读取系统注册表值「HKEY_CURRENT_USER\\%ls\\%ls」时发生错误。"
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "已有名为「%ls」的连接配置文件。"

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -405,6 +405,7 @@ BEGIN
     IDS_NFO_SERVICE_STOPPED "已停止 OpenVPN 服务。"
     IDS_NFO_ACTIVE_CONN_EXIT "当前还有活动的连接，您若退出 OpenVPN GUI 该连接将被中断。\
 \n\n您确定要退出吗？"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "您当前已连接（OpenVPN 服务正在运行中）。\
 退出 OpenVPN GUI 仍将保持连接。\n\n\
 您确定要退出吗？"

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -162,7 +162,7 @@ BEGIN
     GROUPBOX "啟動", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 開機時執行", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好設定", ID_GROUPBOX3, 6, 82, 235, 105
+    GROUPBOX "偏好設定", ID_GROUPBOX3, 6, 82, 235, 150
     AUTOCHECKBOX "附加記錄檔", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "顯示指令碼視窗", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "寧靜連線", ID_CHK_SILENT, 17, 125, 200, 10
@@ -175,6 +175,7 @@ BEGIN
     AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
     AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
 END
 
 /* Advanced Dialog */
@@ -531,6 +532,8 @@ Wintun driver will not work."
     IDS_ERR_OPEN_WRITE_REG "無法開啟系統登錄檔進行寫入，您必須以管理員身分執行此應用程式更新註冊表。"
     IDS_ERR_READ_SET_KEY "讀取並設定系統登錄機碼「%ls」時發生錯誤。"
     IDS_ERR_WRITE_REGVALUE "讀取系統登錄值「HKEY_CURRENT_USER\\%ls\\%ls」時發生錯誤。"
+    IDS_ERR_PLAP_REG "Failed to enable Start Before Logon (error = %d)"
+    IDS_ERR_PLAP_UNREG "Failed to disable Start Before Logon (error = %d)"
 
     /* importation */
     IDS_ERR_IMPORT_EXISTS "已有名為「%ls」的連線設定檔。"

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -405,6 +405,7 @@ BEGIN
     IDS_NFO_SERVICE_STOPPED "已停止 OpenVPN 服務。"
     IDS_NFO_ACTIVE_CONN_EXIT "目前還有進行中的連線，若您結束 OpenVPN GUI 該連線將被中斷。\
 \n\n您確定要離開嗎？"
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
     IDS_NFO_SERVICE_ACTIVE_EXIT "您目前已連線（OpenVPN 服務正在執行中）。\
 離開 OpenVPN GUI 仍將保持連線。\n\n\
 您確定要離開嗎？"

--- a/service.c
+++ b/service.c
@@ -147,3 +147,24 @@ out:
         CloseServiceHandle(schSCManager);
     return ret;
 } 
+
+/* Attempt to start OpenVPN Automatc Service */
+void StartAutomaticService(void)
+{
+    SC_HANDLE schSCManager = NULL;
+    SC_HANDLE schService = NULL;
+
+    schSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_CONNECT);
+
+    if (schSCManager) {
+        schService = OpenService(schSCManager, L"OpenVPNService", SERVICE_START);
+
+        if (schService) {
+             StartService(schService, 0, NULL);
+             CloseServiceHandle(schService);
+        }
+
+        CloseServiceHandle(schSCManager);
+    }
+    return;
+}

--- a/service.h
+++ b/service.h
@@ -21,3 +21,5 @@
 
 int CheckServiceStatus();
 BOOL CheckIServiceStatus(BOOL warn);
+/* Attempt to start OpenVPN Automatc Service */
+void StartAutomaticService(void);


### PR DESCRIPTION
And some small improvements:
 - try to start the service if not running but PLAP is enabled
 - on PLAP screen do not list profiles with no --management option (they just fail)
 