### PR TITLE
Fix broken menu functionality with single profile

### DIFF
--- a/tray.c
+++ b/tray.c
@@ -169,7 +169,7 @@ CreatePopupMenus()
         hMenuConn[c->id] = CreatePopupMenu();
         /* Save the connection index in the menu.*/
         minfo.fMask = MIM_MENUDATA;
-        minfo.dwMenuData = (UINT_PTR) c;
+        minfo.dwMenuData = (ULONG_PTR) c;
         SetMenuInfo(hMenuConn[c->id], &minfo);
     }
     for (int i = 0; i < o.num_groups; i++)
@@ -189,6 +189,12 @@ CreatePopupMenus()
     SetMenuInfo(hMenu, &minfo);
 
     if (o.num_configs == 1 && o.chead) {
+        /* Set main menu's menudata to first connection */
+        minfo.fMask = MIM_MENUDATA;
+        GetMenuInfo(hMenu, &minfo);
+        minfo.dwMenuData = (ULONG_PTR) o.chead;
+        SetMenuInfo(hMenu, &minfo);
+
         /* Create Main menu with actions */
         AppendMenu(hMenu, MF_STRING, IDM_CONNECTMENU, LoadLocalizedString(IDS_MENU_CONNECT));
         AppendMenu(hMenu, MF_STRING, IDM_DISCONNECTMENU, LoadLocalizedString(IDS_MENU_DISCONNECT));


### PR DESCRIPTION
To get connection for menu command, we use "dwMenuData" property of a menu. With single connection profile we read "dwMenuData" of a main menu, not a submenu. There has been a bug in code which hasn't set "dwMenuData" for the main menu but it has worked until recently, since this property stored index of connection array and index 0 has always worked.

Since commit 94179911 ("Use a list instead of array for connections list") we have switched to a linked list and store list pointer in dwMenuData. However due to bug dwMenuData has always being 0, and logic which fetches connections doesn't work:

        minfo.fMask = MIM_MENUDATA;
        GetMenuInfo((HMENU) lParam, &minfo);
        c  = (connection_t *) minfo.dwMenuData;
        if (!c)
            break; /* ignore invalid connection */

Fix by assigning main menu's dwMenuData to a value of submenu's dwMenuData in case of we have single connection - in that case we have submenu's actions (connect/disconnect) in a main menu. This way we can fetch connection from main menu's dwMenuData.

Fixes https://github.com/OpenVPN/openvpn-gui/issues/592

Signed-off-by: Lev Stipakov <lev@openvpn.net>