### PR TITLE
Improve Turkish (tr) localization for OpenVPN GUI

### DIFF
--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -32,7 +32,7 @@ BEGIN
     LTEXT "Şifreyi Giriniz:", 201, 6, 6, 100, 10
     EDITTEXT ID_EDT_PASSPHRASE, 6, 17, 107, 12, ES_PASSWORD | ES_AUTOHSCROLL
     ICON ID_ICO_EYE, ID_PASSWORD_REVEAL, 126, 18, 14, 14, SS_ICON|SS_NOTIFY|SS_REALSIZEIMAGE
-    CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 33, 100, 10
+    CHECKBOX "Şifreyi Kaydet", ID_CHK_SAVE_PASS, 6, 33, 100, 10
     PUSHBUTTON "Tamam", IDOK, 20, 49, 50, 14
     PUSHBUTTON "Çıkış", IDCANCEL, 90, 49, 50, 14
     LTEXT "", ID_TXT_WARNING, 6, 65, 100, 10
@@ -50,7 +50,7 @@ BEGIN
     EDITTEXT ID_EDT_AUTH_USER, 50, 6, 104, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_AUTH_PASS, 50, 23, 104, 12, ES_PASSWORD | ES_AUTOHSCROLL
     ICON ID_ICO_EYE, ID_PASSWORD_REVEAL, 156, 24, 14, 14, SS_ICON|SS_NOTIFY|SS_REALSIZEIMAGE
-    CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 42, 100, 10
+    CHECKBOX "Şifreyi Kaydet", ID_CHK_SAVE_PASS, 6, 42, 100, 10
     PUSHBUTTON "Tamam", IDOK, 20, 58, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Çıkış", IDCANCEL, 90, 58, 52, 14
     LTEXT "", ID_TXT_WARNING, 6, 80, 150, 10
@@ -72,7 +72,7 @@ BEGIN
     ICON ID_ICO_EYE, ID_PASSWORD_REVEAL, 156, 24, 14, 14, SS_ICON|SS_NOTIFY|SS_REALSIZEIMAGE
     LTEXT "", ID_TXT_AUTH_CHALLENGE, 6, 43, 148, 10
     EDITTEXT ID_EDT_AUTH_CHALLENGE, 60, 57, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
-    CHECKBOX "Save password", ID_CHK_SAVE_PASS, 6, 76, 100, 10
+    CHECKBOX "Şifreyi Kaydet", ID_CHK_SAVE_PASS, 6, 76, 100, 10
     PUSHBUTTON "Tamam", IDOK, 20, 92, 50, 14, BS_PUSHBUTTON | WS_TABSTOP | WS_DISABLED
     PUSHBUTTON "Çıkış", IDCANCEL, 90, 92, 52, 14
     LTEXT "", ID_TXT_WARNING, 6, 108, 150, 10
@@ -107,7 +107,7 @@ BEGIN
     LTEXT "", ID_TXT_IP, 20, 160, 300, 10
     PUSHBUTTON "Bağlantıyı Kes", ID_DISCONNECT, 50, 190, 50, 14
     PUSHBUTTON "Yeniden Bağlan", ID_RESTART, 150, 190, 50, 14
-    PUSHBUTTON "De&tach", ID_DETACH, 180, 190, 50, 14, WS_DISABLED
+    PUSHBUTTON "&Ayır", ID_DETACH, 180, 190, 50, 14, WS_DISABLED
     PUSHBUTTON "Gizle", ID_HIDE, 100, 190, 50, 14
 END
 
@@ -161,74 +161,74 @@ BEGIN
     GROUPBOX "Kullanıcı Arayüzü", 201, 6, 12, 235, 30
     LTEXT "Dil:", ID_TXT_LANGUAGE, 17, 25, 52, 12
     COMBOBOX ID_CMB_LANGUAGE, 31, 23, 197, 400, CBS_DROPDOWNLIST | WS_TABSTOP
-    GROUPBOX "Startup", 202, 6, 47, 235, 30
-    AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
+    GROUPBOX "Başlangıç", 202, 6, 47, 235, 30
+    AUTOCHECKBOX "Windows başlangıcında çalıştır", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 180
-    AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
-    AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
-    AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
-    AUTOCHECKBOX "Always use interactive service", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
-    LTEXT "Show Balloon", ID_TXT_BALLOON, 17, 155, 100, 10
-    AUTORADIOBUTTON "On connect", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "On connect/reconnect", ID_RB_BALLOON2, 86, 170, 90, 10
-    AUTORADIOBUTTON "Never", ID_RB_BALLOON0, 181, 170, 40, 10
-    LTEXT "Persistent Connections", ID_TXT_PERSISTENT, 17, 185, 100, 10
-    AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "&Manual", ID_RB_BALLOON4, 86, 200, 90, 10
-    AUTORADIOBUTTON "&Disable", ID_RB_BALLOON5, 181, 200, 40, 10
-    AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
-    AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
-    AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    GROUPBOX "Tercihler", ID_GROUPBOX3, 6, 82, 235, 180
+    AUTOCHECKBOX "Günlüğe ekle", ID_CHK_LOG_APPEND, 17, 95, 60, 10
+    AUTOCHECKBOX "Betik penceresini göster", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
+    AUTOCHECKBOX "Sessiz bağlantı", ID_CHK_SILENT, 17, 125, 200, 10
+    AUTOCHECKBOX "Her zaman etkileşimli servis kullan", ID_CHK_ALWAYS_USE_ISERVICE, 17, 140, 200, 10
+    LTEXT "Balon Bildirimi Göster", ID_TXT_BALLOON, 17, 155, 100, 10
+    AUTORADIOBUTTON "Bağlanırken", ID_RB_BALLOON1, 28, 170, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "Bağlanırken/yeniden bağlanırken", ID_RB_BALLOON2, 86, 170, 90, 10
+    AUTORADIOBUTTON "Asla", ID_RB_BALLOON0, 181, 170, 40, 10
+    LTEXT "Kalıcı Bağlantılar", ID_TXT_PERSISTENT, 17, 185, 100, 10
+    AUTORADIOBUTTON "&Otomatik", ID_RB_BALLOON3, 28, 200, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "&Manuel", ID_RB_BALLOON4, 86, 200, 90, 10
+    AUTORADIOBUTTON "&Devre Dışı", ID_RB_BALLOON5, 181, 200, 40, 10
+    AUTOCHECKBOX "Oturum Açma Öncesi &Erişim Sağlayıcıyı Etkinleştir (yönetici erişimi gerektirir)", ID_CHK_PLAP_REG, 17, 215, 200, 10
+    AUTOCHECKBOX "Aktif bağlantıların otomatik yeniden başlatılmasını etkinleştir", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
+    AUTOCHECKBOX "OTP sorgusu yap ve şifreyle birleştir", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
 END
 
 /* Advanced Dialog */
 ID_DLG_ADVANCED DIALOGEX 6, 18, 252, ADVANCED_DIALOG_HEIGHT
 STYLE WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU | DS_CENTER
-CAPTION "Advanced"
+CAPTION "Gelişmiş"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 BEGIN
-    GROUPBOX "Configuration Files", 201, 6, 12, 235, 45
-    LTEXT "Folder:", ID_TXT_FOLDER, 17, 25, 32, 10
-    LTEXT "Extension:", ID_TXT_EXTENSION, 17, 40, 52, 10
+    GROUPBOX "Yapılandırma Dosyaları", 201, 6, 12, 235, 45
+    LTEXT "Klasör:", ID_TXT_FOLDER, 17, 25, 32, 10
+    LTEXT "Uzantı:", ID_TXT_EXTENSION, 17, 40, 52, 10
     EDITTEXT ID_EDT_CONFIG_DIR, 53, 23, 150, 12, ES_AUTOHSCROLL
     EDITTEXT ID_EDT_CONFIG_EXT, 53, 38, 25, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_CONFIG_DIR, 208, 23, 25, 12
 
-    GROUPBOX "Log Files", 202, 6, 62, 235, 30
-    LTEXT "Folder:", ID_TXT_FOLDER1, 17, 74, 32, 10
+    GROUPBOX "Günlük Dosyaları", 202, 6, 62, 235, 30
+    LTEXT "Klasör:", ID_TXT_FOLDER1, 17, 74, 32, 10
     EDITTEXT ID_EDT_LOG_DIR, 53, 72, 150, 12, ES_AUTOHSCROLL
     PUSHBUTTON "…", ID_BTN_LOG_DIR, 208, 72, 25, 12
 
-    GROUPBOX "Script Timeout", 203, 6, 97, 235, 60
-    LTEXT "Preconnect script timeout:", ID_TXT_PRECONNECT_TIMEOUT, 17, 110, 100, 10
-    LTEXT "Connect script timeout:", ID_TXT_CONNECT_TIMEOUT, 17, 125, 90, 10
-    LTEXT "Disconnect script timeout:", ID_TXT_DISCONNECT_TIMEOUT, 17, 140, 90, 10
+    GROUPBOX "Betik Zaman Aşımı", 203, 6, 97, 235, 60
+    LTEXT "Bağlantı öncesi betik zaman aşımı:", ID_TXT_PRECONNECT_TIMEOUT, 17, 110, 100, 10
+    LTEXT "Bağlantı betiği zaman aşımı:", ID_TXT_CONNECT_TIMEOUT, 17, 125, 90, 10
+    LTEXT "Bağlantı kesme betiği zaman aşımı:", ID_TXT_DISCONNECT_TIMEOUT, 17, 140, 90, 10
     EDITTEXT ID_EDT_PRECONNECT_TIMEOUT, 103, 108, 20, 12, ES_AUTOHSCROLL|ES_NUMBER
     EDITTEXT ID_EDT_CONNECT_TIMEOUT, 103, 123, 20, 12, ES_AUTOHSCROLL|ES_NUMBER
     EDITTEXT ID_EDT_DISCONNECT_TIMEOUT, 103, 138, 20, 12, ES_AUTOHSCROLL|ES_NUMBER
 
-    GROUPBOX "Management interface", 204, 6, 163, 235, 30
-    LTEXT "Port offset:", 205, 17, 175, 75, 10
+    GROUPBOX "Yönetim arayüzü", 204, 6, 163, 235, 30
+    LTEXT "Port ofseti:", 205, 17, 175, 75, 10
     EDITTEXT ID_EDT_MGMT_PORT, 103, 173, 30, 12, ES_AUTOHSCROLL
 
-    GROUPBOX "Config menu view", 206, 6, 198, 235, 30
-    AUTORADIOBUTTON "&Auto", ID_RB_BALLOON0, 28, 210, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "&Flat", ID_RB_BALLOON1, 88, 210, 50, 10
-    AUTORADIOBUTTON "&Nested", ID_RB_BALLOON2, 148, 210, 50, 10
+    GROUPBOX "Yapılandırma menüsü görünümü", 206, 6, 198, 235, 30
+    AUTORADIOBUTTON "&Otomatik", ID_RB_BALLOON0, 28, 210, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "&Düz", ID_RB_BALLOON1, 88, 210, 50, 10
+    AUTORADIOBUTTON "&İç İçe", ID_RB_BALLOON2, 148, 210, 50, 10
 
-    GROUPBOX "Echo message display", 207, 6, 233, 235, 45
-    AUTORADIOBUTTON "A&uto", ID_RB_BALLOON3, 28, 245, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "Ne&ver", ID_RB_BALLOON4, 88, 245, 50, 10
-    LTEXT "Repeated messages are muted for: ", 208, 17, 260, 125, 10
+    GROUPBOX "Echo mesaj görüntüleme", 207, 6, 233, 235, 45
+    AUTORADIOBUTTON "&Otomatik", ID_RB_BALLOON3, 28, 245, 50, 10, WS_GROUP | WS_TABSTOP
+    AUTORADIOBUTTON "&Asla", ID_RB_BALLOON4, 88, 245, 50, 10
+    LTEXT "Tekrarlanan mesajlar şu süre boyunca sessize alınır: ", 208, 17, 260, 125, 10
     EDITTEXT ID_EDT_POPUP_MUTE, 150, 258, 30, 12, ES_AUTOHSCROLL
-    LTEXT "hours", 209, 190, 260, 40, 10
+    LTEXT "saat", 209, 190, 260, 40, 10
 
 #if ENABLE_OVPN3
-    GROUPBOX "OpenVPN Engine", ID_RB_ENGINE_SELECTION, 6, 283, 235, 30
+    GROUPBOX "OpenVPN Motoru", ID_RB_ENGINE_SELECTION, 6, 283, 235, 30
     AUTORADIOBUTTON "OpenVPN2", ID_RB_ENGINE_OVPN2, 18, 296, 50, 10, WS_GROUP | WS_TABSTOP
-    AUTORADIOBUTTON "OpenVPN3 (experimental)", ID_RB_ENGINE_OVPN3, 76, 296, 90, 10
+    AUTORADIOBUTTON "OpenVPN3 (deneysel)", ID_RB_ENGINE_OVPN3, 76, 296, 90, 10
 #endif
 
 END
@@ -274,34 +274,34 @@ END
 /* URL Profile Import Dialog */
 ID_DLG_URL_PROFILE_IMPORT DIALOGEX 6, 18, 249, 95
 STYLE WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU | DS_CENTER | DS_SETFOREGROUND
-CAPTION "Import Profile from Access Server"
+CAPTION "Erişim Sunucusundan Profil İçe Aktar"
 FONT 8, "Microsoft Sans Serif"
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 BEGIN
     LTEXT "U&RL:", 201, 6, 9, 50, 10
     EDITTEXT ID_EDT_URL, 60, 6, 183, 12, ES_AUTOHSCROLL
-    LTEXT "&Username:", 202, 6, 26, 50, 10
+    LTEXT "&Kullanıcı Adı:", 202, 6, 26, 50, 10
     EDITTEXT ID_EDT_AUTH_USER, 60, 23, 94, 12, ES_AUTOHSCROLL
-    LTEXT "&Password:", ID_LTEXT_PASSWORD, 6, 42, 50, 10
+    LTEXT "&Şifre:", ID_LTEXT_PASSWORD, 6, 42, 50, 10
     EDITTEXT ID_EDT_AUTH_PASS, 60, 40, 94, 12, ES_PASSWORD | ES_AUTOHSCROLL
     ICON ID_ICO_EYE, ID_PASSWORD_REVEAL, 156, 41, 14, 14, SS_ICON|SS_NOTIFY|SS_REALSIZEIMAGE
-    AUTOCHECKBOX "&Autologin", ID_CHK_AUTOLOGIN, 6, 59, 100, 10
-    PUSHBUTTON "&OK", IDOK, 20, 76, 50, 14, BS_PUSHBUTTON | WS_TABSTOP | WS_DISABLED
-    PUSHBUTTON "&Cancel", IDCANCEL, 90, 76, 52, 14
+    AUTOCHECKBOX "&Otomatik Giriş", ID_CHK_AUTOLOGIN, 6, 59, 100, 10
+    PUSHBUTTON "&Tamam", IDOK, 20, 76, 50, 14, BS_PUSHBUTTON | WS_TABSTOP | WS_DISABLED
+    PUSHBUTTON "&İptal", IDCANCEL, 90, 76, 52, 14
 END
 
 /* Query PKCS11-ID Dialog */
 ID_DLG_PKCS11_QUERY DIALOGEX 6, 18, 340, 242
 STYLE WS_SIZEBOX| WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU | DS_CENTER | DS_SETFONT
-CAPTION "Select Certificate"
+CAPTION "Sertifika Seç"
 FONT 8, "Segoe UI"
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 BEGIN
-    LTEXT "PKCS11 Certificates available:", ID_TXT_PKCS11, 17, 12, 171, 12
+    LTEXT "Kullanılabilir PKCS11 Sertifikaları:", ID_TXT_PKCS11, 17, 12, 171, 12
     CONTROL "", ID_LVW_PKCS11, "SysListView32", LVS_REPORT | LVS_SINGLESEL | WS_BORDER | WS_TABSTOP, 17, 25, 171,150
-    PUSHBUTTON "&OK", IDOK, 20, 200, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP
-    PUSHBUTTON "&Cancel", IDCANCEL, 90, 200, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
-    PUSHBUTTON "&Retry", IDRETRY, 160, 200, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
+    PUSHBUTTON "&Tamam", IDOK, 20, 200, 50, 14, BS_DEFPUSHBUTTON | WS_TABSTOP
+    PUSHBUTTON "&İptal", IDCANCEL, 90, 200, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
+    PUSHBUTTON "&Yeniden Dene", IDRETRY, 160, 200, 50, 14, BS_PUSHBUTTON | WS_TABSTOP
     LTEXT "", ID_TXT_WARNING, 6, 222, 190, 10
 END
 
@@ -312,7 +312,7 @@ FONT 8, "Segoe UI"
 LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 BEGIN
     CONTROL "", ID_STATIC_QR, "Static", SS_BITMAP | WS_VISIBLE | SS_CENTERIMAGE, 0, 0, 10, 10
-    LTEXT "Scan this QR code on your mobile to proceed with authentication.", ID_TXT_QR, 0, 0, 10, 10, SS_CENTER | WS_VISIBLE | SS_EDITCONTROL
+    LTEXT "Kimlik doğrulama işlemine devam etmek için bu QR kodunu mobil cihazınızla tarayın.", ID_TXT_QR, 0, 0, 10, 10, SS_CENTER | WS_VISIBLE | SS_EDITCONTROL
 END
 
 STRINGTABLE
@@ -326,20 +326,20 @@ BEGIN
     IDS_TIP_CONNECTED_SINCE "\nBağlanıldı: "
     IDS_TIP_ASSIGNED_IP "\nBağlanılan IP: %ls"
     IDS_MENU_SERVICE "OpenVPN Servisi"
-    IDS_MENU_IMPORT "Import"
-    IDS_MENU_IMPORT_AS "Import from Access Server…"
-    IDS_MENU_IMPORT_URL "Import from URL…"
-    IDS_MENU_IMPORT_FILE "Import file…"
+    IDS_MENU_IMPORT "İçe Aktar"
+    IDS_MENU_IMPORT_AS "Erişim Sunucusundan İçe Aktar…"
+    IDS_MENU_IMPORT_URL "URL'den İçe Aktar…"
+    IDS_MENU_IMPORT_FILE "Dosyadan İçe Aktar…"
     IDS_MENU_SETTINGS "Ayarlar…"
     IDS_MENU_CLOSE "Çıkış"
     IDS_MENU_CONNECT "Bağlan"
     IDS_MENU_DISCONNECT "Bağlantıyı Kes"
-    IDS_MENU_RECONNECT "Reconnect"
+    IDS_MENU_RECONNECT "Yeniden Bağlan"
     IDS_MENU_STATUS "Durum"
     IDS_MENU_VIEWLOG "Günlüğe Bak"
     IDS_MENU_EDITCONFIG "Ayarlar"
     IDS_MENU_PASSPHRASE "Şifreyi Değiştir"
-    IDS_MENU_CLEARPASS  "Clear Saved Passwords"
+    IDS_MENU_CLEARPASS  "Kayıtlı Şifreleri Temizle"
     IDS_MENU_SERVICE_START "Başla"
     IDS_MENU_SERVICE_STOP "Durdur"
     IDS_MENU_SERVICE_RESTART "Yeniden Başlat"
@@ -354,10 +354,10 @@ BEGIN
 
     /* OpenVPN */
     IDS_ERR_MANY_CONFIGS "OpenVPN GUI %d den fazla konfigürasyonu desteklemiyor. Eğer daha fazlasına ihtiyacınız varsa lütfen hak sahibi ile görüşün."
-    IDS_NFO_NO_CONFIGS "No readable connection profiles (config files) found.\n\
-Use the ""Import File.."" menu or copy your config files to ""%ls"" or ""%ls""."
-    IDS_ERR_CONFIG_NOT_AUTHORIZED "Starting this connection (%ls) requires membership in \
-""%ls"" group. Contact your system administrator.\n"
+    IDS_NFO_NO_CONFIGS "Okunabilir bağlantı profilleri (yapılandırma dosyaları) bulunamadı.\n\
+""Dosyadan İçe Aktar..."" menüsünü kullanın veya yapılandırma dosyalarınızı ""%ls"" veya ""%ls"" konumuna kopyalayın."
+    IDS_ERR_CONFIG_NOT_AUTHORIZED "Bu bağlantıyı başlatmak (%ls) \
+""%ls"" grubuna üyelik gerektiriyor. Sistem yöneticinizle iletişime geçin.\n"
     IDS_ERR_CONFIG_TRY_AUTHORIZE  "Starting this connection (%ls) requires membership in \
 ""%ls"" group.\n\n\
 Do you want to add yourself to this group?\n\
@@ -382,7 +382,7 @@ Please complete the previous authorization dialog."
     IDS_ERR_CREATE_THREAD_STATUS "CreateThread anında durum penceresi gösterilemedi hatası."
     IDS_NFO_STATE_WAIT_TERM "Geçerli Durum: OpenVPN' in kapanması bekleniyor…"
     IDS_NFO_STATE_CONNECTED "Geçerli Durum: Bağlandı"
-    IDS_NFO_STATE_ONHOLD "Current State: On Hold (disconnected)"
+    IDS_NFO_STATE_ONHOLD "Geçerli Durum: Beklemede (bağlantı kesildi)"
     IDS_NFO_NOW_CONNECTED "%ls şu an bağlı."
     IDS_NFO_ASSIGN_IP "Atanan IP: %ls"
     IDS_ERR_CERT_EXPIRED "Sertifikanız veya sistem tarih/zaman ayarlarınız geçersiz olduğundan bağlantı sağlanamadı."
@@ -552,56 +552,56 @@ sistem yönetici haklarına sahip olmanız gerekmektedir.."
     IDS_NFO_IMPORT_SUCCESS "File imported successfully."
     IDS_NFO_IMPORT_OVERWRITE "A config named ""%ls"" already exists. Do you want to replace it?"
     IDS_NFO_IMPORT_SOURCE "Do you want to import the profile <%ls>?"
-    IDS_ERR_IMPORT_SOURCE "Cannot import file <%ls> as it is already in the global or local config directory"
-    IDS_ERR_IMPORT_ACCESS "Cannot import <%ls> as it is missing or not readable"
+    IDS_ERR_IMPORT_SOURCE "<%ls> dosyası, zaten genel veya yerel yapılandırma dizininde olduğu için içe aktarılamıyor"
+    IDS_ERR_IMPORT_ACCESS "<%ls> eksik veya okunamaz olduğu için içe aktarılamıyor"
 
     /* save/delete password */
-    IDS_NFO_DELETE_PASS "Press OK to delete saved passwords for config ""%ls"""
+    IDS_NFO_DELETE_PASS """%ls"" yapılandırması için kaydedilmiş şifreleri silmek için Tamam'a basın"
 
     /* Token password related */
-    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Password"
-    IDS_NFO_TOKEN_PASSWORD_REQUEST "Input Password/PIN for Token '%hs'"
+    IDS_NFO_TOKEN_PASSWORD_CAPTION "OpenVPN – Token Şifresi"
+    IDS_NFO_TOKEN_PASSWORD_REQUEST "'%hs' Token için Şifre/PIN Girin"
 
-    IDS_NFO_AUTH_PASS_RETRY "Wrong credentials. Try again…"
-    IDS_NFO_KEY_PASS_RETRY  "Wrong password. Try again…"
-    IDS_ERR_INVALID_PASSWORD_INPUT "Invalid character in password"
-    IDS_ERR_INVALID_USERNAME_INPUT "Invalid character in username"
-    IDS_NFO_AUTO_CONNECT    "Connecting automatically in %u seconds…"
-    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI is already running. Right click on the tray icon to start."
-    IDS_NFO_BYTECOUNT "Bytes in: %ls  out: %ls"
-    IDS_NFO_OTP_PROMPT "Input OTP or passcode"
+    IDS_NFO_AUTH_PASS_RETRY "Yanlış kimlik bilgileri. Tekrar deneyin…"
+    IDS_NFO_KEY_PASS_RETRY  "Yanlış şifre. Tekrar deneyin…"
+    IDS_ERR_INVALID_PASSWORD_INPUT "Şifrede geçersiz karakter"
+    IDS_ERR_INVALID_USERNAME_INPUT "Kullanıcı adında geçersiz karakter"
+    IDS_NFO_AUTO_CONNECT    "%u saniye içinde otomatik olarak bağlanılıyor…"
+    IDS_NFO_CLICK_HERE_TO_START "OpenVPN GUI zaten çalışıyor. Başlatmak için sistem tepsisi simgesine sağ tıklayın."
+    IDS_NFO_BYTECOUNT "Gelen bayt: %ls  giden: %ls"
+    IDS_NFO_OTP_PROMPT "OTP veya geçiş kodu girin"
 
     /* AS profile import */
-    IDS_ERR_URL_IMPORT_PROFILE "Error fetching profile from URL: [%d] %ls"
+    IDS_ERR_URL_IMPORT_PROFILE "URL'den profil alınırken hata: [%d] %ls"
 
-    IDS_ERR_NO_PKCS11 "No certificates found. If you have a token insert it and press retry."
-    IDS_ERR_SELECT_PKCS11 "No certificates selected."
+    IDS_ERR_NO_PKCS11 "Sertifika bulunamadı. Bir token'ınız varsa takın ve yeniden deneyin."
+    IDS_ERR_SELECT_PKCS11 "Hiçbir sertifika seçilmedi."
     /* column headers for pkcs11 certificate list */
-    IDS_CERT_DISPLAYNAME "Issued to"
-    IDS_CERT_ISSUER "Issued by"
-    IDS_CERT_NOTAFTER "Valid until"
+    IDS_CERT_DISPLAYNAME "Şuna verildi"
+    IDS_CERT_ISSUER "Veren"
+    IDS_CERT_NOTAFTER "Geçerlilik süresi"
 
 
     /* PLAP related */
-    IDS_NFO_STATE_RETRYING "Retrying"
-    IDS_NFO_STATE_CANCELLING "Cancelling"
-    IDS_NFO_STATE_DISCONNECTING "Disconnecting"
-    IDS_NFO_CONN_CANCELLED "Connection cancelled by user"
+    IDS_NFO_STATE_RETRYING "Yeniden Deneniyor"
+    IDS_NFO_STATE_CANCELLING "İptal Ediliyor"
+    IDS_NFO_STATE_DISCONNECTING "Bağlantı Kesiliyor"
+    IDS_NFO_CONN_CANCELLED "Bağlantı kullanıcı tarafından iptal edildi"
 
     /* openvpn daemon state names -- these are shown on progress dialog in PLAP */
-    IDS_NFO_OVPN_STATE_INITIAL      "Initializing"
-    IDS_NFO_OVPN_STATE_CONNECTING   "Connecting"
-    IDS_NFO_OVPN_STATE_ASSIGN_IP    "Assigning IP address"
-    IDS_NFO_OVPN_STATE_ADD_ROUTES   "Adding routes"
-    IDS_NFO_OVPN_STATE_CONNECTED    "Connected"
-    IDS_NFO_OVPN_STATE_RECONNECTING "Reconnecting"
-    IDS_NFO_OVPN_STATE_EXITING      "Exiting"
-    IDS_NFO_OVPN_STATE_WAIT         "Waiting"
-    IDS_NFO_OVPN_STATE_AUTH         "Authenticating"
-    IDS_NFO_OVPN_STATE_GET_CONFIG   "Pulling configuration from server"
-    IDS_NFO_OVPN_STATE_RESOLVE      "Resolving remote host"
-    IDS_NFO_OVPN_STATE_TCP_CONNECT  "Establishing TCP connection"
-    IDS_NFO_OVPN_STATE_AUTH_PENDING "Authentication pending"
+    IDS_NFO_OVPN_STATE_INITIAL      "Başlatılıyor"
+    IDS_NFO_OVPN_STATE_CONNECTING   "Bağlanıyor"
+    IDS_NFO_OVPN_STATE_ASSIGN_IP    "IP adresi atanıyor"
+    IDS_NFO_OVPN_STATE_ADD_ROUTES   "Rotalar ekleniyor"
+    IDS_NFO_OVPN_STATE_CONNECTED    "Bağlandı"
+    IDS_NFO_OVPN_STATE_RECONNECTING "Yeniden bağlanıyor"
+    IDS_NFO_OVPN_STATE_EXITING      "Çıkılıyor"
+    IDS_NFO_OVPN_STATE_WAIT         "Bekleniyor"
+    IDS_NFO_OVPN_STATE_AUTH         "Kimlik doğrulanıyor"
+    IDS_NFO_OVPN_STATE_GET_CONFIG   "Sunucudan yapılandırma alınıyor"
+    IDS_NFO_OVPN_STATE_RESOLVE      "Uzak ana bilgisayar çözümleniyor"
+    IDS_NFO_OVPN_STATE_TCP_CONNECT  "TCP bağlantısı kuruluyor"
+    IDS_NFO_OVPN_STATE_AUTH_PENDING "Kimlik doğrulama bekliyor"
     IDS_NFO_OVPN_STATE_UNKNOWN      "?"
 
 END


### PR DESCRIPTION
Sorry for being late.

This commit significantly improves the Turkish localization of the OpenVPN GUI by 
translating numerous strings that were previously in English. The changes include:

1. User Interface Elements:
   - Translated all remaining English text in dialog boxes
   - Properly localized checkbox and button labels
   - Updated radio button text to Turkish
   - Improved existing translations for better clarity

2. Dialog Box Translations:
   - Passphrase Dialog: Translated "Save password" to "Şifreyi Kaydet"
   - Authentication Dialog: Translated remaining English elements
   - Advanced Dialog: Fully translated all configuration options
   - General Settings: Translated UI preferences and options
   - URL Profile Import: Localized all elements

3. Menu Items:
   - Translated all import-related menu options
   - Localized "Clear Saved Passwords" to "Kayıtlı Şifreleri Temizle"
   - Fixed other menu item translations

4. Status and Error Messages:
   - Translated OpenVPN daemon state names for connection progress
   - Localized error messages for import functionality
   - Updated authentication-related notifications
   - Translated PKCS11 certificate list headers

5. Technical Terminology:
   - Consistently translated technical terms across the application
   - Used appropriate Turkish terminology for networking concepts

These changes provide a more consistent and professional Turkish localization
that will improve the user experience for Turkish-speaking users.
Regards.