### PR TITLE
Check correct management daemon path when OpenVPN3 is enabled

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -1457,7 +1457,12 @@ ValidateManagementDaemon(connection_t *c)
     wchar_t win32_path[MAX_PATH];
     swprintf(win32_path, _countof(win32_path), L"%ls%ls", L"\\\\?\\GLOBALROOT", nt_path);
 
+#ifdef ENABLE_OVPN3
+    TCHAR *exe_path = o.ovpn_engine == OPENVPN_ENGINE_OVPN3 ? o.omi_exe_path : o.exe_path;
+    res = IsSamePath(win32_path, exe_path);
+#else
     res = IsSamePath(win32_path, o.exe_path);
+#endif
     if (!res)
     {
         MsgToEventLog(EVENTLOG_ERROR_TYPE,

--- a/options.h
+++ b/options.h
@@ -218,6 +218,9 @@ typedef struct
     TCHAR ovpn_admin_group[MAX_NAME];
     DWORD disable_save_passwords;
     DWORD auth_pass_concat_otp;
+#ifdef ENABLE_OVPN3
+    TCHAR omi_exe_path[MAX_PATH];
+#endif
     /* HKCU registry values */
     TCHAR config_dir[MAX_PATH];
     TCHAR ext_string[16];

--- a/registry.c
+++ b/registry.c
@@ -157,6 +157,14 @@ GetGlobalRegistryKeys()
         _sntprintf_0(o.exe_path, _T("%lsbin\\openvpn.exe"), o.install_path);
     }
 
+#ifdef ENABLE_OVPN3
+    /* for OVPN3, always expect the value to be set in the registry */
+    if (regkey)
+    {
+        GetRegistryValue(regkey, _T("omi_exe_path"), o.omi_exe_path, _countof(o.omi_exe_path));
+    }
+#endif
+
     if (!regkey
         || !GetRegistryValue(
             regkey, _T("priority"), o.priority_string, _countof(o.priority_string)))


### PR DESCRIPTION
If OpenVPN3 is enabled then the check needs to verify against the `omi_exe_path` registry key, not the `exe_path` key.

Fixes #779.