### PR TITLE
Add a global option to always prompt for OTP

### DIFF
--- a/localization.c
+++ b/localization.c
@@ -640,6 +640,10 @@ GeneralSettingsDlgProc(HWND hwndDlg, UINT msg, UNUSED WPARAM wParam, LPARAM lPar
             {
                 Button_SetCheck(GetDlgItem(hwndDlg, ID_CHK_AUTO_RESTART), BST_CHECKED);
             }
+            if (o.auth_pass_concat_otp)
+            {
+                Button_SetCheck(GetDlgItem(hwndDlg, ID_CHK_CONCAT_OTP), BST_CHECKED);
+            }
 
             break;
 
@@ -704,7 +708,8 @@ GeneralSettingsDlgProc(HWND hwndDlg, UINT msg, UNUSED WPARAM wParam, LPARAM lPar
                     (Button_GetCheck(GetDlgItem(hwndDlg, ID_CHK_SHOW_SCRIPT_WIN)) == BST_CHECKED);
                 o.enable_auto_restart =
                     (Button_GetCheck(GetDlgItem(hwndDlg, ID_CHK_AUTO_RESTART)) == BST_CHECKED);
-
+                o.auth_pass_concat_otp =
+                    (Button_GetCheck(GetDlgItem(hwndDlg, ID_CHK_CONCAT_OTP)) == BST_CHECKED);
 
                 SaveRegistryKeys();
 

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -166,6 +166,10 @@
 #define ID_LVW_PKCS11                    451
 #define ID_TXT_PKCS11                    452
 
+/* General settings contd.. */
+
+#define ID_CHK_CONCAT_OTP                470
+
 /*
  * String Table Resources
  */
@@ -263,6 +267,7 @@
 #define IDS_NFO_CONN_CANCELLED          1264
 #define IDS_NFO_STATE_ROUTE_ERROR       1265
 #define IDS_NFO_NOTIFY_ROUTE_ERROR      1266
+#define IDS_NFO_OTP_PROMPT              1267
 
 /* Program Startup Related */
 #define IDS_ERR_OPEN_DEBUG_FILE         1301

--- a/openvpn.c
+++ b/openvpn.c
@@ -581,6 +581,10 @@ UserAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
                 }
 
             }
+            else if (param->flags & FLAG_CR_TYPE_CONCAT)
+            {
+                SetDlgItemTextW(hwndDlg, ID_TXT_AUTH_CHALLENGE, LoadLocalizedString(IDS_NFO_OTP_PROMPT));
+            }
             if (RecallUsername(param->c->config_name, username))
             {
                 SetDlgItemTextW(hwndDlg, ID_EDT_AUTH_USER, username);
@@ -1428,6 +1432,11 @@ OnPassword(connection_t *c, char *msg)
             param->flags |= (flags & 0x2) ? FLAG_CR_TYPE_CONCAT : FLAG_CR_TYPE_SCRV1;
             param->flags |= (flags & 0x1) ? FLAG_CR_ECHO : 0;
             param->str = strdup(chstr + 5);
+            LocalizedDialogBoxParamEx(ID_DLG_AUTH_CHALLENGE, c->hwndStatus, UserAuthDialogFunc, (LPARAM) param);
+        }
+        else if (o.auth_pass_concat_otp)
+        {
+            param->flags |= FLAG_CR_ECHO | FLAG_CR_TYPE_CONCAT;
             LocalizedDialogBoxParamEx(ID_DLG_AUTH_CHALLENGE, c->hwndStatus, UserAuthDialogFunc, (LPARAM) param);
         }
         else

--- a/options.h
+++ b/options.h
@@ -206,6 +206,7 @@ typedef struct {
     TCHAR priority_string[64];
     TCHAR ovpn_admin_group[MAX_NAME];
     DWORD disable_save_passwords;
+    DWORD auth_pass_concat_otp;
     /* HKCU registry values */
     TCHAR config_dir[MAX_PATH];
     TCHAR ext_string[16];

--- a/registry.c
+++ b/registry.c
@@ -67,6 +67,7 @@ struct regkey_int {
     {L"management_port_offset", &o.mgmt_port_offset, 25340},
     {L"enable_peristent_connections", &o.enable_persistent, 2},
     {L"enable_auto_restart", &o.enable_auto_restart, 1},
+    {L"auth_pass_concat_otp", &o.auth_pass_concat_otp, 0},
     {L"ovpn_engine", &o.ovpn_engine, OPENVPN_ENGINE_OVPN2}
 };
 

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Spuštění", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Spustit při startu Windows", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Volby", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Volby", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Připojovat záznamy na konec logu", ID_CHK_LOG_APPEND, 17, 95, 130, 10
     AUTOCHECKBOX "Zobrazit okno skriptu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Tiché spojení", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -559,6 +560,7 @@ jednou jako správce, aby se registr aktualizoval."
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Systemstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Mit &Windows starten", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Einstellungen", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Einstellungen", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "An &Log anhängen", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "&Skriptfenster zeigen", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille &Verbindung", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 180, 200, 50, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -561,6 +562,7 @@ als Administrator ausführen, um die Registry zu aktualisieren."
     IDS_NFO_AUTO_CONNECT    "Verbindet automatisch in %u Sekunden…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI läuft bereits. Klicken Sie rechts auf das Symbol in der Taskleiste, um die Anwendung zu starten."
     IDS_NFO_BYTECOUNT "Bytes eingehend: %ls  ausgehend: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Autostart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Start med Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Indstillinger", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Indstillinger", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Tilføj til log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Vis script vindue", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille forbindelse", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -559,6 +560,7 @@ en gang som administrator for at opdatere registret."
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -178,7 +178,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on User &Logon", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "A&ppend to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script &window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "S&ilent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -193,6 +193,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -576,6 +577,7 @@ once as Administrator to update the registry."
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -162,7 +162,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -177,6 +177,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -556,6 +557,7 @@ nuevo como Administrator para actualizar el registro."
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -170,7 +170,7 @@ BEGIN
     GROUPBOX "شروع به کار", 202, 6, 47, 235, 30
     AUTOCHECKBOX "شروع به کار - وقتی کاربر وارد شد", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "تنظیمات", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "تنظیمات", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "چسباندن به گزارشات", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "نمایش پنجره اسکریپت", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "بی صدا(اعلان) متصل شدن", ID_CHK_SILENT, 17, 125, 200, 10
@@ -185,6 +185,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -566,6 +567,7 @@ OpenVPN احتمالا نصب نشده است"
     IDS_NFO_AUTO_CONNECT    "اتصال خودکار در %u ثانیه آینده…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI قبلا باز شده. کلیک راست کنید بر روی آن در نماد های برنامه ها."
     IDS_NFO_BYTECOUNT "بایت به: %ls  خروج: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "خطا در واکشی نمایه از URL: [%d] %ls"

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Käynnistäminen", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Käynnistä Windowsiin kirjautuessa", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Valinnat", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Valinnat", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Lisää lokitiedostoon", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Näytä komentosarjaikkuna", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Yhdistä taustalla", ID_CHK_SILENT, 17, 125, 200, 10
@@ -178,6 +178,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -560,6 +561,7 @@ ajaa ylläpitäjän oikeuksin, jotta se saa lisättyä rekisteriin tietoja."
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Démarrage", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Lancer au démarrage de Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Préférences", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Préférences", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Ajouter au fichier log", ID_CHK_LOG_APPEND, 17, 95, 81, 10
     AUTOCHECKBOX "Afficher la fenêtre des scripts", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connexion silencieuse", ID_CHK_SILENT, 17, 125, 200, 10
@@ -178,6 +178,7 @@ BEGIN
     AUTORADIOBUTTON "&Inactif", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Activer le fournisseur d'&accès à la pré-ouverture de session", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Activer le redémarrage auto des connexions activées", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -559,6 +560,7 @@ en tant qu'Administrator pour mettre à jour la base de registre."
     IDS_NFO_AUTO_CONNECT    "Connecter automatiquement dans %u secondes…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI est déjà en cours d'exécution. Faites un clic droit sur l'icône de la barre d'état pour commencer."
     IDS_NFO_BYTECOUNT "Octets entrants : %ls sortants : %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Erreur lors de la récupération du profil à partir de l'URL: [%d] %ls"

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Opzioni avvio", 202, 6, 47, 235, 30
     AUTOCHECKBOX "&Esegui all'avvio di Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Impostazioni", ID_GROUPBOX3, 6, 82, 235, 175
+    GROUPBOX "Impostazioni", ID_GROUPBOX3, 6, 82, 235, 190
     AUTOCHECKBOX "Aggiungi in coda al f&ile registro", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Visualizza &finestra script", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connessione &silenziosa", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTOCHECKBOX "Abilita provider di pre-accesso/accesso", ID_CHK_PLAP_REG, 17, 215, 200, 10
     LTEXT "(richiede accesso come amministratore)", 220, 28, 225, 200, 10
     AUTOCHECKBOX "Abilita riavvio automatico connessioni attive", ID_CHK_AUTO_RESTART, 17, 240, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 255, 200, 10
 END
 
 /* Advanced Dialog */
@@ -562,6 +563,7 @@ Puoi far partire questa applicazione una volta che l'amministratore ha aggiornat
     IDS_NFO_AUTO_CONNECT    "Connessione automatica tra %u secondi…"
     IDS_NFO_CLICK_HERE_TO_START "L'interfaccia di OpenVPN è già in esecuzione.\nPer avviare fai clic con il tasto destro sull'icona nell'area di notifica."
     IDS_NFO_BYTECOUNT "Byte in: %ls out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Errore durante il recupero del profilo dall'URL: [%d] %ls"

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "起動", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Windows起動時に開始(&L)", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "設定", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "設定", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "ログ追記モード(&P)", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "スクリプト実行ウィンドウを表示(&W)", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "サイレント接続モード(&I)", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "OTPを要求し、パスワードと組み合わせる", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -559,6 +560,7 @@ OpenVPNがインストールされていない可能性があります。"
     IDS_NFO_AUTO_CONNECT    "%u 秒で自動的に再接続します…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI は既に実行されています。トレイアイコンを右クリックして開始してください。"
     IDS_NFO_BYTECOUNT "バイト数 受信: %ls  送信: %ls"
+    IDS_NFO_OTP_PROMPT "OTPまたはパスコード"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -165,7 +165,7 @@ BEGIN
     GROUPBOX "시작 설정", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Windows 시작 시에 실행", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "환경 설정", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "환경 설정", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "로그 파일에 추가", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "스크립트 창 보기", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "연결 시 상태 대화 상자 표시하지 않기", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -557,6 +558,7 @@ Administrator 권한으로 이 프로그램을 실행해야 합니다."
     IDS_NFO_AUTO_CONNECT    "%u초 후 자동으로 연결..."
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI 가 이미 실행 중입니다. 시작하려면 작업 표시줄의 아이콘을 마우스 우클릭 하십시오."
     IDS_NFO_BYTECOUNT "수신 바이트: %ls  전송 바이트: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Opstarten", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Opstarten met Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Voorkeuren", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Voorkeuren", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Aan logbestand toevoegen", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Script-venster tonen", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille verbinding", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -560,6 +561,7 @@ om de registerinstellingen te updaten."
     IDS_NFO_AUTO_CONNECT    "Automatisch verbinden over %u seconden..."
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI draait al. Klik met de rechtermuisknop op het tray icon om te starten."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  uit: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Oppstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Kjør automatisk når Windows starter", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Innstillinger", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Innstillinger", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Tilføy til eksisterende logg", ID_CHK_LOG_APPEND, 17, 95, 93, 10
     AUTOCHECKBOX "Vis scriptvindu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Skjul statusvindu ved tilkobling", ID_CHK_SILENT, 17, 125, 200, 10
@@ -178,6 +178,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -550,6 +551,7 @@ Wintun driver will not work."
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Uruchamianie", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Uruchamiaj po zalogowaniu się użytkownika", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferencje", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Preferencje", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Dodaj do dziennika", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Pokaż okno skryptu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Połączenie dyskretne", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -558,6 +559,7 @@ z prawami administratora aby uaktualnić rejestr."
     IDS_NFO_AUTO_CONNECT    "Automatycznie połączenie za %u sek…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI jest już uruchomiony. Kliknij prawym przyciskiem myszy na ikonę w pasku zadań aby rozpocząć."
     IDS_NFO_BYTECOUNT "Bajtów pobranych: %ls  wysłanych: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -162,7 +162,7 @@ BEGIN
     GROUPBOX "Inicialização", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Executar ao iniciar o Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferências", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Preferências", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Anexar ao log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Mostrar janela de script", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Conexão silenciosa", ID_CHK_SILENT, 17, 125, 200, 10
@@ -177,6 +177,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -558,6 +559,7 @@ uma vez como Administrador para alterar o registro."
     IDS_NFO_AUTO_CONNECT    "Conectando automaticamente em %u segundos…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI já está em execução. Clique direito no ícone da área de notificação para iniciar."
     IDS_NFO_BYTECOUNT "Bytes recebidos: %ls  enviados: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -165,7 +165,7 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускать при старте Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Настройки", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Настройки", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Дописывать, а не перезаписывать журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показывать окно выполнения", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихое» подключение", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -559,6 +560,7 @@ OpenVPN, возможно, не установлен."
     IDS_NFO_AUTO_CONNECT    "Автоматическое подключение через %u сек..."
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI уже запущен. Нажмите правой кнопкой на иконке в трее чтобы развернуть."
     IDS_NFO_BYTECOUNT "Входящие байты: %ls  Исходящие байты: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Ошибка получения профиля по ссылке: [%d] %ls"

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -162,7 +162,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -177,6 +177,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -553,6 +554,7 @@ Wintun driver ska inte fungera."
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -558,6 +559,7 @@ sistem yönetici haklarına sahip olmanız gerekmektedir.."
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускати при старті Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Налаштування", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "Налаштування", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "Додати, а не перезаписувати журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показувати вікно виконання", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихе» підключення", ID_CHK_SILENT, 17, 125, 200, 10
@@ -178,6 +178,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -559,6 +560,7 @@ OpenVPN, можливо, не встановлений."
     IDS_NFO_AUTO_CONNECT    "Автоматичне підключення через %u секунд…"
     IDS_NFO_CLICK_HERE_TO_START "Графічний інтерфейс OpenVPN вже запущений. Клацніть правою кнопкою мишки на піктограмі OpenVPN в лотку, щоб його запустити."
     IDS_NFO_BYTECOUNT "Завантажено байт: %ls Передано байт: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -166,7 +166,7 @@ BEGIN
     GROUPBOX "启动", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 开机时启动", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好设置", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "偏好设置", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "追加日志文件", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "显示脚本窗口", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "静默连接", ID_CHK_SILENT, 17, 125, 200, 10
@@ -181,6 +181,7 @@ BEGIN
     AUTORADIOBUTTON "禁用", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "启用预登录访问提供程序（需要管理员访问权限）", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "启用活动连接的自动重新启动", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -560,6 +561,7 @@ Wintun驱动程序将无法正常工作。"
     IDS_NFO_AUTO_CONNECT    "在 %u 秒后自动连接..."
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI 已经运行. 右击任务栏图标启动."
     IDS_NFO_BYTECOUNT "接收字节: %ls  发送字节: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "从URL获取配置文件时出错:[%d] %ls"

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -166,7 +166,7 @@ BEGIN
     GROUPBOX "啟動", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 開機時執行", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好設定", ID_GROUPBOX3, 6, 82, 235, 165
+    GROUPBOX "偏好設定", ID_GROUPBOX3, 6, 82, 235, 180
     AUTOCHECKBOX "附加記錄檔", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "顯示指令碼視窗", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "寧靜連線", ID_CHK_SILENT, 17, 125, 200, 10
@@ -181,6 +181,7 @@ BEGIN
     AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
@@ -560,6 +561,7 @@ Wintun driver will not work."
     IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
     IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
     IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
+    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
 
     /* AS profile import */
     IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"


### PR DESCRIPTION
This is more like a quick solution for user requests such as #663.
This is built on top of #701, by adding a global option to always prompt for OTP and submit it concatenated with password. Submitting as a separate PR as I'm not fully convinced of the need for this.

The newly extended static-challenge config option (GUI support is in PR #701)  that can optionally specify concatenation format should be preferred over this. Always prompting for OTP could confuse users when none are required.  But the former will be available only in OpenVPN 2.7 while this is immediately usable.