### PR TITLE
Increase max size of management password buffer

### DIFF
--- a/options.h
+++ b/options.h
@@ -146,7 +146,7 @@ struct connection {
         SOCKET sk;
         SOCKADDR_IN skaddr;
         time_t timeout;
-        char password[16];
+        char password[4096];        /* match with largest possible passwd in openvpn.exe */
         char *saved_data;
         size_t saved_size;
         mgmt_cmd_t *cmd_queue;


### PR DESCRIPTION
As we now allow users to set a management password (for persistent connections), the max size of password should match what openvpn.exe can handle (128 or 4096 bytes depending on build options).

Increase the buffer size to 4096 though such large passwords may not work in practice. 127 bytes + NUL, may be a safe upper limit.

For the random password used for connections spawned by the GUI, the current size of 15 bytes + NUL is retained.

Fixes: #567
Signed-off-by: Selva Nair <selva.nair@gmail.com>