### PR TITLE
Handle CONNECTED,ROUTE_ERROR from openvpn.exe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 11.35.0
+===============
+
+Updates
+-------
+* Translations (Italian, Chinese-Simplified)
+* Notify user if connection completes with route addition errors
+
 Version 11.34.0
 ===============
 

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -259,6 +259,8 @@
 #define IDS_NFO_STATE_RETRYING          1262
 #define IDS_NFO_STATE_DISCONNECTING     1263
 #define IDS_NFO_CONN_CANCELLED          1264
+#define IDS_NFO_STATE_ROUTE_ERROR       1265
+#define IDS_NFO_NOTIFY_ROUTE_ERROR      1266
 
 /* Program Startup Related */
 #define IDS_ERR_OPEN_DEBUG_FILE         1301

--- a/openvpn.c
+++ b/openvpn.c
@@ -1528,6 +1528,29 @@ WriteStatusLog (connection_t *c, const WCHAR *prefix, const WCHAR *line, BOOL fi
     wcsncpy (datetime, _wctime(&now), _countof(datetime));
     datetime[24] = L' ';
 
+    /* change text color if Warning or Error */
+    COLORREF text_clr = 0;
+
+    if (wcsstr(prefix, L"ERROR"))
+    {
+        text_clr = o.clr_error;
+    }
+    else if (wcsstr(prefix, L"WARNING"))
+    {
+        text_clr = o.clr_warning;
+    }
+
+    if (text_clr != 0)
+    {
+        CHARFORMAT cfm = { .cbSize = sizeof(CHARFORMAT),
+                           .dwMask = CFM_COLOR|CFM_BOLD,
+                           .dwEffects = 0,
+                           .crTextColor = text_clr,
+                         };
+        SendMessage(logWnd, EM_SETCHARFORMAT, SCF_SELECTION, (LPARAM) &cfm);
+    }
+
+
     /* Remove lines from log window if it is getting full */
     if (SendMessage(logWnd, EM_GETLINECOUNT, 0, 0) > MAX_LOG_LINES)
     {

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -424,6 +424,8 @@ View log file (%ls) for more details."
     IDS_NFO_SERVICE_ACTIVE_EXIT "You are currently connected (the OpenVPN Service is running). \
 You will stay connected even if you exit OpenVPN GUI.\n\n\
 Do you want to proceed and exit OpenVPN GUI?"
+    IDS_NFO_STATE_ROUTE_ERROR "Current State: Connected with route errors"
+    IDS_NFO_NOTIFY_ROUTE_ERROR "%ls connected with route errors"
 
     /* options – Resources */
     IDS_NFO_USAGE "--help\t\t\t: Show this message.\n\


### PR DESCRIPTION
OpenVPN 2.6 now reports `CONNECTED,ROUTE_ERROR` when connection completed. Currently in the GUI we will treat this as an error and may be seen as a regression by some users.

Until we decide on how to treat route errors in the GUI, this PR is a quick fix to handle it almost the same way as the _status quo_. What is added is some extra error logging and automatic popup of the status window to draw attention to the errors.

**Change in behaviour when using 2.6 master:**
If openvpn.exe reports CONNECTED,SUCCESS or CONNECTED,ERROR: no changes
If openvpn.exe reports CONNECTED,ROUTE_ERROR : 
   - an error is written to the status log (in red)
   - the status window is displayed (if not already open)
   - the status window icon stays yellow
   - the status text says "Connected with route errors"
   - the tray notification indicates "route errors".
   Apart from that the connection works same as before, the tray icon turns green.

As this is an interim fix, new resource strings are defined only in the fall-back language (English). Both the error/info messages and the tray icon state could be improved based how fatal route errors are in real use.

To test, use openvpn.exe from 2.6 master and force a route error --- either use a bogus route like `--route 192.168.10.0 255.255.255.0 1.1.1.1` with `dco` or stop `interactive service` and set driver to `tap-windows6` (without the service running, `dco` will error out early at address setting stage).