### PR TITLE
Update vcpkg commit id

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Restore artifacts, or setup vcpkg (do not install any package)
       uses: lukka/run-vcpkg@v10
       with:
-        vcpkgGitCommitId: "a5d6d145164e82e67fbf91a4a30f98699d30de63"
+        vcpkgGitCommitId: "6adca01a3fadca0cc0b80f03ec57c7c3a0be5c02"
         appendedCacheKey: "${{ matrix.arch }} - ${{ matrix.ossl }}"
 
     - name: Run CMake consuming CMakePreset.json and vcpkg.json by mean of vcpkg.

--- a/BUILD.rst
+++ b/BUILD.rst
@@ -6,7 +6,7 @@ This is the recommended way of building openvpn-gui on Windows, which is also us
 Prerequisites
 -------------
 
- - Visual Studio 2019 (build tools should be enough, also 2022 will likely work)
+ - Visual Studio 2022 (build tools should be enough)
  - CMake
  - vcpkg (add the environment variable ``VCPKG_ROOT`` which points to vcpkg installation)
 


### PR DESCRIPTION
This will bump OpenSSL version to 3.0.7, the same
we use for master and release/2.6.

Signed-off-by: Lev Stipakov <lev@openvpn.net>