### PR TITLE
New sorting option

### DIFF
--- a/localization.c
+++ b/localization.c
@@ -655,6 +655,10 @@ GeneralSettingsDlgProc(HWND hwndDlg, UINT msg, UNUSED WPARAM wParam, LPARAM lPar
             {
                 Button_SetCheck(GetDlgItem(hwndDlg, ID_CHK_CONCAT_OTP), BST_CHECKED);
             }
+            if (o.sort_configs)
+            {
+                Button_SetCheck(GetDlgItem(hwndDlg, ID_CHK_SORT_CONFIGS), BST_CHECKED);
+            }
 
             break;
 
@@ -723,6 +727,8 @@ GeneralSettingsDlgProc(HWND hwndDlg, UINT msg, UNUSED WPARAM wParam, LPARAM lPar
                     (Button_GetCheck(GetDlgItem(hwndDlg, ID_CHK_AUTO_RESTART)) == BST_CHECKED);
                 o.auth_pass_concat_otp =
                     (Button_GetCheck(GetDlgItem(hwndDlg, ID_CHK_CONCAT_OTP)) == BST_CHECKED);
+                o.sort_configs =
+                    (Button_GetCheck(GetDlgItem(hwndDlg, ID_CHK_SORT_CONFIGS)) == BST_CHECKED);
 
                 SaveRegistryKeys();
 

--- a/openvpn-gui-res.h
+++ b/openvpn-gui-res.h
@@ -173,6 +173,7 @@
 /* General settings contd.. */
 
 #define ID_CHK_CONCAT_OTP               470
+#define ID_CHK_SORT_CONFIGS             471
 
 /*
  * String Table Resources

--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -372,6 +372,82 @@ BuildFileList0(const TCHAR *config_dir, int recurse_depth, int group, int flags)
     FindClose(find_handle);
 }
 
+/* qsort comparator: alphabetical by config_name, locale-aware and case
+ * insensitive. Ties are broken by load order (c->id) to keep the sort stable.
+ */
+static int
+ConfigCompareName(const void *a, const void *b)
+{
+    const connection_t *c1 = *(connection_t *const *)a;
+    const connection_t *c2 = *(connection_t *const *)b;
+
+    int cmp = CompareStringW(LOCALE_USER_DEFAULT, NORM_IGNORECASE, c1->config_name, -1,
+                             c2->config_name, -1)
+              - 2; /* -2 to match strcmp semantics (CSTR_LESS_THAN == 1) */
+    if (cmp == 0)
+    {
+        cmp = (c1->id > c2->id) - (c1->id < c2->id);
+    }
+    return cmp;
+}
+
+/* qsort comparator: by load order (c->id), i.e. filesystem enumeration order */
+static int
+ConfigCompareId(const void *a, const void *b)
+{
+    const connection_t *c1 = *(connection_t *const *)a;
+    const connection_t *c2 = *(connection_t *const *)b;
+
+    return (c1->id > c2->id) - (c1->id < c2->id);
+}
+
+/*
+ * Reorder the connection list used to build the tray menu. When o.sort_configs
+ * is set the configs are sorted alphabetically by name; otherwise they are
+ * restored to their original load order (c->id), so toggling the option off
+ * fully reverts to the filesystem enumeration order. c->id is never modified,
+ * so the management port mapping and per-config menu handles stay intact.
+ */
+static void
+SortConfigList(void)
+{
+    int n = o.num_configs;
+    if (n < 2)
+    {
+        return;
+    }
+
+    connection_t **arr = malloc(n * sizeof(connection_t *));
+    if (!arr)
+    {
+        return; /* leave the list unchanged on allocation failure */
+    }
+
+    int i = 0;
+    for (connection_t *c = o.chead; c && i < n; c = c->next)
+    {
+        arr[i++] = c;
+    }
+    n = i;
+    if (n < 2)
+    {
+        free(arr);
+        return;
+    }
+
+    qsort(arr, n, sizeof(connection_t *), o.sort_configs ? ConfigCompareName : ConfigCompareId);
+
+    for (i = 0; i < n - 1; ++i)
+    {
+        arr[i]->next = arr[i + 1];
+    }
+    arr[n - 1]->next = NULL;
+    o.chead = arr[0];
+    o.ctail = arr[n - 1];
+
+    free(arr);
+}
+
 void
 BuildFileList()
 {
@@ -432,6 +508,8 @@ BuildFileList()
     }
 
     ActivateConfigGroups();
+
+    SortConfigList();
 
     issue_warnings = false;
 }

--- a/options.h
+++ b/options.h
@@ -237,6 +237,7 @@ typedef struct
     DWORD disconnectscript_timeout; /* Disconnect Script execution timeout (sec) */
     DWORD preconnectscript_timeout; /* Preconnect Script execution timeout (sec) */
     DWORD config_menu_view;         /* 0 for auto, 1 for original flat menu, 2 for hierarchical */
+    DWORD sort_configs;             /* nonzero to sort configs alphabetically in the menu */
     DWORD disable_popup_messages;   /* set nonzero to suppress all echo msg messages */
     DWORD popup_mute_interval;      /* Interval in hours to suppress repeated echo messages */
     DWORD mgmt_port_offset; /* management interface port = this offset + index of connection profile

--- a/registry.c
+++ b/registry.c
@@ -67,6 +67,7 @@ struct regkey_int
                    { L"disconnectscript_timeout", &o.disconnectscript_timeout, 10 },
                    { L"show_script_window", &o.show_script_window, 0 },
                    { L"config_menu_view", &o.config_menu_view, CONFIG_VIEW_AUTO },
+                   { L"sort_configs", &o.sort_configs, 0 },
                    { L"popup_mute_interval", &o.popup_mute_interval, 24 },
                    { L"disable_popup_messages", &o.disable_popup_messages, 0 },
                    { L"management_port_offset", &o.mgmt_port_offset, 25340 },

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Spuštění", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Spustit při startu Windows", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Volby", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Volby", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Připojovat záznamy na konec logu", ID_CHK_LOG_APPEND, 17, 95, 130, 10
     AUTOCHECKBOX "Zobrazit okno skriptu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Tiché spojení", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     AUTOCHECKBOX "Připojení před přihlášením (vyžaduje práva správce)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Povolit automatický restart aktivních spojení", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Vyžadovat &OTP a spojit s heslem", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Systemstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Mit &Windows starten", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Einstellungen", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Einstellungen", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "An &Log anhängen", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "&Skriptfenster zeigen", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille &Verbindung", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Autostart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Start med Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Indstillinger", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Indstillinger", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Tilføj til log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Vis script vindue", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille forbindelse", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-el.rc
+++ b/res/openvpn-gui-res-el.rc
@@ -165,7 +165,7 @@ BEGIN
     GROUPBOX "Εκκίνηση", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Εκκίνηση μαζί με τα Windows", ID_CHK_STARTUP, 17, 59, 150, 12
 
-    GROUPBOX "Επιλογές", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Επιλογές", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Προσθήκη εγγραφών στο τέλος του log", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Εμφάνιση παραθύρου σεναρίου (script)", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Αθόρυβη σύνδεση", ID_CHK_SILENT, 17, 125, 200, 10
@@ -181,6 +181,7 @@ BEGIN
     AUTOCHECKBOX "Ενεργοποίηση Pre-Logon Access Provider (απαιτεί admin)", ID_CHK_PLAP_REG, 17, 215, 220, 10
     AUTOCHECKBOX "Ενεργοποίηση αυτόματης επανεκκίνησης ενεργών συνδέσεων", ID_CHK_AUTO_RESTART, 17, 230, 220, 10
     AUTOCHECKBOX "Ερώτηση για OTP και συνδυασμός με σύνθημα", ID_CHK_CONCAT_OTP, 17, 245, 220, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 220, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -178,7 +178,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on User &Logon", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "A&ppend to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script &window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "S&ilent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -194,6 +194,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -162,7 +162,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -178,6 +178,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -170,7 +170,7 @@ BEGIN
     GROUPBOX "شروع به کار", 202, 6, 47, 235, 30
     AUTOCHECKBOX "شروع به کار - وقتی کاربر وارد شد", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "تنظیمات", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "تنظیمات", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "چسباندن به گزارشات", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "نمایش پنجره اسکریپت", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "بی صدا(اعلان) متصل شدن", ID_CHK_SILENT, 17, 125, 200, 10
@@ -186,6 +186,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Käynnistäminen", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Käynnistä Windowsiin kirjautuessa", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Valinnat", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Valinnat", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Lisää lokitiedostoon", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Näytä komentosarjaikkuna", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Yhdistä taustalla", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Démarrage", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Lancer au démarrage de Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Préférences", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Préférences", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Ajouter au fichier log", ID_CHK_LOG_APPEND, 17, 95, 81, 10
     AUTOCHECKBOX "Afficher la fenêtre des scripts", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connexion silencieuse", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTOCHECKBOX "Activer le fournisseur d'&accès à la pré-ouverture de session", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Activer le redémarrage auto des connexions activées", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Demande d'OTP et combinaison avec le mot de passe", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Opzioni avvio", 202, 6, 47, 235, 30
     AUTOCHECKBOX "&Esegui all'avvio di Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Impostazioni", ID_GROUPBOX3, 6, 82, 235, 190
+    GROUPBOX "Impostazioni", ID_GROUPBOX3, 6, 82, 235, 205
     AUTOCHECKBOX "Aggiungi in coda al f&ile registro", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Visualizza &finestra script", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Connessione &silenziosa", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     LTEXT "(richiede accesso come amministratore)", 220, 28, 225, 200, 10
     AUTOCHECKBOX "Abilita riavvio automatico connessioni attive", ID_CHK_AUTO_RESTART, 17, 240, 200, 10
     AUTOCHECKBOX "Richiedi &OTP e combinalo con la password", ID_CHK_CONCAT_OTP, 17, 255, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 270, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "起動", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Windows起動時に開始(&L)", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "設定", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "設定", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "ログ追記モード(&P)", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "スクリプト実行ウィンドウを表示(&W)", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "サイレント接続モード(&I)", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "OTPを要求し、パスワードと組み合わせる", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -165,7 +165,7 @@ BEGIN
     GROUPBOX "시작 설정", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Windows 시작 시에 실행", ID_CHK_STARTUP, 17, 59, 100, 12
 
-    GROUPBOX "환경 설정", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "환경 설정", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "로그 파일에 추가", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "스크립트 창 보기", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "연결 시 상태 대화 상자 표시하지 않기", ID_CHK_SILENT, 17, 125, 200, 10
@@ -181,6 +181,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Opstarten", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Opstarten met Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Voorkeuren", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Voorkeuren", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Aan logbestand toevoegen", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Script-venster tonen", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Stille verbinding", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Oppstart", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Kjør automatisk når Windows starter", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Innstillinger", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Innstillinger", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Tilføy til eksisterende logg", ID_CHK_LOG_APPEND, 17, 95, 93, 10
     AUTOCHECKBOX "Vis scriptvindu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Skjul statusvindu ved tilkobling", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Uruchamianie", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Uruchamiaj po zalogowaniu się użytkownika", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferencje", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Preferencje", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Dodaj do dziennika", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Pokaż okno skryptu", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Połączenie dyskretne", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sortuj konfiguracje alfabetycznie", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -162,7 +162,7 @@ BEGIN
     GROUPBOX "Inicialização", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Executar ao iniciar o Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferências", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Preferências", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Anexar ao log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Mostrar janela de script", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Conexão silenciosa", ID_CHK_SILENT, 17, 125, 200, 10
@@ -178,6 +178,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -165,7 +165,7 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускать при старте Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Настройки", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Настройки", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Дописывать, а не перезаписывать журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показывать окно выполнения", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихое» подключение", ID_CHK_SILENT, 17, 125, 200, 10
@@ -181,6 +181,7 @@ BEGIN
     AUTOCHECKBOX "Включить A&ccess Provider до входа в систему (нужны адм. права)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Автоматически переподключать активные соединения", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Запрашивать ключ OTP и объединять его с паролем", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -162,7 +162,7 @@ BEGIN
     GROUPBOX "Startup", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Launch on Windows startup", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Preferences", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Append to log", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Show script window", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Silent connection", ID_CHK_SILENT, 17, 125, 200, 10
@@ -178,6 +178,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -164,7 +164,7 @@ BEGIN
     GROUPBOX "Başlangıç", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Windows başlangıcında çalıştır", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Tercihler", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Tercihler", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Günlüğe ekle", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "Betik penceresini göster", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "Sessiz bağlantı", ID_CHK_SILENT, 17, 125, 200, 10
@@ -180,6 +180,7 @@ BEGIN
     AUTOCHECKBOX "Oturum Açma Öncesi &Erişim Sağlayıcıyı Etkinleştir (yönetici erişimi gerektirir)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Aktif bağlantıların otomatik yeniden başlatılmasını etkinleştir", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "OTP sorgusu yap ve şifreyle birleştir", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -163,7 +163,7 @@ BEGIN
     GROUPBOX "Запуск", 202, 6, 47, 235, 30
     AUTOCHECKBOX "Запускати при старті Windows", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "Налаштування", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "Налаштування", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "Додати, а не перезаписувати журнал", ID_CHK_LOG_APPEND, 17, 95, 200, 10
     AUTOCHECKBOX "Показувати вікно виконання", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "«Тихе» підключення", ID_CHK_SILENT, 17, 125, 200, 10
@@ -179,6 +179,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -166,7 +166,7 @@ BEGIN
     GROUPBOX "启动", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 开机时启动", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好设置", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "偏好设置", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "追加日志文件", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "显示脚本窗口", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "静默连接", ID_CHK_SILENT, 17, 125, 200, 10
@@ -182,6 +182,7 @@ BEGIN
     AUTOCHECKBOX "启用预登录访问提供程序（需要管理员访问权限）", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "启用活动连接的自动重新启动", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "提示输入&OTP并与密码结合", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -166,7 +166,7 @@ BEGIN
     GROUPBOX "啟動", 202, 6, 47, 235, 30
     AUTOCHECKBOX "在 Windows 開機時執行", ID_CHK_STARTUP, 17, 59, 200, 12
 
-    GROUPBOX "偏好設定", ID_GROUPBOX3, 6, 82, 235, 180
+    GROUPBOX "偏好設定", ID_GROUPBOX3, 6, 82, 235, 195
     AUTOCHECKBOX "附加記錄檔", ID_CHK_LOG_APPEND, 17, 95, 60, 10
     AUTOCHECKBOX "顯示指令碼視窗", ID_CHK_SHOW_SCRIPT_WIN, 17, 110, 200, 10
     AUTOCHECKBOX "寧靜連線", ID_CHK_SILENT, 17, 125, 200, 10
@@ -182,6 +182,7 @@ BEGIN
     AUTOCHECKBOX "Enable Pre-Logon A&ccess Provider (requires admin access)", ID_CHK_PLAP_REG, 17, 215, 200, 10
     AUTOCHECKBOX "Enable auto restart of active connections", ID_CHK_AUTO_RESTART, 17, 230, 200, 10
     AUTOCHECKBOX "Prompt for &OTP and combine with password", ID_CHK_CONCAT_OTP, 17, 245, 200, 10
+    AUTOCHECKBOX "&Sort configurations alphabetically", ID_CHK_SORT_CONFIGS, 17, 260, 200, 10
 END
 
 /* Advanced Dialog */


### PR DESCRIPTION
## Summary

VPN profiles are listed in the tray menu in the order returned by the
filesystem (`FindFirstFile`/`FindNextFile`). On NTFS this is usually
alphabetical, but it is not guaranteed - FAT/exFAT and network shares can
return creation order - and there was no explicit sorting anywhere.

This PR adds an opt-in setting to sort configurations alphabetically in the
menu, controlled by a new checkbox in **General → Preferences**. The option is
**off by default**, so existing behavior is unchanged unless the user enables it.

## Behavior notes

- The menu is rebuilt on every open (`RecreatePopupMenus` → `BuildFileList` →
  `CreatePopupMenus`), so toggling the checkbox takes effect immediately on the
  next menu open - no restart required.
- Toggling the option **off** fully reverts to the on-disk order, because each
  config keeps its immutable `c->id` (assigned at load time).
- `c->id` is never modified, so the management port mapping
  (`mgmt_port_offset + id`) and the per-config menu handles (`hMenuConn[id]`)
  remain intact.
- Sorting applies to config entries only. In the nested/grouped menu view,
  configs within each folder are sorted while the order of the folders
  themselves is left unchanged.