### PR TITLE
GHA: Change windows-latest to windows-2022

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -47,7 +47,7 @@ jobs:
             arch: x64
 
     name: 'msvc - ${{matrix.arch}} ${{ matrix.ovpn3.name }}${{ matrix.conf.name }}'
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: lukka/get-cmake@ea83089aa35e08e459464341fe24ad024ee2466f # v4.3.1


### PR DESCRIPTION
windows-latest has VS 2026 now, while our CMake
presets hardcode VS 2022 for now.