### PR TITLE
Escape the type id of password message received from openvpn

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -1008,14 +1008,14 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
                         template = "password \"%s\" \"%%s\"";
                     }
 
-                    fmt = malloc(strlen(template) + strlen(param->id));
-                    if (fmt)
+                    char *escaped_id = escape_string(param->id);
+                    fmt = malloc(strlen(template) + (escaped_id ? strlen(escaped_id) : 0));
+                    if (fmt && escaped_id)
                     {
                         string_mod(param->id, "%", '_');
-                        sprintf(fmt, template, param->id);
+                        sprintf(fmt, template, escaped_id);
                         PrintDebug(L"Send passwd to mgmt with format: '%hs'", fmt);
                         ManagementCommandFromInput(param->c, fmt, hwndDlg, ID_EDT_RESPONSE);
-                        free(fmt);
                     }
                     else /* no memory? send stop signal */
                     {
@@ -1025,6 +1025,8 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
                                        false);
                         StopOpenVPN(param->c);
                     }
+                    free(fmt);
+                    free(escaped_id);
 
                     EndDialog(hwndDlg, LOWORD(wParam));
                     return TRUE;


### PR DESCRIPTION
For password/PIN requests such as for a token, the type of the request includes the token name. This string is included in the response (parsed as param->id). When such strings contain special characters such as quotes, we currently fail as openvpn.exe cannot parse the response correctly:

Eg., token name = "Test Token" including the quotes, lead to the following error:

  password of type '' entered, but we need one of type '"Test Token" token'

We already escape username and password. Escape param->id as well.