### PR TITLE
Check the return value of GetProp()

### DIFF
--- a/as.c
+++ b/as.c
@@ -307,7 +307,7 @@ CRDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_COMMAND:
-            param = (auth_param_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, param, FALSE);
 
             switch (LOWORD(wParam))
             {
@@ -765,7 +765,7 @@ ImportProfileFromURLDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lPa
             break;
 
         case WM_COMMAND:
-            type = (server_type_t)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, type, FALSE);
             switch (LOWORD(wParam))
             {
                 case ID_EDT_AUTH_PASS:

--- a/openvpn.c
+++ b/openvpn.c
@@ -695,7 +695,7 @@ UserAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_COMMAND:
-            param = (auth_param_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, param, FALSE);
             switch (LOWORD(wParam))
             {
                 case ID_EDT_AUTH_PASS:
@@ -828,7 +828,7 @@ UserAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 
         case WM_CLOSE:
             EndDialog(hwndDlg, LOWORD(wParam));
-            param = (auth_param_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, param, TRUE);
             StopOpenVPN(param->c);
             return TRUE;
 
@@ -939,7 +939,7 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_COMMAND:
-            param = (auth_param_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, param, FALSE);
             const char *template;
             char *fmt;
             switch (LOWORD(wParam))
@@ -1050,7 +1050,7 @@ GenericPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
              * other than GET_CONFIG. The state is in lParam.
              * For other auth dialogs any state change signals a restart: end the dialog
              */
-            param = (auth_param_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, param, TRUE);
             if (!(param->flags & FLAG_CR_TYPE_CRTEXT) || strcmp((const char *)lParam, "GET_CONFIG"))
             {
                 EndDialog(hwndDlg, LOWORD(wParam));
@@ -1127,7 +1127,7 @@ PrivKeyPassDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_COMMAND:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             switch (LOWORD(wParam))
             {
                 case ID_CHK_SAVE_PASS:
@@ -2508,7 +2508,7 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             return TRUE;
 
         case WM_COMMAND:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             switch (LOWORD(wParam))
             {
                 case ID_DISCONNECT:
@@ -2547,7 +2547,7 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             return FALSE;
 
         case WM_CLOSE:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, TRUE);
             if (c->state != disconnected && c->state != detached)
             {
                 ShowWindow(hwndDlg, SW_HIDE);
@@ -2568,7 +2568,7 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_OVPN_RELEASE:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             c->state = reconnecting;
             SetDlgItemText(
                 c->hwndStatus, ID_TXT_STATUS, LoadLocalizedString(IDS_NFO_STATE_RECONNECTING));
@@ -2578,7 +2578,7 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_OVPN_STOP:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             /* external messages can trigger when we are not ready -- check the state */
             if (!IsWindowEnabled(GetDlgItem(c->hwndStatus, ID_DISCONNECT)) || c->state == onhold)
             {
@@ -2598,7 +2598,7 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_OVPN_DETACH:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             /* just stop the thread keeping openvpn.exe running */
             c->state = detaching;
             EnableWindow(GetDlgItem(c->hwndStatus, ID_DISCONNECT), FALSE);
@@ -2607,7 +2607,7 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_OVPN_SUSPEND:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             c->state = suspending;
             EnableWindow(GetDlgItem(c->hwndStatus, ID_DISCONNECT), FALSE);
             EnableWindow(GetDlgItem(c->hwndStatus, ID_RESTART), FALSE);
@@ -2620,7 +2620,7 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 
         case WM_TIMER:
             PrintDebug(L"WM_TIMER message with wParam = %lu", wParam);
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             if (wParam == IDT_STOP_TIMER)
             {
                 /* openvpn failed to respond to stop signal -- terminate */
@@ -2631,7 +2631,7 @@ StatusDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_OVPN_RESTART:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             /* external messages can trigger when we are not ready -- check the state */
             if (IsWindowEnabled(GetDlgItem(c->hwndStatus, ID_RESTART)))
             {

--- a/openvpn.h
+++ b/openvpn.h
@@ -30,9 +30,23 @@
     {                                                                                            \
         if (SetPropW(hwnd, name, p))                                                             \
             break;                                                                               \
-        MsgToEventLog(EVENTLOG_ERROR_TYPE, L"%hs:%d GetProp returned null", __func__, __LINE__); \
+        MsgToEventLog(EVENTLOG_ERROR_TYPE, L"%hs:%d SetProp returned null", __func__, __LINE__); \
         EndDialog(hwnd, IDABORT);                                                                \
         return false;                                                                            \
+    } while (0)
+
+/* A macro to set lval = GetProp(hwnd, name) or log an error and return err_return */
+#define TRY_GETPROP(hwnd, name, lval, err_return)                                          \
+    do                                                                                     \
+    {                                                                                      \
+        HANDLE handle_##lval = GetProp(hwnd, name);                                        \
+        if (!handle_##lval)                                                                \
+        {                                                                                  \
+            MsgToEventLog(                                                                 \
+                EVENTLOG_ERROR_TYPE, L"%hs:%d GetProp returned null", __func__, __LINE__); \
+            return err_return;                                                             \
+        }                                                                                  \
+        lval = (__typeof__(lval))handle_##lval;                                            \
     } while (0)
 
 BOOL StartOpenVPN(connection_t *);

--- a/pkcs11.c
+++ b/pkcs11.c
@@ -476,7 +476,9 @@ pkcs11_listview_init(HWND parent)
 static void CALLBACK
 pkcs11_listview_fill(HWND hwnd, UINT UNUSED msg, UINT_PTR id, DWORD UNUSED now)
 {
-    connection_t *c = (connection_t *)GetProp(hwnd, cfgProp);
+    connection_t *c;
+    TRY_GETPROP(hwnd, cfgProp, c, );
+
     struct pkcs11_list *l = &c->pkcs11_list;
 
     HWND lv = GetDlgItem(hwnd, ID_LVW_PKCS11);
@@ -539,7 +541,8 @@ pkcs11_listview_fill(HWND hwnd, UINT UNUSED msg, UINT_PTR id, DWORD UNUSED now)
 static void
 pkcs11_listview_reset(HWND parent)
 {
-    connection_t *c = (connection_t *)GetProp(parent, cfgProp);
+    connection_t *c;
+    TRY_GETPROP(parent, cfgProp, c, );
     struct pkcs11_list *l = &c->pkcs11_list;
     HWND lv = GetDlgItem(parent, ID_LVW_PKCS11);
 
@@ -610,7 +613,7 @@ QueryPkcs11DialogProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             return TRUE;
 
         case WM_COMMAND:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             if (LOWORD(wParam) == IDOK)
             {
                 HWND lv = GetDlgItem(hwndDlg, ID_LVW_PKCS11);
@@ -664,7 +667,7 @@ QueryPkcs11DialogProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             return FALSE;
 
         case WM_NOTIFY:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
+            TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
             if (((NMHDR *)lParam)->idFrom == ID_LVW_PKCS11)
             {
                 NMITEMACTIVATE *ln = (NMITEMACTIVATE *)lParam;
@@ -681,9 +684,9 @@ QueryPkcs11DialogProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_CLOSE:
-            c = (connection_t *)GetProp(hwndDlg, cfgProp);
-            StopOpenVPN(c);
             EndDialog(hwndDlg, wParam);
+            TRY_GETPROP(hwndDlg, cfgProp, c, TRUE);
+            StopOpenVPN(c);
             return TRUE;
 
         case WM_NCDESTROY:

--- a/proxy.c
+++ b/proxy.c
@@ -379,7 +379,7 @@ ProxyAuthDialogFunc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam)
                     break;
 
                 case IDOK:
-                    c = (connection_t *)GetProp(hwndDlg, cfgProp);
+                    TRY_GETPROP(hwndDlg, cfgProp, c, FALSE);
                     proxy_type = (c->proxy_type == http ? "HTTP" : "SOCKS");
 
                     snprintf(fmt, sizeof(fmt), "username \"%s Proxy\" \"%%s\"", proxy_type);


### PR DESCRIPTION
Most of GetProp() calls are replaced by a macro that logs a message and returns on error.