### PR TITLE
Check return value of SetProp()

### DIFF
--- a/as.c
+++ b/as.c
@@ -230,7 +230,7 @@ CRDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
     switch (msg) {
         case WM_INITDIALOG:
             param = (auth_param_t*)lParam;
-            SetProp(hwndDlg, cfgProp, (HANDLE)param);
+            TRY_SETPROP(hwndDlg, cfgProp, (HANDLE)param);
 
             WCHAR *wstr = Widen(param->str);
             if (!wstr) {
@@ -252,6 +252,7 @@ CRDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 
         case WM_COMMAND:
             param = (auth_param_t*)GetProp(hwndDlg, cfgProp);
+            CHECK_NULL_PARAM(param);
 
             switch (LOWORD(wParam)) {
             case ID_EDT_RESPONSE:
@@ -280,7 +281,6 @@ CRDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             return TRUE;
 
         case WM_NCDESTROY:
-            param = (auth_param_t*)GetProp(hwndDlg, cfgProp);
             RemoveProp(hwndDlg, cfgProp);
             break;
     }
@@ -614,7 +614,7 @@ ImportProfileFromURLDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lPa
     {
     case WM_INITDIALOG:
         type = (server_type_t) lParam;
-        SetProp(hwndDlg, cfgProp, (HANDLE)lParam);
+        TRY_SETPROP(hwndDlg, cfgProp, (HANDLE)lParam);
         SetStatusWinIcon(hwndDlg, ID_ICO_APP);
 
         if (type == server_generic)
@@ -630,6 +630,8 @@ ImportProfileFromURLDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lPa
 
     case WM_COMMAND:
         type = (server_type_t) GetProp(hwndDlg, cfgProp);
+        CHECK_NULL_PARAM(type);
+
         switch (LOWORD(wParam))
         {
         case ID_EDT_AUTH_USER:

--- a/openvpn.h
+++ b/openvpn.h
@@ -25,6 +25,21 @@
 
 #include "options.h"
 
+#define CHECK_NULL_PARAM(p)                                                          \
+            do { if (p) break;                                                       \
+                 MsgToEventLog(EVENTLOG_ERROR_TYPE, L"%hs:%d GetProp returned null", \
+                               __func__, __LINE__);                                  \
+                 return false;                                                       \
+               } while(0)
+
+#define TRY_SETPROP(hwnd, name, p)                                                   \
+            do { if (SetPropW(hwnd, name, p)) break;                                 \
+                 MsgToEventLog(EVENTLOG_ERROR_TYPE, L"%hs:%d GetProp returned null", \
+                               __func__, __LINE__);                                  \
+                 EndDialog(hwnd, IDABORT);                                           \
+                 return false;                                                       \
+               } while(0)
+
 BOOL StartOpenVPN(connection_t *);
 void StopOpenVPN(connection_t *);
 void DetachOpenVPN(connection_t *);

--- a/proxy.c
+++ b/proxy.c
@@ -341,7 +341,7 @@ ProxyAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
     case WM_INITDIALOG:
         /* Set connection for this dialog and show it */
         c = (connection_t *) lParam;
-        SetProp(hwndDlg, cfgProp, (HANDLE) c);
+        TRY_SETPROP(hwndDlg, cfgProp, (HANDLE) c);
         if (c->state == resuming)
             ForceForegroundWindow(hwndDlg);
         else
@@ -361,6 +361,7 @@ ProxyAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 
         case IDOK:
             c = (connection_t *) GetProp(hwndDlg, cfgProp);
+            CHECK_NULL_PARAM(c);
             proxy_type = (c->proxy_type == http ? "HTTP" : "SOCKS");
 
             snprintf(fmt, sizeof(fmt), "username \"%s Proxy\" \"%%s\"", proxy_type);


### PR DESCRIPTION
- If SetProp() is unsuccessful, we'll crash later when GetProp() returns null. Add a check, log the error and close the dialog.

  A check on GetProp() is also added, though not strictly necessary.

  We could abort here, but closing the current dialog and possibly the corresponding connection, provides a chance for the user to fix the OOM condition which is the most likely cause of SetProp() failure.

  Github: Fixes OpenVPN/openvpn-gui#577

Signed-off-by: Selva Nair <selva.nair@gmail.com>