### PR TITLE
service: change CheckServiceStatus() return type to VOID

### DIFF
--- a/main.c
+++ b/main.c
@@ -487,7 +487,7 @@ HandleCopyDataMessage(const COPYDATASTRUCT *copy_data)
 static void CALLBACK
 ManagePersistent(HWND hwnd, UINT UNUSED msg, UINT_PTR id, DWORD UNUSED now)
 {
-    CheckServiceStatus(false);
+    CheckServiceStatus();
     if (o.service_state == service_connected)
     {
         for (int i = 0; i < o.num_configs; i++)

--- a/service.h
+++ b/service.h
@@ -19,7 +19,7 @@
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-int CheckServiceStatus();
+VOID CheckServiceStatus();
 BOOL CheckIServiceStatus(BOOL warn);
 /* Attempt to start OpenVPN Automatc Service */
 void StartAutomaticService(void);


### PR DESCRIPTION
CheckServiceStatus() return value is never used - the status is set to global options_t struct.

While on it, remove unneccessary "false" argument
and reformat the code.

Signed-off-by: Lev Stipakov <lev@openvpn.net>