### PR TITLE
Hide password reveal eye icon when no response box is shown

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -911,14 +911,16 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             {
                 ShowWindow(GetDlgItem(hwndDlg, ID_LTEXT_RESPONSE), SW_HIDE);
                 ShowWindow(GetDlgItem(hwndDlg, ID_EDT_RESPONSE), SW_HIDE);
+                ShowWindow(GetDlgItem(hwndDlg, ID_PASSWORD_REVEAL), SW_HIDE);
             }
             else
             {
                 /* disable OK button until response is filled-in */
                 EnableWindow(GetDlgItem(hwndDlg, IDOK), FALSE);
+                ResetPasswordReveal(GetDlgItem(hwndDlg, ID_EDT_RESPONSE),
+                                    GetDlgItem(hwndDlg, ID_PASSWORD_REVEAL),
+                                    0);
             }
-            ResetPasswordReveal(
-                GetDlgItem(hwndDlg, ID_EDT_RESPONSE), GetDlgItem(hwndDlg, ID_PASSWORD_REVEAL), 0);
 
             break;
 


### PR DESCRIPTION
When CR_TEXT or dynamic CR prompt is triggered with 'response not required' ('R' not present in flags), we hide the response box, but not the password reveal eye icon. Fix it.

Avoids this lonely eye:
![lonely-eye](https://github.com/user-attachments/assets/29f78a8c-e2a1-418f-a3f5-93a58326b868)
