### PR TITLE
Use GetTempPath() for debug file in plap as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ add_executable(${TEST_PLAP_EXE}
 target_link_libraries(${TEST_PLAP_EXE} PRIVATE
     Rpcrt4
     Ole32
+    Shlwapi
     Gdi32)
 
 target_include_directories(${TEST_PLAP_EXE} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})

--- a/plap/Makefile.am
+++ b/plap/Makefile.am
@@ -39,6 +39,7 @@ AM_CPPFLAGS = -I$(srcdir)/..
 
 libopenvpn_plap_la_CFLAGS = -D_UNICODE -municode
 test_plap_CXXFLAGS = -DDEBUG -D_UNICODE -municode
+test_plap_CFLAGS = -DDEBUG -D_UNICODE -municode
 
 libopenvpn_plap_la_RESOURCES = \
 	$(top_srcdir)/res/openvpn-gui-res-cs.rc \
@@ -127,4 +128,4 @@ credentialprovider.h:
 
 test_plap_SOURCES = test_plap.cpp test-plap-res.rc test-plap.manifest plap_common.c credentialprovider.h
 test_plap_LDFLAGS = -static-libgcc -static-libstdc++
-test_plap_LDADD = -lrpcrt4 -lole32 -lgdi32 -lcomctl32
+test_plap_LDADD = -lrpcrt4 -lole32 -lgdi32 -lcomctl32 -lshlwapi

--- a/plap/plap_common.c
+++ b/plap/plap_common.c
@@ -30,15 +30,34 @@
 #include <time.h>
 
 #include "localization.h"
+
 static FILE *fp;
 static CRITICAL_SECTION log_write;
 
 void
 init_debug()
 {
+    if (fp)
+    {
+        return;
+    }
+    /* try to open debug file in TempPath -- failure is not critical */
+    WCHAR tempPath[MAX_PATH];
+    DWORD pathLen = GetTempPathW(MAX_PATH, tempPath);
+    if (pathLen == 0 || pathLen > MAX_PATH)
+    {
+        return;
+    }
+
+    WCHAR fullPath[MAX_PATH];
+    if (!PathCombineW(fullPath, tempPath, L"openvpn-plap-debug.txt"))
+    {
+        return;
+    }
+    _wfopen_s(&fp, fullPath, L"a+,ccs=UTF-8");
     if (!fp)
     {
-        _wfopen_s(&fp, L"C:\\Windows\\Temp\\openvpn-plap-debug.txt", L"a+,ccs=UTF-8");
+        return;
     }
     InitializeCriticalSection(&log_write);
 }


### PR DESCRIPTION
This is mainly useful for running test_plap.exe as user. For plap dll running as SYSTEM, `Windows\Temp` is usually the same as what GetTempPath() returns.