### PR TITLE
Bug-fix: Connection list

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -2682,12 +2682,6 @@ TerminateOpenVPN (connection_t *c)
 }
 
 void
-SuspendOpenVPN(int config)
-{
-    PostMessage(o.conn[config].hwndStatus, WM_OVPN_SUSPEND, 0, 0);
-}
-
-void
 RestartOpenVPN(connection_t *c)
 {
     if (c->state == onhold)

--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -414,7 +414,6 @@ BuildFileList()
     int recurse_depth = 20; /* maximum number of levels below config_dir to recurse into */
     int flags = 0;
     static int root_gp, system_gp, persistent_gp;
-    int max_configs = (1<<16) - o.mgmt_port_offset;
 
     if (o.silent_connection)
         issue_warnings = false;
@@ -464,14 +463,6 @@ BuildFileList()
 
     if (o.num_configs == 0 && issue_warnings)
         ShowLocalizedMsg(IDS_NFO_NO_CONFIGS, o.config_dir, o.global_config_dir);
-
-    /* More than max_configs are ignored in the menu listing */
-    if (o.num_configs > max_configs)
-    {
-        if (issue_warnings)
-            ShowLocalizedMsg(IDS_ERR_MANY_CONFIGS, max_configs);
-        o.num_configs = max_configs; /* management-port cant handle more -- ignore the rest */
-    }
 
     ActivateConfigGroups();
 

--- a/options.c
+++ b/options.c
@@ -453,12 +453,11 @@ ProcessCommandLine(options_t *options, TCHAR *command_line)
 int
 CountConnState(conn_state_t check)
 {
-    int i;
     int count = 0;
 
-    for (i = 0; i < o.num_configs; ++i)
+    for (connection_t *c = o.chead; c; c = c->next)
     {
-        if (o.conn[i].state == check)
+        if (c->state == check)
             ++count;
     }
 
@@ -468,11 +467,10 @@ CountConnState(conn_state_t check)
 connection_t*
 GetConnByManagement(SOCKET sk)
 {
-    int i;
-    for (i = 0; i < o.num_configs; ++i)
+    for (connection_t *c = o.chead; c; c = c->next)
     {
-        if (o.conn[i].manage.sk == sk)
-            return &o.conn[i];
+        if (c->manage.sk == sk)
+            return c;
     }
     return NULL;
 }
@@ -480,11 +478,11 @@ GetConnByManagement(SOCKET sk)
 connection_t*
 GetConnByName(const WCHAR *name)
 {
-    for (int i = 0; i < o.num_configs; ++i)
+    for (connection_t *c = o.chead; c; c = c->next)
     {
-        if (wcsicmp (o.conn[i].config_file, name) == 0
-            || wcsicmp(o.conn[i].config_name, name) == 0)
-            return &o.conn[i];
+        if (wcsicmp (c->config_file, name) == 0
+            || wcsicmp(c->config_name, name) == 0)
+            return c;
     }
     return NULL;
 }

--- a/options.h
+++ b/options.h
@@ -167,6 +167,8 @@ struct connection {
     struct echo_msg echo_msg;      /* Message echo-ed from server or client config and related data */
     struct pkcs11_list pkcs11_list;
     char daemon_state[20];         /* state of openvpn.ex: WAIT, AUTH, GET_CONFIG etc.. */
+    int id;                        /* index of config -- treat as immutable once assigned */
+    connection_t *next;
 };
 
 /* All options used within OpenVPN GUI */
@@ -175,7 +177,8 @@ typedef struct {
     const TCHAR **auto_connect;
 
     /* Connection parameters */
-    connection_t *conn;               /* Array of connection structure */
+    connection_t *chead;              /* Head of connection list */
+    connection_t *ctail;              /* Tail of connection list */
     config_group_t *groups;           /* Array of nodes defining the config groups tree */
     int num_configs;                  /* Number of configs */
     int num_auto_connect;             /* Number of auto-connect configs */

--- a/plap/stub.c
+++ b/plap/stub.c
@@ -76,10 +76,6 @@ void SetMenuStatus(UNUSED connection_t *c, UNUSED conn_state_t state)
 {
     return;
 }
-void SetMenuStatusById(UNUSED int id, UNUSED conn_state_t state)
-{
-    return;
-}
 void SetServiceMenuStatus(void)
 {
     return;

--- a/plap/ui_glue.c
+++ b/plap/ui_glue.c
@@ -265,8 +265,9 @@ InitializeUI(HINSTANCE hinstance)
     CheckServiceStatus();
     int num_persistent = 0;
 
-    for (int i = 0; i < o.num_configs; i++) {
-        if (o.conn[i].flags & FLAG_DAEMON_PERSISTENT) num_persistent++;
+    for (connection_t *c = o.chead; c; c = c->next)
+    {
+        if (c->flags & FLAG_DAEMON_PERSISTENT) num_persistent++;
     }
 
     if (o.service_state == service_disconnected && num_persistent > 0) {
@@ -281,15 +282,14 @@ InitializeUI(HINSTANCE hinstance)
 /* Returns number of PLAP enabled configs -- for now
  * same as autostarted (persistent) connections.
  * The corresponding connection pointers are set in
- * the conn[] array.
+ * the conn[] array
  */
 DWORD
 FindPLAPConnections(connection_t *conn[], size_t max_count)
 {
     DWORD count = 0;
-    for (int i = 0; i < o.num_configs && count < max_count; i++)
+    for (connection_t *c = o.chead; c && count < max_count; c = c->next)
     {
-        connection_t *c = &o.conn[i];
         if (!(c->flags & FLAG_DAEMON_PERSISTENT)
             || !ParseManagementAddress(c))
         {
@@ -390,11 +390,11 @@ DetachAllOpenVPN()
     int i;
 
     /* Detach from the mgmt i/f of all connections */
-    for (i = 0; i < o.num_configs; i++)
+    for (connection_t *c = o.chead; c; c = c->next)
     {
-        if (o.conn[i].state != disconnected)
+        if (c->state != disconnected)
         {
-            DetachOpenVPN(&o.conn[i]);
+            DetachOpenVPN(c);
         }
     }
 
@@ -408,12 +408,12 @@ DetachAllOpenVPN()
         Sleep(100);
     }
 
-    for (i = 0; i < o.num_configs; i++)
+    for (connection_t *c = o.chead; c; c = c->next)
     {
-        if (o.conn[i].hwndStatus)
+        if (c->hwndStatus)
         {
             /* Status thread still running? kill it */
-            WaitOnThread(&o.conn[i], 0);
+            WaitOnThread(c, 0);
         }
     }
 }

--- a/tray.h
+++ b/tray.h
@@ -52,7 +52,6 @@ void OnDestroyTray(void);
 void ShowTrayIcon();
 void SetTrayIcon(conn_state_t);
 void SetMenuStatus(connection_t *, conn_state_t);
-void SetMenuStatusById(int, conn_state_t);
 void SetServiceMenuStatus();
 void ShowTrayBalloon(TCHAR *, TCHAR *);
 void CheckAndSetTrayIcon();

--- a/viewlog.c
+++ b/viewlog.c
@@ -37,7 +37,7 @@
 
 extern options_t o;
 
-void ViewLog(int config)
+void ViewLog(connection_t *c)
 {
   TCHAR filename[2*MAX_PATH];
 
@@ -54,15 +54,15 @@ void ViewLog(int config)
 
   /* Try first using file association */
   CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE); /* Safe to init COM multiple times */
-  status = ShellExecuteW (o.hWnd, L"open", o.conn[config].log_path, NULL, o.log_dir, SW_SHOWNORMAL);
+  status = ShellExecuteW (o.hWnd, L"open", c->log_path, NULL, o.log_dir, SW_SHOWNORMAL);
 
   if (status > (HINSTANCE) 32) /* Success */
     return;
   else
     PrintDebug (L"Opening log file using ShellExecute with verb = open failed"
-                 " for config '%ls' (status = %lu)", o.conn[config].config_name, status);
+                 " for config '%ls' (status = %lu)", c->config_name, status);
 
-  _sntprintf_0(filename, _T("%ls \"%ls\""), o.log_viewer, o.conn[config].log_path);
+  _sntprintf_0(filename, _T("%ls \"%ls\""), o.log_viewer, c->log_path);
 
   /* fill in STARTUPINFO struct */
   GetStartupInfo(&start_info);
@@ -92,7 +92,7 @@ void ViewLog(int config)
 }
 
 
-void EditConfig(int config)
+void EditConfig(connection_t *c)
 {
   TCHAR filename[2*MAX_PATH];
 
@@ -108,17 +108,17 @@ void EditConfig(int config)
   CLEAR (sd);
 
   /* Try first using file association */
-  _sntprintf_0(filename, L"%ls\\%ls", o.conn[config].config_dir, o.conn[config].config_file);
+  _sntprintf_0(filename, L"%ls\\%ls", c->config_dir, c->config_file);
 
   CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE); /* Safe to init COM multiple times */
-  status = ShellExecuteW (o.hWnd, L"open", filename, NULL, o.conn[config].config_dir, SW_SHOWNORMAL);
+  status = ShellExecuteW (o.hWnd, L"open", filename, NULL, c->config_dir, SW_SHOWNORMAL);
   if (status > (HINSTANCE) 32)
     return;
   else
     PrintDebug (L"Opening config file using ShellExecute with verb = open failed"
-                 " for config '%ls' (status = %lu)", o.conn[config].config_name, status);
+                 " for config '%ls' (status = %lu)", c->config_name, status);
 
-  _sntprintf_0(filename, _T("%ls \"%ls\\%ls\""), o.editor, o.conn[config].config_dir, o.conn[config].config_file);
+  _sntprintf_0(filename, _T("%ls \"%ls\\%ls\""), o.editor, c->config_dir, c->config_file);
 
   /* fill in STARTUPINFO struct */
   GetStartupInfo(&start_info);
@@ -135,7 +135,7 @@ void EditConfig(int config)
 		     TRUE,
 		     CREATE_NEW_CONSOLE,
 		     NULL,
-		     o.conn[config].config_dir,	//start-up dir
+		     c->config_dir,	//start-up dir
 		     &start_info,
 		     &proc_info))
     {

--- a/viewlog.h
+++ b/viewlog.h
@@ -19,5 +19,7 @@
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-void ViewLog(int config);
-void EditConfig(int config);
+struct connection;
+
+void ViewLog(struct connection *c);
+void EditConfig(struct connection *c);


### PR DESCRIPTION
Currently we use an array of connection pointers which needs
to be reallocated when space runs out. But, that happens from
the main thread while the status thread may be referring to those
pointers. This can cause invalid memory access in some situations:
e.g., a connection is active and user adds tens of configs 
requiring a re-alloc during next re-scan.

Use a list instead of an array  so that connection pointer never
changes once created.