### PR TITLE
Change WM_RBUTTONUP to WM_CONTEXTMENU

### DIFF
--- a/main.c
+++ b/main.c
@@ -513,7 +513,7 @@ HandleCopyDataMessage(const COPYDATASTRUCT *copy_data)
     }
     else if (copy_data->dwData == WM_OVPN_RESCAN)
     {
-        OnNotifyTray(WM_OVPN_RESCAN);
+        OnNotifyTray(0, WM_OVPN_RESCAN);
     }
     else
     {
@@ -653,7 +653,7 @@ WindowProcedure(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_NOTIFYICONTRAY:
-            OnNotifyTray(lParam); /* Manages message from tray */
+            OnNotifyTray(wParam, lParam); /* Manages message from tray */
             break;
 
         case WM_COPYDATA: /* custom messages with data from other processes */

--- a/tray.c
+++ b/tray.c
@@ -427,17 +427,20 @@ PositionTrayToolTip(LONG x, LONG y)
  * Handle mouse clicks on tray icon
  */
 void
-OnNotifyTray(LPARAM lParam)
+OnNotifyTray(WPARAM wParam, LPARAM lParam)
 {
     POINT pt;
 
     /* Use LOWORD(lParam)  as HIWORD() contains the icon id if uVersion >= 4 */
     switch (LOWORD(lParam))
     {
-        case WM_RBUTTONUP:
+        case WM_CONTEXTMENU:
             RecreatePopupMenus();
+            /* wParam contains the upper left corner of the anchor point */
 
-            GetCursorPos(&pt);
+            pt.x = (int)LOWORD(wParam);
+            pt.y = (int)HIWORD(wParam);
+
             SetForegroundWindow(o.hWnd);
             TrackPopupMenu(hMenu, TPM_RIGHTALIGN, pt.x, pt.y, 0, o.hWnd, NULL);
             PostMessage(o.hWnd, WM_NULL, 0, 0);

--- a/tray.h
+++ b/tray.h
@@ -49,7 +49,7 @@ void RecreatePopupMenus(void);
 
 void CreatePopupMenus();
 
-void OnNotifyTray(LPARAM);
+void OnNotifyTray(WPARAM, LPARAM);
 
 void OnDestroyTray(void);
 


### PR DESCRIPTION
Required for correct behavior under right click as well as keyboard event (Shift-F10) for context menu.

The location of the context menu is now taken from the message as the cursor position may not match when triggered by keyboard event.

Fixes Github #763