### PR TITLE
Always update tray icon on state change

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -438,6 +438,10 @@ OnStateChange(connection_t *c, char *data)
             SetStatusWinIcon(c->hwndStatus, ID_ICO_CONNECTING);
         }
     }
+    else
+    {
+        CheckAndSetTrayIcon();
+    }
 }
 
 static void


### PR DESCRIPTION
The tray icon and its tip text get updated to the connecting state when starting a new status window thread. This is not enough for persistent connections as these can be restarted from the hold state which does not go through a new thread creation.

To see the bug, disconnect and reconnect a persistent connection and have it wait in the connecting state. The tray icon colour does not change to yellow and the tray tip message does not show the "Connecting to:" text.

Fix by ensuring that  CheckAndSetTrayIcon() or SetTrayIcon() gets called whenever a state change message is received.

Fixes issue #668