### PR TITLE
Bugfix AutoCloseHandler(): accommodate wraparound of 32 bit time

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -453,15 +453,15 @@ AutoCloseHandler(HWND hwnd, UINT UNUSED msg, UINT_PTR id, DWORD now)
     if (!ac)
         return;
 
-    UINT end = ac->start + ac->timeout;
-    if (now >= end)
+    DWORD elapsed = now - ac->start;
+    if (elapsed >= ac->timeout)
     {
         SimulateButtonPress(hwnd, ac->btn);
         AutoCloseCancel(hwnd);
     }
     else
     {
-        SetDlgItemText(hwnd, ac->txtid, LoadLocalizedString(ac->txtres, (end - now)/1000));
+        SetDlgItemText(hwnd, ac->txtid, LoadLocalizedString(ac->txtres, (ac->timeout - elapsed)/1000));
         SetTimer(hwnd, id, 500, AutoCloseHandler);
     }
 }


### PR DESCRIPTION
- GetTickcount() and current-time passed-in to the callback are both 32 bit which wraps around every ~50 days. In the stop condition compare the elasped ticks and timeout value instead of end-time and now. The latter can wraparound in a long-running process.

Signed-off-by: Selva Nair <selva.nair@gmail.com>