### PR TITLE
Connection grouping improvements

### DIFF
--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -26,6 +26,7 @@
 #endif
 
 #include <windows.h>
+#include <assert.h>
 
 #include "main.h"
 #include "openvpn-gui-res.h"
@@ -438,6 +439,8 @@ BuildFileList()
     }
     /* else these parent groups use their saved values */
 
+    assert (&o.groups[persistent_gp] == PERSISTENT_ROOT_GROUP); /* sanity check */
+
     if (issue_warnings)
     {
         flags |= FLAG_WARN_DUPLICATES | FLAG_WARN_MAX_CONFIGS;
@@ -470,11 +473,7 @@ BuildFileList()
         o.num_configs = max_configs; /* management-port cant handle more -- ignore the rest */
     }
 
-    /* if adding groups, activate non-empty ones */
-    if (flags &FLAG_ADD_CONFIG_GROUPS)
-    {
-        ActivateConfigGroups();
-    }
+    ActivateConfigGroups();
 
     issue_warnings = false;
 }

--- a/options.h
+++ b/options.h
@@ -123,6 +123,7 @@ typedef struct config_group {
 /* short hand for pointer to the group a config belongs to */
 #define CONFIG_GROUP(c) (&o.groups[(c)->group])
 #define PARENT_GROUP(cg) ((cg)->parent < 0 ? NULL : &o.groups[(cg)->parent])
+#define PERSISTENT_ROOT_GROUP (&o.groups[1])
 
 /* Connections parameters */
 struct connection {


### PR DESCRIPTION
Since version 11.30, we scan config-auto folder and show them
in the menu of available connection profiles. To reduce user-confusion,
always group these configs under a sub-menu ("Persistent Connections")
even when nested config menu view is not in use.