### PR TITLE
Fix config paths for profiles in subdirectories

### DIFF
--- a/openvpn.c
+++ b/openvpn.c
@@ -26,6 +26,7 @@
 #endif
 
 #include <windows.h>
+#include <shlwapi.h>
 #include <windowsx.h>
 #include <versionhelpers.h>
 #include <tchar.h>
@@ -2953,12 +2954,18 @@ StartOpenVPN(connection_t *c)
             /* Show an error if manually connecting */
             if (c->state == disconnected)
             {
+                WCHAR config_path[MAX_PATH];
+
+                if (PathCombineW(config_path, c->config_dir, c->config_file) == NULL)
+                {
+                    wcsncpy_s(config_path, _countof(config_path), c->config_file, _TRUNCATE);
+                }
+
                 ShowLocalizedMsgEx(MB_OK | MB_ICONERROR,
                                    o.hWnd,
                                    TEXT(PACKAGE_NAME),
                                    IDS_ERR_PARSE_MGMT_OPTION,
-                                   c->config_dir,
-                                   c->config_file);
+                                   config_path);
             }
             else
             {

--- a/openvpn_config.c
+++ b/openvpn_config.c
@@ -26,6 +26,7 @@
 #endif
 
 #include <windows.h>
+#include <shlwapi.h>
 
 #include "main.h"
 #include "openvpn-gui-res.h"
@@ -361,7 +362,11 @@ BuildFileList0(const TCHAR *config_dir, int recurse_depth, int group, int flags)
             if (wcscmp(find_obj.cFileName, _T(".")) && wcscmp(find_obj.cFileName, _T("..")))
             {
                 /* recurse into subdirectory */
-                _sntprintf_0(subdir_name, _T("%ls\\%ls"), config_dir, find_obj.cFileName);
+                if (PathCombineW(subdir_name, config_dir, find_obj.cFileName) == NULL)
+                {
+                    continue;
+                }
+
                 int sub_group = NewConfigGroup(find_obj.cFileName, group, flags);
 
                 BuildFileList0(subdir_name, recurse_depth - 1, sub_group, flags);

--- a/res/openvpn-gui-res-cs.rc
+++ b/res/openvpn-gui-res-cs.rc
@@ -401,7 +401,7 @@ Více informací najdete v logu (%ls)."
     IDS_ERR_SHELL_DLL_VERSION "Verze vaší knihovny shell32.dll je příliš nízká (0x%lx). Potřebujete verzi 5.0 nebo novější."
     IDS_NFO_ACTIVE_CONN_EXIT "Některá spojení jsou stále aktivní. Pokud OpenVPN GUI ukončíte, budou přerušena.\
 \n\nOpravdu chcete aplikaci ukončit?"
-    IDS_ERR_PARSE_MGMT_OPTION "Nepodařilo se zpracovat parametr --management v <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Nepodařilo se zpracovat parametr --management v <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Zobrazí tuto zprávu.\n\

--- a/res/openvpn-gui-res-de.rc
+++ b/res/openvpn-gui-res-de.rc
@@ -402,7 +402,7 @@ Konsultieren Sie die Log-Datei (%ls) für weitere Informationen."
     IDS_ERR_SHELL_DLL_VERSION "Die shell32.dll Versionsnummer ist zu niedrig (0x%lx). Es muss mindestens Version 5.0 installiert sein."
     IDS_NFO_ACTIVE_CONN_EXIT "Es exisiert noch eine aktive Verbindung, welche geschlossen wird, wenn Sie OpenVPN GUI beenden.\
 \n\nSind Sie sicher, dass Sie das Programm beenden möchten?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options – Resources */
     IDS_NFO_USAGE "--help\t\t\t: Zeigt diese Informationen.\n\

--- a/res/openvpn-gui-res-dk.rc
+++ b/res/openvpn-gui-res-dk.rc
@@ -400,7 +400,7 @@ ligger i forskellige kataloger."
     IDS_NFO_ACTIVE_CONN_EXIT "Aktive forbindelser vil blive afbrudt hvis du afslutter OpenVPN GUI. \
  \n\nVil du afslutte?"
 
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Vis denne meddelelse.\n\

--- a/res/openvpn-gui-res-el.rc
+++ b/res/openvpn-gui-res-el.rc
@@ -401,7 +401,7 @@ BEGIN
     IDS_ERR_SHELL_DLL_VERSION "Η έκδοση του shell32.dll είναι παλιά (0x%lx). Απαιτείται έκδοση 5.0 ή νεότερη."
     IDS_NFO_ACTIVE_CONN_EXIT "Υπάρχουν ενεργές συνδέσεις. Αν κλείσετε το OpenVPN GUI, θα διακοπούν.\
 \n\nΘέλετε σίγουρα να κλείσετε την εφαρμογή;"
-    IDS_ERR_PARSE_MGMT_OPTION "Αδυναμία ανάλυσης της επιλογής --management στο <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Αδυναμία ανάλυσης της επιλογής --management στο <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Εμφάνιση αυτού του μηνύματος.\n\

--- a/res/openvpn-gui-res-en.rc
+++ b/res/openvpn-gui-res-en.rc
@@ -415,7 +415,7 @@ View log file (%ls) for more details."
     IDS_ERR_SHELL_DLL_VERSION "Your shell32.dll version is to low (0x%lx). You need at least version 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "There are still active connections that will be closed if you exit OpenVPN GUI.\
 \n\nAre you sure you want to exit?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>. \
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>. \
 Attaching to auto-started connections requires --management option in the config file."
     IDS_NFO_STATE_ROUTE_ERROR "Current State: Connected with route errors"
     IDS_NFO_NOTIFY_ROUTE_ERROR "%ls connected with route errors"

--- a/res/openvpn-gui-res-es.rc
+++ b/res/openvpn-gui-res-es.rc
@@ -397,7 +397,7 @@ están en directorios diferentes."
     IDS_ERR_SHELL_DLL_VERSION "La versión del shell32.dll es demasiado antigua (0x%lx). Se necesita al menos la versión 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Aún hay conexiones activas que serán cerradas si se sale de OpenVPN GUI.\
 \n\nEstá seguro de querer salir?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Mostrar éste mensaje.\n\

--- a/res/openvpn-gui-res-fa.rc
+++ b/res/openvpn-gui-res-fa.rc
@@ -409,7 +409,7 @@ BEGIN
     IDS_ERR_SHELL_DLL_VERSION "shell32.dll شما نسخه اش پایینتر از (0x%lx) است. تو نیاز به نسخه بالا تر داری -نسخه آخر 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "هنوز اتصالات فعال وجود دارد که در صورت خروج بسته خواهد شد - OpenVPN GUI.\
 \n\nشما مطمئن هستید میخواهید خارج شوید?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options – Resources */
     IDS_NFO_USAGE "--help\t\t\t: Show this message.\n\

--- a/res/openvpn-gui-res-fi.rc
+++ b/res/openvpn-gui-res-fi.rc
@@ -400,7 +400,7 @@ Lisätietoja lokitiedostossa (%ls)."
     IDS_ERR_SHELL_DLL_VERSION "Kirjasto shell32.dll on liian vanha (0x%lx), tarvitaan vähintään versio 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Jos OpenVPN GUI suljetaan, aktiiviset yhteydet katkeavat.\
 \n\nHaluatko varmasti jatkaa?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Näytä tämä viesti.\n\

--- a/res/openvpn-gui-res-fr.rc
+++ b/res/openvpn-gui-res-fr.rc
@@ -400,7 +400,7 @@ Afficher le fichier journal (%ls) pour plus de détails."
     IDS_ERR_SHELL_DLL_VERSION "La version de votre shell32.dll est trop basse (0x%lx). Vous devez avoir au moins la version 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Les connexions en cours seront interrompues si vous fermez OpenVPN GUI.\
 \n\nVous êtes sûr de vouloir fermer l'application ?"
-    IDS_ERR_PARSE_MGMT_OPTION "Impossible d'analyser l'option de gestion --dans <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Impossible d'analyser l'option de gestion --dans <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--aide\t\t\t: Afficher ce message.\n\

--- a/res/openvpn-gui-res-it.rc
+++ b/res/openvpn-gui-res-it.rc
@@ -401,7 +401,7 @@ Per maggiori dettagli consulta il file log (%ls) ."
     IDS_ERR_SHELL_DLL_VERSION "La versione di shell32.dll è troppo vecchia (0x%lx).\nÈ necessaria almeno la versione 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Ci sono ancora connessioni attive che verranno chiuse se esci dall'interfaccia di OpenVPN.\
 \n\nSei sicuro di voler uscire?"
-    IDS_ERR_PARSE_MGMT_OPTION "Impossibile analizzare l'opzione --management in <%ls%ls>. \
+    IDS_ERR_PARSE_MGMT_OPTION "Impossibile analizzare l'opzione --management in <%ls>. \
 Il collegamento a connessioni avviate automaticamente richiede l'opzione --management nel file di configurazione."
     IDS_NFO_STATE_ROUTE_ERROR "Stato attuale: connesso con errori nelle rotte"
     IDS_NFO_NOTIFY_ROUTE_ERROR "%ls connesso con errori nelle rotte"

--- a/res/openvpn-gui-res-jp.rc
+++ b/res/openvpn-gui-res-jp.rc
@@ -401,7 +401,7 @@ BEGIN
     IDS_ERR_SHELL_DLL_VERSION "shell32.dll のバージョンが古いです (0x%lx). バージョン 5.0 以降に更新してください。"
     IDS_NFO_ACTIVE_CONN_EXIT "OpenVPN GUIを終了すると、現在接続中の接続が切断されます。\
 \n\n終了してもよろしいですか？"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: このメッセージを表示する。\n\

--- a/res/openvpn-gui-res-kr.rc
+++ b/res/openvpn-gui-res-kr.rc
@@ -398,7 +398,7 @@ BEGIN
     IDS_ERR_SHELL_DLL_VERSION "shell32.dll version이 오래되었습니다(0x%lx). 5.0 이상이 필요 합니다."
     IDS_NFO_ACTIVE_CONN_EXIT "OpenVPN GUI을 종료하면 현재 연결되어 있는 접속이 중단 됩니다.\
 \n\n그래도 종료 하겠습니까?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: 이 메시지 보기.\n\

--- a/res/openvpn-gui-res-nl.rc
+++ b/res/openvpn-gui-res-nl.rc
@@ -401,7 +401,7 @@ Bekijk logbestand (%ls) voor meer informatie."
     IDS_ERR_SHELL_DLL_VERSION "De shell32.dll versie is te oud (0x%lx). Minstens versie 5.0 is vereist."
     IDS_NFO_ACTIVE_CONN_EXIT "Er zijn nog actieve connecties die verbroken zullen worden indien OpenVPN GUI afgesloten wordt.\
 \n\nBent u zeker dan u wilt afsluiten?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options – Resources */
     IDS_NFO_USAGE "--help\t\t\t: Toon dit bericht.\n\

--- a/res/openvpn-gui-res-no.rc
+++ b/res/openvpn-gui-res-no.rc
@@ -395,7 +395,7 @@ konfigurasjonsfiler med samme navn, selv om de ligger i ulike kataloger."
     IDS_ERR_LOAD_RICHED20 "Kunne ikke laste RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Din versjon av shell32.dll er for lav (0x%lx). Du trenger minst versjon 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Aktive tilkoblinger vil bli avbrutt om du avslutter OpenVPN GUI.\n\nVil du avslutte?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Vis dene meldingen.\n\

--- a/res/openvpn-gui-res-pl.rc
+++ b/res/openvpn-gui-res-pl.rc
@@ -399,7 +399,7 @@ umieszczone są w innych katalogach."
     IDS_ERR_SHELL_DLL_VERSION "Twoja wersja biblioteki shell32.dll jest za stara (0x%lx). Wymagana co najmniej wersja 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Istnieją aktywne połączenia, które zostaną zakończone jeśli zamkniesz OpenVPN GUI.\
 \n\nCzy chcesz kontynuować?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Pokaż tę wiadomość.\n\

--- a/res/openvpn-gui-res-pt.rc
+++ b/res/openvpn-gui-res-pt.rc
@@ -399,7 +399,7 @@ Consulte o arquivo de log (%ls) para mais detalhes."
     IDS_ERR_SHELL_DLL_VERSION "Sua versão do shell32.dll é antiga (0x%lx). Você precisa de no mínimo da versão 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Ainda existem conexões ativas. Estas conexões serão encerradas se você sair do OpenVPN GUI.\
 \n\nVocê tem certeza de que deseja sair?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Mostra esta mensagem.\n\

--- a/res/openvpn-gui-res-ru.rc
+++ b/res/openvpn-gui-res-ru.rc
@@ -400,7 +400,7 @@ BEGIN
     IDS_ERR_SHELL_DLL_VERSION "Ваша версия shell32.dll слишком старая (0x%lx). Вам необходима как минимум версия 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Ещё присутствуют активные соединения, которые будут закрыты, если вы выйдите из OpenVPN GUI.\
 \n\nВы уверены, что хотите выйти?"
-    IDS_ERR_PARSE_MGMT_OPTION "Опция --management не распознана в <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Опция --management не распознана в <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Отобразить это сообщение.\n\

--- a/res/openvpn-gui-res-se.rc
+++ b/res/openvpn-gui-res-se.rc
@@ -396,7 +396,7 @@ konfigurations filer med samma namn, även om de ligger i olika kataloger."
     IDS_ERR_LOAD_RICHED20 "Kunde inte ladda RICHED20.DLL."
     IDS_ERR_SHELL_DLL_VERSION "Din shell32.dll version är för låg (0x%lx). Du böhöver minst version 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Du har aktiva uppkopplingar i gång som kommer kopplas ner om du avslutar OpenVPN GUI.\n\nÄr du säker på att du vill avsluta?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Visa detta meddelande.\n\

--- a/res/openvpn-gui-res-tr.rc
+++ b/res/openvpn-gui-res-tr.rc
@@ -399,7 +399,7 @@ kayıt edemezsiniz."
     IDS_ERR_SHELL_DLL_VERSION "Sistemde bulunan shell32.dll verdsiyonu eski. (0x%lx). En az 5.0 versiyonuna sahip olmalısınız."
     IDS_NFO_ACTIVE_CONN_EXIT "OpenVPN GUI ' yi kapatırsanız, açık olan bağlantılarınız sonlandırılacaktır.\
 \n\nÇıkmak istediğinize emin misiniz?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Yardım mesajını gözter.\n\

--- a/res/openvpn-gui-res-ua.rc
+++ b/res/openvpn-gui-res-ua.rc
@@ -399,7 +399,7 @@ BEGIN
     IDS_ERR_SHELL_DLL_VERSION "Ваша версія shell32.dll занадто стара (0x%lx). Вам необхідно використовувати, як мінімум, версію файлів 5.0."
     IDS_NFO_ACTIVE_CONN_EXIT "Ще є активні з'єднання, які будуть зупинені, якщо ви завершите роботу OpenVPN GUI.\
 \n\nВи впевнені, що бажаєте завершити?"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: Відобразити це повідомлення.\n\

--- a/res/openvpn-gui-res-zh-hans.rc
+++ b/res/openvpn-gui-res-zh-hans.rc
@@ -402,7 +402,7 @@ BEGIN
     IDS_ERR_SHELL_DLL_VERSION "您的 shell32.dll 版本太旧 (0x%lx)，需要至少 5.0 版本或更新版。"
     IDS_NFO_ACTIVE_CONN_EXIT "当前还有活动的连接，您若退出 OpenVPN GUI 该连接将被中断。\
 \n\n您确定要退出吗？"
-    IDS_ERR_PARSE_MGMT_OPTION "无法分析<%ls%ls>中的--management选项。"
+    IDS_ERR_PARSE_MGMT_OPTION "无法分析<%ls>中的--management选项。"
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: 显示此信息。\n\

--- a/res/openvpn-gui-res-zh-hant.rc
+++ b/res/openvpn-gui-res-zh-hant.rc
@@ -402,7 +402,7 @@ BEGIN
     IDS_ERR_SHELL_DLL_VERSION "您的 shell32.dll 版本太舊 (0x%lx)，需要至少 5.0 版本或更新版。"
     IDS_NFO_ACTIVE_CONN_EXIT "目前還有進行中的連線，若您結束 OpenVPN GUI 該連線將被中斷。\
 \n\n您確定要離開嗎？"
-    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls%ls>."
+    IDS_ERR_PARSE_MGMT_OPTION "Could not parse --management option in <%ls>."
 
     /* options - Resources */
     IDS_NFO_USAGE "--help\t\t\t: 顯示此訊息。\n\


### PR DESCRIPTION
Fixes malformed config paths for persistent profiles located in subdirectories of config-auto.

config_auto_dir is stored with a trailing path separator, while recursive profile discovery appended another separator manually. 

In addition, the management-option error message concatenated config_dir and config_file through two adjacent %ls placeholders, without inserting a separator.

As reported in #661, this could produce:

C:\Program Files\OpenVPN\config-auto\\IPFire_prebootIPFire_preboot.ovpn

instead of:

C:\Program Files\OpenVPN\config-auto\IPFire_preboot\IPFire_preboot.ovpn

This change:

- uses PathCombineW() when descending into configuration subdirectories;
- constructs the complete config path before passing it to the localized management parse error message;
- changes the localized resource strings from two path arguments to one.

Tested on Windows x64 with a persistent profile in a config-auto subdirectory and a relative management password file. The patched GUI successfully attaches to the running OpenVPN service. A negative permissions test also confirmed that the error dialog now reports the correct full config path.

Related to #661.