### PR TITLE
Validate the service pipe to avoid connecting to a bogus pipe

### DIFF
--- a/service.h
+++ b/service.h
@@ -25,3 +25,6 @@ BOOL CheckIServiceStatus(BOOL warn);
 
 /* Attempt to start OpenVPN Automatc Service */
 void StartAutomaticService(void);
+
+/* Get the processId of the Interactive Service */
+ULONG GetServicePid(void);


### PR DESCRIPTION
If an attacker with SeImeprsonatePrivilege manages to create a namedpipe server with a name matching that used by the "Interactive Service", the GUI connecting to it could allow the attacker to impersonate the GUI user.

Fix by validating the service pipe by comparing the pid of the pipe server with that of the "Interactive Service".

Note: GetNamedPipeServerProcessId() returns the pid of the process that created the first instance of the pipe. So, this patch only guards against a rogue pipe instance created before the service has started. This has to work in combination with a patch for the service that disallows creation of additional pipe instances when the service is running.

CVE: CVE-2024-4877
Reported by: Zeze with TeamT5 <zeze7w@gmail.com>

Acked-by: Lev Stipakov <lstipakov@gmail.com>