### PR TITLE
Fix a Y2038 bug by replacing `Int32x32To64` with regular multiplication

### DIFF
--- a/localization.c
+++ b/localization.c
@@ -189,7 +189,7 @@ LocalizedTime(const time_t t, LPTSTR buf, size_t size)
     /* Convert Unix timestamp to Win32 SYSTEMTIME */
     FILETIME lft;
     SYSTEMTIME st;
-    LONGLONG tmp = Int32x32To64(t, 10000000) + 116444736000000000;
+    LONGLONG tmp = (t * 10000000LL) + 116444736000000000LL;
     FILETIME ft = { .dwLowDateTime = (DWORD) tmp, .dwHighDateTime = tmp >> 32};
     FileTimeToLocalFileTime(&ft, &lft);
     FileTimeToSystemTime(&lft, &st);


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>