### PR TITLE
Bring back delay before management is ready

### DIFF
--- a/manage.c
+++ b/manage.c
@@ -345,7 +345,8 @@ OnManagement(SOCKET sk, LPARAM lParam)
                 else if (strncmp(pos, "INFO:", 5) == 0)
                 {
                     /* delay until management interface accepts input */
-                    OVPNMsgWait(100, c->hwndStatus);
+                    /* use real sleep here, since WM_MANAGEMENT might arrive before management is ready */
+                    Sleep(100);
                     c->manage.connected = 2;
                     if (rtmsg_handler[ready_])
                         rtmsg_handler[ready_](c, pos + 5);


### PR DESCRIPTION
Commit 2b1e5867

  "Replace Sleep by a Wait function that pumps messages"

replaced Sleep() with a wait function which also processes messages. However WM_MANAGEMENT message in some cases requires actual delay to be processed. To acheve that, filter out WM_MANAGEMENT from message dispatching.

Fixes https://github.com/OpenVPN/openvpn-gui/issues/619