### PR TITLE
Do not delete entropy data when clearing passwords

### DIFF
--- a/save_pass.c
+++ b/save_pass.c
@@ -291,7 +291,6 @@ DeleteSavedPasswords(const WCHAR *config_name)
 {
     DeleteConfigRegistryValue(config_name, KEY_PASS_DATA);
     DeleteConfigRegistryValue(config_name, AUTH_PASS_DATA);
-    DeleteConfigRegistryValue(config_name, ENTROPY_DATA);
 }
 
 /* check if auth password is saved */


### PR DESCRIPTION
This data is required for decrypting saved username. Fixes: issue #809