### PR TITLE
Disable config in menu listing if its ovpn file becomes inaccessible

### DIFF
--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -280,6 +280,15 @@ ActivateConfigGroups(void)
             cg->active = true;
             cg = PARENT_GROUP(cg);
         }
+        /* also deactivate any configs that are no longer readable */
+        if (CheckReadAccess(c->config_dir, c->config_file))
+        {
+            c->flags &= ~FLAG_CONFIG_DISABLED;
+        }
+        else
+        {
+            c->flags |= FLAG_CONFIG_DISABLED;
+        }
     }
 }
 

--- a/options.h
+++ b/options.h
@@ -97,6 +97,7 @@ typedef struct
 #define FLAG_DISABLE_ECHO_MSG        (1 << 7)
 #define FLAG_DAEMON_PERSISTENT       (1 << 8)
 #define FLAG_WAIT_UNLOCK             (1 << 9)
+#define FLAG_CONFIG_DISABLED         (1 << 10)
 
 #define CONFIG_VIEW_AUTO             (0)
 #define CONFIG_VIEW_FLAT             (1)

--- a/tray.c
+++ b/tray.c
@@ -740,7 +740,8 @@ SetMenuStatus(connection_t *c, conn_state_t state)
     {
         if (state == disconnected || state == detached)
         {
-            EnableMenuItem(hMenu, IDM_CONNECTMENU, MF_ENABLED);
+            EnableMenuItem(
+                hMenu, IDM_CONNECTMENU, (c->flags & FLAG_CONFIG_DISABLED) ? MF_GRAYED : MF_ENABLED);
             EnableMenuItem(hMenu, IDM_DISCONNECTMENU, MF_GRAYED);
             EnableMenuItem(hMenu, IDM_RECONNECTMENU, MF_GRAYED);
             EnableMenuItem(hMenu, IDM_STATUSMENU, MF_GRAYED);
@@ -819,10 +820,17 @@ SetMenuStatus(connection_t *c, conn_state_t state)
 
         if (state == disconnected || state == detached)
         {
-            EnableMenuItem(hMenuConn[i], IDM_CONNECTMENU, MF_ENABLED);
-            EnableMenuItem(hMenuConn[i], IDM_DISCONNECTMENU, MF_GRAYED);
-            EnableMenuItem(hMenuConn[i], IDM_RECONNECTMENU, MF_GRAYED);
-            EnableMenuItem(hMenuConn[i], IDM_STATUSMENU, MF_GRAYED);
+            if (c->flags & FLAG_CONFIG_DISABLED)
+            {
+                EnableMenuItem(parent->menu, pos, MF_BYPOSITION | MF_GRAYED);
+            }
+            else
+            {
+                EnableMenuItem(hMenuConn[i], IDM_CONNECTMENU, MF_ENABLED);
+                EnableMenuItem(hMenuConn[i], IDM_DISCONNECTMENU, MF_GRAYED);
+                EnableMenuItem(hMenuConn[i], IDM_RECONNECTMENU, MF_GRAYED);
+                EnableMenuItem(hMenuConn[i], IDM_STATUSMENU, MF_GRAYED);
+            }
         }
         else if (state == connecting || state == resuming || state == connected)
         {


### PR DESCRIPTION
Since the introduction of persistent connections, we no longer recreate the entire config menu but only add newly added connection profiles during each rescan. This leaves any deleted configs actively displayed in the menu until the GUI is restarted.

Improve this situation by graying out entries corresponding to profiles not readable from file system. If the file reappears, the item gets automatically enabled again.

Also, if the corresponding connection is active, the item is not grayed out to allow the user to disconnect or reconnect it. Otherwise the corresponding OpenVPN core process will hang around with no way to control it from the GUI. Here "active" includes those on management-hold in case of persistent connections, as those can be started even if the underlying config file has gone missing.

Addresses github issue #729