### PR TITLE
Migrate all saved plain usernames to encrypted format

### DIFF
--- a/plap/stub.c
+++ b/plap/stub.c
@@ -217,3 +217,8 @@ CheckKeyFileWriteAccess(UNUSED connection_t *c)
 {
     return 0;
 }
+
+void
+MigrateUsername(UNUSED const WCHAR *config_name)
+{
+}

--- a/save_pass.c
+++ b/save_pass.c
@@ -258,18 +258,19 @@ RecallUsernamePlain(const WCHAR *config_name, WCHAR *username)
 int
 RecallUsername(const WCHAR *config_name, WCHAR *username)
 {
-    int res = recall_encrypted(config_name, username, USER_PASS_LEN, AUTH_USER_ENC_DATA);
-    if (res)
-    {
-        return res;
-    }
-    /* Check whether old style plain username is available and migrate it */
-    res = RecallUsernamePlain(config_name, username);
-    if (res && SaveUsername(config_name, username))
+    return recall_encrypted(config_name, username, USER_PASS_LEN, AUTH_USER_ENC_DATA);
+}
+
+/* Convert saved plain text username to encrypted form */
+void
+MigrateUsername(const WCHAR *config_name)
+{
+    WCHAR username[USER_PASS_LEN];
+
+    if (RecallUsernamePlain(config_name, username) && SaveUsername(config_name, username))
     {
         DeleteConfigRegistryValue(config_name, AUTH_USER_DATA);
     }
-    return res;
 }
 
 void

--- a/save_pass.h
+++ b/save_pass.h
@@ -49,4 +49,6 @@ BOOL IsAuthPassSaved(const WCHAR *config_name);
 
 BOOL IsKeyPassSaved(const WCHAR *config_name);
 
+void MigrateUsername(const WCHAR *config_name);
+
 #endif /* ifndef SAVEPASS_H */


### PR DESCRIPTION
This is done at startup of the GUI as a part of registry version upgrade process.

Turned out to be easier than I thought -- could have done this in the encrypted username patch.